### PR TITLE
Run On Startup once; explicit reported defaulting opt-in; never suppress division by zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ dependency-cone runners.
 
 ## What it adds (Phase 2 — the whole-project multi-rate scheduler)
 
-**Phase 2** turns the engine into a faithful **mini-ECU**: instead of running one
+**Phase 2** adds the whole-project multi-rate scheduler: instead of running one
 function or one dependency cone, the `whole-project` mode runs *every*
 periodically-scheduled function each tick at its own rate, over a fixed duration,
-producing one deterministic `Trace`. Select it with `mode = "whole-project"` in
+producing one deterministic `Trace`. It models the ECU's *schedule*, not the
+ECU itself — execution budgets, stalls, preemption, and watchdog effects are
+out of scope. Select it with `mode = "whole-project"` in
 the scenario or the `--whole-project` CLI flag (which overrides the scenario's
 mode and is mutually exclusive with `--function` / `--target`).
 
@@ -53,8 +55,10 @@ The multi-rate model:
   `.m1prj` trigger — a `BuiltIn.EventKernel` clock such as `On 500Hz` /
   `On 50Hz` — surfaced by `m1-typecheck` as the symbol's `call_rate_hz`. Every
   function with a resolvable periodic rate (500 / 200 / 50 / 10 / 2 Hz) is
-  scheduled; an `On Startup` or untriggered function (rate `None`) is **not** run
-  by the scheduler and is flagged *unscheduled* in `--coverage`.
+  scheduled. An `On Startup` function runs **exactly once**, before the first
+  periodic tick (its outputs hold from tick 0). Untriggered and
+  `$(…)`-parameterised-trigger functions are **not** run and are flagged
+  *unscheduled* in `--coverage`.
 - **Base tick + exact rate divisors.** The run advances on one base tick grid.
   When `base_rate_hz` is unset it defaults to the **least common multiple** of
   the scheduled rates, so every function has an exact integer tick period —
@@ -85,10 +89,18 @@ The multi-rate model:
 
 - **Deterministic.** A fixed tick grid and explicit `dt`, no wall-clock and no
   RNG: the same scenario always produces the same `Trace`.
-- **Fail-loud.** The evaluator never substitutes a guessed or default number. An
-  unimplemented builtin, an unsupported construct, a missing calibration value,
-  an unresolved symbol, or a missing scenario input all surface as an error and
-  abort the run — never a silently-wrong value.
+- **Fail-loud.** By default the evaluator never substitutes a guessed number. An
+  unimplemented builtin, an unsupported construct, an unresolved symbol, or a
+  missing scenario input all surface as an error and abort the run — never a
+  silently-wrong value. Whole-project mode may opt in to
+  **`allow_default_inputs`** (scenario field or `--allow-default-inputs`):
+  unseeded channel reads then fall back to their type-correct startup defaults,
+  and **every substitution is reported** (channel, substituted value, first
+  reading script) — visible guessing, never silent. Arithmetic errors are not
+  inputs: integer division/modulo by zero always fails loud, opt-in or not.
+  (An unseeded *parameter* still reads as its type-correct tunable default —
+  parameters are calibration values with real defaults in M1 Tune, not runtime
+  inputs.)
 
 ### `--coverage`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,7 +23,8 @@ m1-eval [--project P] [--config C]
 | `--scenario <PATH>` | The scenario file (TOML or JSON; parser chosen by extension) describing how to drive the run. |
 | `--function <NAME>` | Override the scenario's mode: run this single function each tick. Mutually exclusive with `--target` and `--whole-project`. |
 | `--target <CHANNEL>` | Override the scenario's mode: run this target channel plus its upstream dependency cone. Mutually exclusive with `--function` and `--whole-project`. |
-| `--whole-project` | Override the scenario's mode: run the whole-project multi-rate scheduler (every periodically-scheduled function at its own rate). Mutually exclusive with `--function` and `--target`. |
+| `--whole-project` | Override the scenario's mode: run the whole-project multi-rate scheduler (every periodically-scheduled function at its own rate; `On Startup` functions run once first). Mutually exclusive with `--function` and `--target`. |
+| `--allow-default-inputs` | Whole-project mode: substitute type-correct startup defaults for unseeded channel reads instead of failing loud. Every substitution is reported on stderr. Strict fail-loud is the default. |
 | `--out <PATH>` | Where to write the trace. Format follows the extension: `.csv` writes CSV, anything else (including `.json`) writes JSON. Without `--out`, the trace prints to stdout as JSON. |
 | `--log <PATH>` | Counterfactual replay: a recorded MoTeC log held as ground truth (`.csv`, or `.ld` with `--features ld`). Triggers a counterfactual run instead of a scenario run. |
 | `--override <CH=expr>` | Pin a logged channel to a constant or expression for the counterfactual run, recomputing only its downstream cone. Repeatable (override several channels). Requires `--log`. |
@@ -52,6 +53,9 @@ base_rate_hz = 100.0         # base tick rate; dt = 1 / base_rate_hz. In
                              # function runs every base_rate_hz / rate_hz ticks
                              # (must divide exactly — an inexact ratio is rejected);
                              # when 0/absent it defaults to the lcm of the scheduled rates
+allow_default_inputs = false # whole-project only: opt-in default substitution
+                             # for unseeded channel reads (reported; strict
+                             # fail-loud when absent/false)
 
 # Inputs the engine is *given* rather than computes. Each entry is a constant
 # or a (t_seconds, value) time series sampled by zero-order hold.

--- a/src/bin/m1_eval.rs
+++ b/src/bin/m1_eval.rs
@@ -73,6 +73,13 @@ struct Args {
     #[arg(long)]
     whole_project: bool,
 
+    /// Whole-project mode: substitute type-correct startup defaults for
+    /// unseeded channel reads instead of failing loud. Every substitution is
+    /// reported on stderr (channel, value, first reading script). Strict
+    /// fail-loud is the default.
+    #[arg(long)]
+    allow_default_inputs: bool,
+
     /// Where to write the trace. Format is inferred from the extension
     /// (.json or .csv); without --out the trace prints to stdout as JSON.
     #[arg(long)]
@@ -269,6 +276,9 @@ fn main() {
             args.target,
             args.whole_project,
         );
+        // The CLI flag is an OR over the scenario's own opt-in — it can enable
+        // defaulting, never silently disable what the scenario asked for.
+        scenario.allow_default_inputs |= args.allow_default_inputs;
 
         let trace = match engine.run(&scenario) {
             Ok(t) => t,
@@ -277,6 +287,21 @@ fn main() {
                 process::exit(1);
             }
         };
+
+        // Honest accounting: every input the run GUESSED (type-correct startup
+        // default under the explicit opt-in) is reported, not silently absorbed.
+        if !trace.defaulted.is_empty() {
+            eprintln!(
+                "m1-eval: {} unseeded input(s) substituted with startup defaults (--allow-default-inputs):",
+                trace.defaulted.len()
+            );
+            for (path, d) in &trace.defaulted {
+                eprintln!(
+                    "  {path} = {:?} (first read by {})",
+                    d.value, d.first_reader
+                );
+            }
+        }
 
         match args.out {
             Some(out) => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -346,8 +346,10 @@ const = 6.0
             .get("Root.MR.Slow Echo")
             .expect("Slow Echo column");
         assert_eq!(echo, &vec![Value::Float(6.0); 4]);
-        // The On-Startup function never runs in whole-project mode.
-        assert!(!trace.channels.contains_key("Root.MR.Started"));
+        // The On-Startup function ran exactly once before the periodic loop;
+        // its marker holds across every tick.
+        let started = trace.channels.get("Root.MR.Started").expect("Started");
+        assert_eq!(started, &vec![Value::Float(1.0); 4]);
     }
 
     #[test]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -359,6 +359,9 @@ pub(crate) fn read_symbol(canon: &str, ctx: &mut EvalCtx) -> Result<Value, EvalE
                 let value_type = symbol.map(|s| s.value_type).unwrap_or(ValueType::Unknown);
                 let default = typed_io_input_default(value_type, ctx.project);
                 if let Some(trace) = ctx.trace.as_deref_mut() {
+                    // Report the substitution honestly: the channel, the value
+                    // GUESSED for it, and the script whose read triggered it.
+                    trace.mark_defaulted(canon, default.clone(), ctx.script_name);
                     trace.mark_external(canon);
                 }
                 Ok(default)
@@ -589,7 +592,7 @@ fn eval_binary(node: &Node, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
     // The remaining operators (arithmetic, comparison, equality, bitwise/shift)
     // operate on the two evaluated values; share that core with the compound
     // assignment operators. An unhandled token reports its byte offset.
-    apply_binary_values(kind, &l, &r, ctx.env.default_unseeded_channels).map_err(|e| match e {
+    apply_binary_values(kind, &l, &r).map_err(|e| match e {
         EvalError::UnsupportedConstruct { kind, .. } => EvalError::UnsupportedConstruct {
             kind,
             at: op.byte_range().start,
@@ -604,22 +607,16 @@ fn eval_binary(node: &Node, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
 /// assignment operators (`+=`, `&=`, …). Logical/short-circuit operators are
 /// intentionally excluded — they are handled in [`eval_binary`] before both
 /// operands are evaluated, and compound assignment never targets them.
-/// `div_by_zero_yields_zero` makes integer `/` and `%` by zero return `0` instead
-/// of failing loud — the documented M1 firmware behaviour, enabled in
-/// whole-project mode where the all-default offline input world can produce a
-/// degenerate zero divisor that real calibration/CAN data would not. `false`
-/// (single-function/cone mode) keeps the fail-loud guard so a genuine zero divisor
-/// in user-supplied inputs surfaces.
-pub(crate) fn apply_binary_values(
-    op: Kind,
-    l: &Value,
-    r: &Value,
-    div_by_zero_yields_zero: bool,
-) -> Result<Value, EvalError> {
+/// Integer `/` and `%` by zero always fail loud, in every mode: an arithmetic
+/// error is not a missing input, so it is never converted into a value — not
+/// even under the whole-project `allow_default_inputs` opt-in (whose scope is
+/// unseeded *reads* only). No firmware documentation substantiates a
+/// divide-by-zero-yields-zero behaviour; if that evidence ever appears, the
+/// behaviour belongs here unconditionally with the citation, not gated on
+/// offline defaulting.
+pub(crate) fn apply_binary_values(op: Kind, l: &Value, r: &Value) -> Result<Value, EvalError> {
     match op {
-        Kind::Plus | Kind::Minus | Kind::Star | Kind::Slash | Kind::Percent => {
-            arithmetic(op, l, r, div_by_zero_yields_zero)
-        }
+        Kind::Plus | Kind::Minus | Kind::Star | Kind::Slash | Kind::Percent => arithmetic(op, l, r),
         Kind::Lt | Kind::Gt | Kind::LtEq | Kind::GtEq => compare(op, l, r),
         Kind::Eq | Kind::EqEq => Ok(Value::Bool(values_equal(l, r)?)),
         Kind::Neq | Kind::BangEq => Ok(Value::Bool(!values_equal(l, r)?)),
@@ -634,12 +631,7 @@ pub(crate) fn apply_binary_values(
 /// Apply an arithmetic operator. Integer/unsigned operands stay integral (with
 /// the result kind chosen by `numeric_join`); any float operand promotes to
 /// float. Division/modulo by zero fail loud rather than producing NaN/inf.
-fn arithmetic(
-    op: Kind,
-    l: &Value,
-    r: &Value,
-    div_by_zero_yields_zero: bool,
-) -> Result<Value, EvalError> {
+fn arithmetic(op: Kind, l: &Value, r: &Value) -> Result<Value, EvalError> {
     let lt = value_type(l);
     let rt = value_type(r);
     let joined = numeric_join(lt, rt);
@@ -661,12 +653,12 @@ fn arithmetic(
         ValueType::Unsigned => {
             let a = as_u64(l)?;
             let b = as_u64(r)?;
-            int_op_u64(op, a, b, div_by_zero_yields_zero)
+            int_op_u64(op, a, b)
         }
         ValueType::Integer => {
             let a = as_i64(l)?;
             let b = as_i64(r)?;
-            int_op_i64(op, a, b, div_by_zero_yields_zero)
+            int_op_i64(op, a, b)
         }
         // One operand is non-numeric (Bool/Enum/String) or Unknown.
         _ => Err(EvalError::TypeError {
@@ -675,20 +667,20 @@ fn arithmetic(
     }
 }
 
-fn int_op_i64(op: Kind, a: i64, b: i64, div_by_zero_yields_zero: bool) -> Result<Value, EvalError> {
+fn int_op_i64(op: Kind, a: i64, b: i64) -> Result<Value, EvalError> {
     let out = match op {
         Kind::Plus => a.wrapping_add(b),
         Kind::Minus => a.wrapping_sub(b),
         Kind::Star => a.wrapping_mul(b),
         Kind::Slash => {
             if b == 0 {
-                return zero_divisor_result(div_by_zero_yields_zero).map(Value::Int);
+                return Err(div_by_zero());
             }
             a.wrapping_div(b)
         }
         Kind::Percent => {
             if b == 0 {
-                return zero_divisor_result(div_by_zero_yields_zero).map(Value::Int);
+                return Err(div_by_zero());
             }
             a.wrapping_rem(b)
         }
@@ -697,37 +689,26 @@ fn int_op_i64(op: Kind, a: i64, b: i64, div_by_zero_yields_zero: bool) -> Result
     Ok(Value::Int(out))
 }
 
-fn int_op_u64(op: Kind, a: u64, b: u64, div_by_zero_yields_zero: bool) -> Result<Value, EvalError> {
+fn int_op_u64(op: Kind, a: u64, b: u64) -> Result<Value, EvalError> {
     let out = match op {
         Kind::Plus => a.wrapping_add(b),
         Kind::Minus => a.wrapping_sub(b),
         Kind::Star => a.wrapping_mul(b),
         Kind::Slash => {
             if b == 0 {
-                return zero_divisor_result(div_by_zero_yields_zero).map(|z| Value::Uint(z as u64));
+                return Err(div_by_zero());
             }
             a.wrapping_div(b)
         }
         Kind::Percent => {
             if b == 0 {
-                return zero_divisor_result(div_by_zero_yields_zero).map(|z| Value::Uint(z as u64));
+                return Err(div_by_zero());
             }
             a.wrapping_rem(b)
         }
         _ => unreachable!(),
     };
     Ok(Value::Uint(out))
-}
-
-/// The result of an integer divide/modulo by zero. In whole-project mode it is the
-/// documented M1 firmware result `0` (the ECU never traps); otherwise it is a
-/// fail-loud [`EvalError`] so a genuine zero divisor in user inputs surfaces.
-fn zero_divisor_result(div_by_zero_yields_zero: bool) -> Result<i64, EvalError> {
-    if div_by_zero_yields_zero {
-        Ok(0)
-    } else {
-        Err(div_by_zero())
-    }
 }
 
 fn div_by_zero() -> EvalError {
@@ -1161,6 +1142,24 @@ mod tests {
         let mut h = Harness::new();
         assert!(matches!(
             rhs_value("1 / 0", &mut h),
+            Err(EvalError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn division_by_zero_fails_loud_even_with_default_inputs_enabled() {
+        // The allow-default-inputs opt-in covers unseeded READS only. An
+        // arithmetic error is not a missing input: integer divide/modulo by
+        // zero fails loud in every mode — it is never converted to 0 because
+        // offline defaulting happens to be on (2026-07-19 review, B6).
+        let mut h = Harness::new();
+        h.env.default_unseeded_channels = true;
+        assert!(matches!(
+            rhs_value("1 / 0", &mut h),
+            Err(EvalError::TypeError { .. })
+        ));
+        assert!(matches!(
+            rhs_value("7 % 0", &mut h),
             Err(EvalError::TypeError { .. })
         ));
     }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -29,6 +29,12 @@ pub struct Loaded {
     pub scripts: Vec<ParsedScript>,
     /// Numeric calibration values (parameters + table cells).
     pub calib: Calibration,
+    /// Function symbols whose `.m1prj` `SelectedTrigger` resolves to the
+    /// `On Startup` event kernel (trigger leaf `"On Startup"`, the convention
+    /// both real corpora follow). The whole-project runner executes these
+    /// exactly once before the periodic loop. `$(…)`-parameterised and
+    /// untriggered functions are NOT here — they stay unscheduled.
+    pub startup_fn_symbols: Vec<String>,
 }
 
 /// Load a project, its scripts, and (optionally) its calibration values.
@@ -74,11 +80,46 @@ pub fn load(project_path: &Path, cfg_path: Option<&Path>) -> Result<Loaded, Eval
         None => Calibration::default(),
     };
 
+    let startup_fn_symbols = startup_functions(&read_xml(project_path)?)?;
+
     Ok(Loaded {
         project,
         scripts,
         calib,
+        startup_fn_symbols,
     })
+}
+
+/// The full component names (function symbols) whose `SelectedTrigger` points at
+/// the `On Startup` event kernel — trigger path leaf `"On Startup"`, matching
+/// both synthetic fixtures and the real corpora (`…Events.On Startup`, possibly
+/// `Parent.`-prefixed). Parsed from the raw `.m1prj` because the typed symbol
+/// model deliberately collapses non-periodic triggers to `call_rate_hz = None`
+/// without recording which are startup. Fails loud on unparseable XML — the
+/// project just loaded through `m1-typecheck`, so a parse failure here is a
+/// genuine inconsistency, not a condition to guess through.
+fn startup_functions(xml: &str) -> Result<Vec<String>, EvalError> {
+    let doc = roxmltree::Document::parse(xml).map_err(|e| EvalError::UnsupportedConstruct {
+        kind: format!("project XML re-parse for startup triggers failed: {e}"),
+        at: 0,
+    })?;
+    let mut out = Vec::new();
+    for node in doc.descendants().filter(|n| n.has_tag_name("Component")) {
+        let Some(name) = node.attribute("Name") else {
+            continue;
+        };
+        let trigger = node
+            .children()
+            .find(|c| c.has_tag_name("Props"))
+            .and_then(|p| p.attribute("SelectedTrigger"));
+        if let Some(t) = trigger
+            && t.rsplit('.').next() == Some("On Startup")
+        {
+            out.push(name.to_string());
+        }
+    }
+    out.sort();
+    Ok(out)
 }
 
 /// Read a MoTeC XML file as text, decoding lossily so Windows-1252 exports do not

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -442,22 +442,28 @@ fn tick_loop(
     let mut state = StateStore::new();
     let mut trace = Trace::new();
 
-    // In **whole-project** mode there is no scenario driving the sensor/CAN inputs
-    // and no calibration seeding the tunables, so an unseeded *channel* read falls
-    // back to its type-correct startup default (flagged externally driven) rather
-    // than aborting the run — the channel-side analogue of the Tier-3 IO stubs.
-    // This covers every unseeded read uniformly: a hardware sensor channel, a CAN
-    // signal, a table-output `.Value` the auto-`Lookup` would compute, and a state
-    // channel read before its writer's first run. It propagates to inline
-    // user-function callees (they share this env). In `function`/`cone` mode the
-    // flag stays `false`, so a read of an unprovided input still fails loud — the
-    // scenario must drive every channel a single function reads.
-    env.default_unseeded_channels = matches!(scenario.mode, RunMode::WholeProject);
+    // Unseeded-channel defaulting is the scenario's EXPLICIT opt-in
+    // (`allow_default_inputs = true`, whole-project mode only): an unseeded
+    // channel read then falls back to its type-correct startup default, and
+    // every substitution is reported on the trace (channel, value, first
+    // reader). Strict fail-loud is the baseline in every mode — a missing input
+    // aborts the run rather than quietly becoming a guessed number.
+    env.default_unseeded_channels =
+        matches!(scenario.mode, RunMode::WholeProject) && scenario.allow_default_inputs;
 
     // The union of every channel the schedule writes, computed once: on a tick a
     // function holds (does not run), we repeat its last value from `env` for these
-    // channels so the trace stays a dense grid (zero-order hold).
-    let scheduled_writes = schedule_writes(loaded, schedule);
+    // channels so the trace stays a dense grid (zero-order hold). Startup
+    // functions' writes are included so their once-written outputs appear (and
+    // hold) as trace columns from the first tick.
+    let startup = startup_schedule(loaded, scenario);
+    let mut scheduled_writes = schedule_writes(loaded, schedule);
+    for sched in &startup {
+        let io = io_sets(sched.script, &loaded.project, sched.group.as_deref());
+        for w in io.writes {
+            scheduled_writes.insert(w);
+        }
+    }
 
     // Canonicalise each scenario input/override channel once, against the first
     // scheduled function's scope (all scheduled functions share the project; the
@@ -466,6 +472,41 @@ fn tick_loop(
     let scope_fn = schedule.first().and_then(|s| s.sched.fn_symbol.as_deref());
     let inputs = canonicalise(&scenario.inputs, loaded, scope_group, scope_fn);
     let overrides = canonicalise(&scenario.overrides, loaded, scope_group, scope_fn);
+
+    // Run every On-Startup function exactly once, before the periodic grid —
+    // the ECU's initialisation pass. Inputs/overrides are seeded at t = 0 first
+    // so startup code can read scenario-driven channels; writes land in the
+    // shared env (no trace tick is open yet) and surface via the zero-order
+    // hold from tick 0 on. dt is the base period — startup code has no rate of
+    // its own, and its stateful operators see one nominal step.
+    if !startup.is_empty() {
+        for (path, series) in &inputs {
+            env.set(path.clone(), series.sample(0.0));
+        }
+        for (path, series) in &overrides {
+            env.set(path.clone(), series.sample(0.0));
+        }
+        for sched in &startup {
+            let root = sched.script.cst.root();
+            let mut ctx = EvalCtx {
+                project: &loaded.project,
+                calib: &loaded.calib,
+                env: &mut env,
+                state: &mut state,
+                group: sched.group.as_deref(),
+                fn_symbol: sched.fn_symbol.as_deref(),
+                script_name: &sched.script.name,
+                dt: 1.0 / base_rate_hz,
+                scripts: &loaded.scripts,
+                depth: 0,
+                // No trace: no tick is open yet, and record_channel appends
+                // blindly — a startup record would desync columns from the time
+                // axis. Startup writes surface via the tick-0 zero-order hold.
+                trace: None,
+            };
+            exec_script(&root, &mut ctx)?;
+        }
+    }
 
     for i in 0..ticks {
         let t = i as f64 / base_rate_hz;
@@ -545,6 +586,34 @@ struct RunPlan {
     /// `1 / rate_hz` — the time since this function's previous run, handed to its
     /// stateful operators so accumulation is rate-correct.
     dt: f64,
+}
+
+/// The On-Startup functions to run once before the periodic loop, in
+/// writer-before-reader order — whole-project mode only (function/cone modes
+/// pin a single explicit target and model no initialisation pass). Each
+/// `startup_fn_symbols` entry (from the loader's trigger scan) is matched back
+/// to its parsed script; ordering reuses the same single-group topological
+/// machinery as the periodic schedule (nominal rate, stripped after ordering).
+fn startup_schedule<'a>(loaded: &'a Loaded, scenario: &Scenario) -> Vec<Scheduled<'a>> {
+    if !matches!(scenario.mode, RunMode::WholeProject) || loaded.startup_fn_symbols.is_empty() {
+        return Vec::new();
+    }
+    let mut rated: Vec<ScheduledRated> = loaded
+        .scripts
+        .iter()
+        .filter_map(|script| {
+            let fn_symbol = loaded.project.function_symbol_for_script(&script.name)?;
+            if !loaded.startup_fn_symbols.contains(&fn_symbol) {
+                return None;
+            }
+            Some(ScheduledRated {
+                sched: scheduled_for(loaded, script),
+                rate_hz: 1.0,
+            })
+        })
+        .collect();
+    order_by_dependency_then_rate(loaded, &mut rated);
+    rated.into_iter().map(|r| r.sched).collect()
 }
 
 /// The union of every channel any scheduled function writes (canonical paths),
@@ -1317,6 +1386,7 @@ mod tests {
         let toml = r#"
 mode = "whole-project"
 duration_s = 0.01
+allow_default_inputs = true
 
 [[inputs]]
 channel = "Root.RX.Seed"
@@ -1342,6 +1412,7 @@ const = 3.0
         let toml = r#"
 mode = "whole-project"
 duration_s = 1.0
+allow_default_inputs = true
 
 [[inputs]]
 channel = "Root.RX.Seed"
@@ -1362,6 +1433,94 @@ const = 3.0
         assert!(
             (total - 2.985).abs() < 1e-9,
             "exact dt=5 ms trapezoidal accumulation, got {total}"
+        );
+    }
+
+    #[test]
+    fn whole_project_is_strict_by_default_on_unseeded_channels() {
+        // ratemix's counters read their own (unseeded) channels. Whole-project
+        // mode used to silently substitute type-correct defaults for every
+        // unseeded read; strict fail-loud is now the default and defaulting is
+        // the scenario's explicit opt-in (`allow_default_inputs = true`).
+        let loaded = ratemix();
+        let toml = r#"
+mode = "whole-project"
+duration_s = 0.01
+
+[[inputs]]
+channel = "Root.RX.Seed"
+const = 3.0
+"#;
+        let scenario = Scenario::from_toml_str(toml).unwrap();
+        let err = run(&loaded, &scenario).expect_err("unseeded channel must fail loud");
+        assert!(
+            matches!(err, EvalError::MissingInput { .. }),
+            "expected MissingInput, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn allow_default_inputs_defaults_and_reports_substitutions() {
+        // With the explicit opt-in, unseeded channel reads fall back to their
+        // type-correct startup defaults — and every substitution is REPORTED on
+        // the trace: channel, substituted value, and the first reading script.
+        let loaded = ratemix();
+        let toml = r#"
+mode = "whole-project"
+duration_s = 0.01
+allow_default_inputs = true
+
+[[inputs]]
+channel = "Root.RX.Seed"
+const = 3.0
+"#;
+        let scenario = Scenario::from_toml_str(toml).unwrap();
+        let trace = run(&loaded, &scenario).expect("opt-in defaulted run succeeds");
+        let fast = trace
+            .defaulted
+            .get("Root.RX.Fast Count")
+            .expect("Fast Count substitution reported");
+        assert_eq!(fast.value, Value::Float(0.0));
+        assert_eq!(fast.first_reader, "RX.Fast Counter.m1scr");
+        assert!(
+            trace.defaulted.contains_key("Root.RX.Mid Count"),
+            "Mid Count substitution reported: {:?}",
+            trace.defaulted.keys().collect::<Vec<_>>()
+        );
+        // The seeded input is NOT a substitution.
+        assert!(!trace.defaulted.contains_key("Root.RX.Seed"));
+    }
+
+    #[test]
+    fn startup_functions_run_once_before_the_periodic_loop() {
+        // The multirate fixture's Root.MR.Init (On Startup) writes Started = 1.
+        // Whole-project mode used to skip startup functions entirely; they now
+        // run exactly once, before the first periodic tick, and their outputs
+        // hold (zero-order) across the whole trace.
+        let loaded = multirate();
+        let toml = r#"
+mode = "whole-project"
+duration_s = 0.05
+base_rate_hz = 100.0
+
+[[inputs]]
+channel = "Root.MR.Seed"
+const = 3.0
+
+[[inputs]]
+channel = "Root.MR.Slow Out"
+const = 6.0
+"#;
+        let scenario = Scenario::from_toml_str(toml).unwrap();
+        let trace = run(&loaded, &scenario).expect("whole-project run succeeds");
+        let started = trace
+            .channels
+            .get("Root.MR.Started")
+            .expect("startup-written channel appears in the trace");
+        assert_eq!(started.len(), 5, "held across every tick");
+        assert!(
+            started.iter().all(|v| *v == Value::Float(1.0)),
+            "startup ran once and its output holds: {started:?}"
         );
     }
 
@@ -1521,11 +1680,12 @@ const = 6.0
         assert!(shared.iter().all(|v| *v == Value::Float(7.0)), "{shared:?}");
         assert!(fast.iter().all(|v| *v == Value::Float(70.0)), "{fast:?}");
 
-        // The startup function never runs in whole-project mode, so its channel
-        // is never written by the schedule.
+        // The startup function runs exactly once before the periodic loop, so
+        // its marker channel is present and holds its startup value.
+        let started = trace.channels.get("Root.MR.Started").expect("Started");
         assert!(
-            !trace.channels.contains_key("Root.MR.Started"),
-            "startup channel must not be produced"
+            started.iter().all(|v| *v == Value::Float(1.0)),
+            "startup marker holds: {started:?}"
         );
     }
 

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -134,6 +134,11 @@ pub struct Scenario {
     /// Channels pinned to a constant or series, layered *over* the inputs and
     /// any computed value. Same shape as [`Scenario::inputs`].
     pub overrides: Vec<InputSeries>,
+    /// Whole-project mode only: substitute type-correct startup defaults for
+    /// unseeded channel reads (each substitution is reported on the trace)
+    /// instead of failing loud. **Off by default** — strict fail-loud is the
+    /// baseline; defaulting is an explicit, visible opt-in.
+    pub allow_default_inputs: bool,
 }
 
 impl Scenario {
@@ -351,6 +356,10 @@ struct RawScenario {
     inputs: Vec<RawInput>,
     #[serde(default)]
     overrides: Vec<RawInput>,
+    /// Opt-in unseeded-channel defaulting for whole-project mode (strict
+    /// fail-loud when absent/false).
+    #[serde(default)]
+    allow_default_inputs: bool,
 }
 
 /// A raw input/override entry: a channel plus exactly one of `const`/`series`.
@@ -456,6 +465,7 @@ impl RawScenario {
             duration_s: self.duration_s,
             base_rate_hz: self.base_rate_hz,
             overrides,
+            allow_default_inputs: self.allow_default_inputs,
         })
     }
 }

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -116,8 +116,7 @@ fn exec_assignment(node: &Node, ctx: &mut EvalCtx) -> Result<(), EvalError> {
     // first, applies the corresponding binary operator, then writes the result.
     let final_value = if m1_core::is_compound_assign(op.kind()) {
         let current = read_dest(&dest, ctx)?;
-        let div_by_zero_yields_zero = ctx.env.default_unseeded_channels;
-        apply_compound(op.kind(), &current, &rhs, div_by_zero_yields_zero)?
+        apply_compound(op.kind(), &current, &rhs)?
     } else {
         rhs
     };
@@ -272,12 +271,7 @@ fn write_dest(dest: &Dest, value: Value, ctx: &mut EvalCtx) {
 /// Apply a compound-assignment operator to the current value and the rhs. The
 /// arithmetic/bitwise semantics match the expression evaluator's binary
 /// operators (delegated through a fresh binary-op evaluation).
-fn apply_compound(
-    op: Kind,
-    current: &Value,
-    rhs: &Value,
-    div_by_zero_yields_zero: bool,
-) -> Result<Value, EvalError> {
+fn apply_compound(op: Kind, current: &Value, rhs: &Value) -> Result<Value, EvalError> {
     // Map each compound operator to its underlying binary operator, then reuse the
     // expression evaluator's binary semantics so the result typing/coercions stay
     // consistent (`numeric_join`, integral-only bitwise, div-by-zero handling).
@@ -299,7 +293,7 @@ fn apply_compound(
             });
         }
     };
-    expr::apply_binary_values(binop, current, rhs, div_by_zero_yields_zero)
+    expr::apply_binary_values(binop, current, rhs)
 }
 
 // ---- Task 21: if/else, when/is, expand/to, local/static local, block ----

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -44,6 +44,21 @@ pub struct Trace {
     /// Tier-3 stub) rather than computed by the engine. Metadata only — these
     /// channels still appear in [`Trace::channels`].
     pub external: BTreeSet<String>,
+    /// Unseeded inputs substituted with a type-correct startup default under the
+    /// scenario's explicit `allow_default_inputs` opt-in, keyed by canonical
+    /// channel path. Metadata only (not part of the JSON/CSV trace body): the
+    /// honest record of every value the run GUESSED rather than computed.
+    pub defaulted: BTreeMap<String, DefaultedInput>,
+}
+
+/// One reported default substitution: what value was substituted and which
+/// script read it first.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DefaultedInput {
+    /// The substituted (type-correct startup default) value.
+    pub value: Value,
+    /// The script whose read first triggered the substitution.
+    pub first_reader: String,
 }
 
 impl Trace {
@@ -70,6 +85,17 @@ impl Trace {
     /// `(script, byte_offset)` identity) for the current tick.
     pub fn record_expr(&mut self, site: (String, usize), value: Value) {
         self.exprs.entry(site).or_default().push(value);
+    }
+
+    /// Record a default-substituted input (first reader wins — later reads of
+    /// the same channel do not overwrite the original report).
+    pub fn mark_defaulted(&mut self, path: impl Into<String>, value: Value, reader: &str) {
+        self.defaulted
+            .entry(path.into())
+            .or_insert_with(|| DefaultedInput {
+                value,
+                first_reader: reader.to_string(),
+            });
     }
 
     /// Flag a channel as externally driven (scenario-fed or a Tier-3 stub).

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -279,10 +279,11 @@ fn whole_project_flag_runs_every_scheduled_channel() {
         header.contains("Root.MR.Slow Echo"),
         "header missing slow channel: {header}"
     );
-    // The On-Startup function never runs, so its channel is absent.
+    // The On-Startup function ran once before the periodic loop; its marker
+    // channel appears and holds 1 on every tick.
     assert!(
-        !csv.contains("Root.MR.Started"),
-        "startup channel must not appear: {csv}"
+        csv.contains("Root.MR.Started"),
+        "startup channel must appear: {csv}"
     );
 }
 

--- a/tests/snapshots/snapshot__whole_project_trace.snap
+++ b/tests/snapshots/snapshot__whole_project_trace.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/snapshot.rs
+assertion_line: 115
 expression: trace.to_json()
 ---
-{"time":[0,0.01,0.02,0.03,0.04,0.05],"channels":{"Root.MR.Fast Out":[50,50,50,50,50,50],"Root.MR.Fast Shared":[5,5,5,5,5,5],"Root.MR.Seed":[2,2,2,2,2,2],"Root.MR.Slow Echo":[4,4,4,4,4,4],"Root.MR.Slow Out":[4,4,4,4,4,4],"Root.MR.Slow Total":[0,0,0.04,0.04,0.08,0.08]},"external":["Root.MR.Seed"]}
+{"time":[0,0.01,0.02,0.03,0.04,0.05],"channels":{"Root.MR.Fast Out":[50,50,50,50,50,50],"Root.MR.Fast Shared":[5,5,5,5,5,5],"Root.MR.Seed":[2,2,2,2,2,2],"Root.MR.Slow Echo":[4,4,4,4,4,4],"Root.MR.Slow Out":[4,4,4,4,4,4],"Root.MR.Slow Total":[0,0,0.04,0.04,0.08,0.08],"Root.MR.Started":[1,1,1,1,1,1]},"external":["Root.MR.Seed"]}


### PR DESCRIPTION
Fixes #7 (P1.1 / B5 / B6 of the 2026-07-19 ecosystem review).

**Startup semantics.** Whole-project mode now runs `On Startup` functions exactly once before the first periodic tick (writer-before-reader order; outputs hold from tick 0). The loader identifies them by re-scanning the `.m1prj` for `SelectedTrigger` leaves equal to `On Startup` — the convention both real corpora follow. `$(…)`-parameterised and untriggered functions stay unscheduled.

**Defaulting is an explicit, reported opt-in.** Whole-project mode previously substituted type-correct defaults for every unseeded channel read, silently — contradicting the README's fail-loud claim. Now strict fail-loud is the baseline in every mode; `allow_default_inputs = true` (scenario) or `--allow-default-inputs` (CLI) enables it, and every substitution is reported: `trace.defaulted` carries channel → substituted value + first reading script, and the CLI prints the report to stderr. Unseeded *parameters* still read as tunable defaults (they are calibration values, not runtime inputs).

**Division by zero always fails loud.** The old code returned 0 for integer `/`/`%` by zero whenever defaulting was on, citing "documented firmware behaviour" — neither the Development Manual nor the captured intrinsics catalogue substantiates that, and an arithmetic error is not a missing input regardless. The flag plumbing is removed end-to-end.

**Docs.** "Faithful mini-ECU" rescoped to "models the schedule, not the ECU" (no execution budgets, stalls, preemption, watchdogs); fail-loud section rewritten to the precise contract.

Tests: strict-by-default fails loud on ratemix's self-reading counters; the opt-in run reports both substitutions with first readers; the multirate startup marker holds 1 across the whole trace (unit + engine + CLI CSV); div-by-zero fails loud with defaulting enabled; whole-project snapshot updated (the Started column is the intended diff).