### PR TITLE
fix(eval): honour no-op invariant for empty overrides + reject zero .ld scale

### DIFF
--- a/src/log/ld.rs
+++ b/src/log/ld.rs
@@ -314,7 +314,8 @@ fn decode_channel_points(bytes: &[u8], ch: &M1Channel) -> Result<Vec<(f64, Value
 }
 
 /// Reject a channel whose samples we cannot decode correctly. Returns a fail-loud
-/// [`EvalError`] for a non-zero offset or a zero sample rate — otherwise `Ok(())`.
+/// [`EvalError`] for a non-zero offset, a zero sample rate, or a zero
+/// engineering-unit scale (the decode divisor) — otherwise `Ok(())`.
 /// (An unrecognised datatype is already rejected at metadata-parse time.)
 fn check_decodable(ch: &M1Channel) -> Result<(), EvalError> {
     // The documented engineering-unit decode assumes a zero raw-sample offset.
@@ -333,6 +334,18 @@ fn check_decodable(ch: &M1Channel) -> Result<(), EvalError> {
         return Err(EvalError::UnsupportedConstruct {
             kind: format!(
                 "`.ld` channel `{}` has a zero sample rate (no time base)",
+                ch.name
+            ),
+            at: 0,
+        });
+    }
+    // The engineering-unit decode divides by `scale`; a zero scale would divide by
+    // zero and produce inf/NaN samples silently.
+    if ch.scale == 0 {
+        return Err(EvalError::UnsupportedConstruct {
+            kind: format!(
+                "`.ld` channel `{}` has a zero engineering-unit scale (divisor), \
+                 which would produce inf/NaN samples",
                 ch.name
             ),
             at: 0,
@@ -422,7 +435,7 @@ pub fn from_ld(bytes: &[u8], source: impl Into<String>) -> Result<Log, EvalError
 
 #[cfg(test)]
 mod tests {
-    use super::{M1Channel, M1Datatype, from_ld};
+    use super::{M1Channel, M1Datatype, check_decodable, from_ld};
     use crate::error::EvalError;
     use crate::scenario::InputKind;
     use crate::value::Value;
@@ -780,5 +793,18 @@ mod tests {
             }
             other => panic!("expected fail-loud on zero sample rate, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn zero_scale_fails_loud() {
+        // The engineering-unit decode divides by `scale`; a zero scale would yield
+        // inf/NaN samples silently. Reject it up front, like the zero-sample-rate
+        // guard.
+        let mut ch = m1_channel(M1Datatype::I16);
+        ch.scale = 0;
+        assert!(
+            check_decodable(&ch).is_err(),
+            "a zero engineering-unit scale must fail loud, not decode to inf/NaN"
+        );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -836,10 +836,19 @@ pub fn run_counterfactual(
     };
 
     // Build the downstream cone of the override channels: the only functions that
-    // recompute. Fails loud when no function reads any override channel.
+    // recompute. Fails loud when a (non-empty) override targets a channel no
+    // function reads. With NO overrides, however, there is nothing to recompute:
+    // the cone is empty and the tick loop reproduces the log verbatim — the
+    // documented no-op invariant (`--log` with no `--override`). Guard the empty
+    // case so `build_downstream_cone`'s empty-seed fail-loud is reserved for a real
+    // no-reader override.
     let override_channels: Vec<String> =
         overrides.iter().map(|o| o.channel().to_string()).collect();
-    let cone = build_downstream_cone(loaded, &override_channels)?;
+    let cone = if override_channels.is_empty() {
+        Vec::new()
+    } else {
+        build_downstream_cone(loaded, &override_channels)?
+    };
 
     // Canonicalise the log series and each override channel against the project
     // scope (the cone's first function), so `Sensor` and `Root.CF.Sensor` address
@@ -1884,6 +1893,43 @@ base_rate_hz = 100.0
             2,
             "default duration = log.duration_s (0.02)"
         );
+    }
+
+    #[test]
+    fn counterfactual_no_override_reproduces_log() {
+        // The documented no-op invariant: `--log` with NO `--override` reproduces
+        // the logged series verbatim and the changed-channel set is empty. With no
+        // overrides there is no downstream cone to build, so nothing recomputes —
+        // every logged channel passes through at its logged value. (Regression:
+        // this used to fail loud with `no function reads override channel(s) []`.)
+        let loaded = counterfactual();
+        let log = consistent_log();
+        let cfg = CounterfactualCfg {
+            base_rate_hz: 100.0,
+            duration_s: 0.03,
+        };
+        let trace = run_counterfactual(&loaded, &log, &[], &cfg).expect("no-op cf runs");
+
+        // Every logged channel is reproduced verbatim at its logged keyframes.
+        assert_eq!(floats(&trace, "Root.CF.Sensor"), vec![10.0, 20.0, 30.0]);
+        assert_eq!(floats(&trace, "Root.CF.Mid"), vec![20.0, 40.0, 60.0]);
+        assert_eq!(floats(&trace, "Root.CF.Result"), vec![21.0, 41.0, 61.0]);
+        assert_eq!(floats(&trace, "Root.CF.Other"), vec![42.0, 42.0, 42.0]);
+
+        // The changed-channel set is empty: the counterfactual trace equals the log
+        // sampled on the same grid, so no channel moved.
+        let log_inputs = canonicalise(&log.channels, &loaded, None, None);
+        for (path, series) in &log_inputs {
+            let cf = floats(&trace, path);
+            for (i, value) in cf.iter().enumerate() {
+                let t = i as f64 / cfg.base_rate_hz;
+                let logged = match series.sample(t) {
+                    Value::Float(x) => x,
+                    other => panic!("expected float in log {path:?}, got {other:?}"),
+                };
+                assert_eq!(*value, logged, "channel {path:?} unchanged at tick {i}");
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Two fail-loud/correctness bugs surfaced during a toolchain audit of the eval crate. Each is fixed as its own commit with its own regression test.

## Bug A — no-op invariant violated for `--log` with no `--override`

`run_counterfactual` unconditionally called `build_downstream_cone` with the override-channel seed set, and that helper fail-louds on an empty seed set. Running `--log LOG` with **no** `--override` therefore errored with `no function reads override channel(s) []` and exited 1, directly contradicting the documented no-op invariant in the README ("`--log` with no `--override` reproduces the logged series within tolerance, and the changed-channel set is empty").

**Fix:** guard the empty case — with no overrides the downstream cone is empty, so the tick loop reproduces the log verbatim and the changed-channel set is empty. The existing fail-loud is preserved for a real no-reader override (a non-empty override whose channel nothing reads).

**Test:** `counterfactual_no_override_reproduces_log` runs `run_counterfactual(&loaded, &log, &[], &cfg)` and asserts it succeeds, reproduces every logged channel verbatim, and leaves the changed-channel set empty. It fails on `main` with the `UnresolvedSymbol` error.

## Bug B — zero engineering-unit scale silently decodes to inf/NaN

The `.ld` engineering-unit decode divides the raw sample by the channel's `scale` field (`raw / scale * 10^-dec_places * mul`) with no zero-check, so a channel advertising `scale == 0` silently produced inf/NaN samples.

**Fix:** add a guard in `check_decodable` mirroring the existing zero-sample-rate check; a zero scale now fails loud with a clear message.

**Test:** `zero_scale_fails_loud` builds a channel with `scale = 0` and asserts `check_decodable` returns an error. It passes (wrongly) on `main` and fails without the guard.

## Verification

- `cargo test` and `cargo test --features ld` — all pass
- `cargo clippy --all-targets -- -D warnings` and `--features ld` — clean
- `cargo fmt --check` — clean
