### PR TITLE
Diff: flag non-finite divergence, reject ambiguous log matches; validate CSV time/headers/width

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -38,9 +38,14 @@ pub struct ChannelDiff {
     pub counterfactual: Vec<f64>,
     /// `counterfactual - logged` at each tick.
     pub delta: Vec<f64>,
-    /// The maximum absolute delta over the grid (0.0 for an empty grid).
+    /// The maximum absolute delta over the grid (0.0 for an empty grid),
+    /// over the ticks where both sides are finite.
     pub max_abs_delta: f64,
-    /// Whether `max_abs_delta` exceeds the diff's `eps`.
+    /// Ticks where exactly one side is non-finite (finite↔NaN/±Inf) — the most
+    /// alarming kind of divergence, counted rather than silently dropped.
+    pub non_finite_mismatches: usize,
+    /// Whether `max_abs_delta` exceeds the diff's `eps` OR any finite↔non-finite
+    /// mismatch occurred.
     pub changed: bool,
 }
 
@@ -64,6 +69,13 @@ pub struct Diff {
     pub channels: BTreeMap<String, ChannelDiff>,
     /// The change threshold used to set each channel's `changed` flag.
     pub eps: f64,
+    /// The audited binding of each diffed trace channel to the log series it was
+    /// compared against (trace path → log channel name).
+    pub mapping: BTreeMap<String, String>,
+    /// Trace channels EXCLUDED from the diff because their fallback match was
+    /// ambiguous — more than one trace channel claimed the same log series via
+    /// the `Root.`-stripped/bare-leaf fallback. Reported, never silently bound.
+    pub ambiguous: Vec<String>,
 }
 
 impl Diff {
@@ -83,27 +95,60 @@ impl Diff {
     /// canonicalises log inputs). Other channels are skipped.
     pub fn between_eps(log: &Log, trace: &Trace, eps: f64) -> Diff {
         let time = trace.time.clone();
+
+        // Resolve every candidate binding first, then reject ambiguous fallback
+        // claims: two distinct trace channels bound to the SAME log series via
+        // the stripped/leaf fallback means at least one would diff against the
+        // wrong ground truth. An exact (verbatim) match always keeps its
+        // binding; only fallback claimants are excluded (and reported).
+        let mut bindings: Vec<(&String, &crate::scenario::InputSeries, bool)> = Vec::new();
+        for path in trace.channels.keys() {
+            if let Some((series, exact)) = match_log_series(log, path) {
+                bindings.push((path, series, exact));
+            }
+        }
+        let mut claims: BTreeMap<&str, usize> = BTreeMap::new();
+        for (_, series, exact) in &bindings {
+            if !exact {
+                *claims.entry(series.channel.as_str()).or_default() += 1;
+            }
+        }
+        let exact_names: std::collections::BTreeSet<&str> = bindings
+            .iter()
+            .filter(|(_, _, exact)| *exact)
+            .map(|(_, series, _)| series.channel.as_str())
+            .collect();
+        let mut ambiguous: Vec<String> = Vec::new();
+        let mut mapping = BTreeMap::new();
         let mut channels = BTreeMap::new();
 
-        for (path, col) in &trace.channels {
-            let Some(series) = match_log_series(log, path) else {
+        for (path, series, exact) in bindings {
+            let fallback_conflicted = !exact
+                && (claims.get(series.channel.as_str()).copied().unwrap_or(0) > 1
+                    || exact_names.contains(series.channel.as_str()));
+            if fallback_conflicted {
+                ambiguous.push(path.clone());
                 continue;
-            };
-            let Some(counterfactual) = column_as_f64(col) else {
+            }
+            let Some(counterfactual) = column_as_f64(&trace.channels[path]) else {
                 continue;
             };
             let logged: Vec<f64> = time.iter().map(|&t| sample_f64(series, t)).collect();
 
             let n = logged.len().min(counterfactual.len());
             let delta: Vec<f64> = (0..n).map(|i| counterfactual[i] - logged[i]).collect();
+            let non_finite_mismatches = (0..n)
+                .filter(|&i| logged[i].is_finite() != counterfactual[i].is_finite())
+                .count();
             let max_abs_delta = delta
                 .iter()
                 .copied()
                 .map(f64::abs)
                 .filter(|d| d.is_finite())
                 .fold(0.0_f64, f64::max);
-            let changed = max_abs_delta > eps;
+            let changed = max_abs_delta > eps || non_finite_mismatches > 0;
 
+            mapping.insert(path.clone(), series.channel.clone());
             channels.insert(
                 path.clone(),
                 ChannelDiff {
@@ -111,15 +156,19 @@ impl Diff {
                     counterfactual,
                     delta,
                     max_abs_delta,
+                    non_finite_mismatches,
                     changed,
                 },
             );
         }
+        ambiguous.sort();
 
         Diff {
             time,
             channels,
             eps,
+            mapping,
+            ambiguous,
         }
     }
 
@@ -148,6 +197,8 @@ impl Diff {
             s.push_str(&json_string(path));
             s.push_str(":{\"max_abs_delta\":");
             s.push_str(&num_json(d.max_abs_delta));
+            s.push_str(",\"non_finite_mismatches\":");
+            s.push_str(&d.non_finite_mismatches.to_string());
             s.push_str(",\"changed\":");
             s.push_str(if d.changed { "true" } else { "false" });
             s.push_str(",\"logged\":");
@@ -158,7 +209,23 @@ impl Diff {
             push_array(&mut s, &d.delta);
             s.push('}');
         }
-        s.push_str("}}");
+        s.push_str("},\"mapping\":{");
+        for (i, (path, log_name)) in self.mapping.iter().enumerate() {
+            if i > 0 {
+                s.push(',');
+            }
+            s.push_str(&json_string(path));
+            s.push(':');
+            s.push_str(&json_string(log_name));
+        }
+        s.push_str("},\"ambiguous\":[");
+        for (i, path) in self.ambiguous.iter().enumerate() {
+            if i > 0 {
+                s.push(',');
+            }
+            s.push_str(&json_string(path));
+        }
+        s.push_str("]}");
         s
     }
 
@@ -195,18 +262,20 @@ impl Diff {
 
 /// Find the log series matching a trace channel path: exact, then the `Root.`-
 /// stripped path, then the bare leaf name (logs commonly omit the implicit `Root.`
-/// group prefix the symbol table uses).
-fn match_log_series<'a>(log: &'a Log, path: &str) -> Option<&'a InputSeries> {
+/// group prefix the symbol table uses). The second tuple element is `true` for an
+/// exact (verbatim) match — fallback matches are subject to the caller's
+/// ambiguity rejection, exact matches are not.
+fn match_log_series<'a>(log: &'a Log, path: &str) -> Option<(&'a InputSeries, bool)> {
     if let Some(s) = log.series_for(path) {
-        return Some(s);
+        return Some((s, true));
     }
     if let Some(stripped) = path.strip_prefix("Root.")
         && let Some(s) = log.series_for(stripped)
     {
-        return Some(s);
+        return Some((s, false));
     }
     let leaf = path.rsplit('.').next().unwrap_or(path);
-    log.series_for(leaf)
+    log.series_for(leaf).map(|s| (s, false))
 }
 
 /// A whole column as `f64`, or `None` if any cell is non-numeric (bool/enum/string)
@@ -385,6 +454,105 @@ mod tests {
         let trace = trace_with(&[("Root.CF.Sensor", &[3.0])], &[0.0]);
         let diff = Diff::between(&log, &trace);
         assert_eq!(diff.channels["Root.CF.Sensor"].delta, vec![2.0]);
+    }
+
+    #[test]
+    fn finite_to_non_finite_divergence_is_changed() {
+        // The counterfactual turned a finite logged value into NaN/Infinity. The
+        // old max_abs_delta filtered non-finite deltas before folding, so the
+        // channel reported UNCHANGED — the most alarming divergence read as "no
+        // difference". A finite↔non-finite mismatch is a change, and the count
+        // of such ticks is reported.
+        let log = two_channel_log();
+        let trace = trace_with(
+            &[
+                ("Root.CF.Sensor", &[10.0, f64::NAN]),
+                ("Root.CF.Mid", &[25.0, f64::INFINITY]),
+            ],
+            &[0.0, 1.0],
+        );
+        let diff = Diff::between(&log, &trace);
+        let sensor = &diff.channels["Root.CF.Sensor"];
+        assert!(sensor.changed, "finite→NaN must flag changed");
+        assert_eq!(sensor.non_finite_mismatches, 1);
+        let mid = &diff.channels["Root.CF.Mid"];
+        assert!(mid.changed, "finite→Inf must flag changed");
+        assert_eq!(mid.non_finite_mismatches, 1);
+        assert_eq!(
+            diff.changed_channels(),
+            vec!["Root.CF.Mid", "Root.CF.Sensor"]
+        );
+    }
+
+    #[test]
+    fn ambiguous_leaf_fallback_is_rejected_and_reported() {
+        // Two distinct trace channels (Root.A.Value, Root.B.Value) both
+        // leaf-fall-back to the single logged series `Value`. Binding either one
+        // silently would diff at least one of them against the wrong ground
+        // truth: both are excluded from the numeric diff and reported as
+        // ambiguous instead.
+        let log = Log {
+            channels: vec![InputSeries {
+                channel: "Value".to_string(),
+                kind: InputKind::Series(vec![(0.0, Value::Float(1.0))]),
+            }],
+            meta: crate::log::LogMeta::default(),
+        };
+        let trace = trace_with(
+            &[("Root.A.Value", &[3.0]), ("Root.B.Value", &[4.0])],
+            &[0.0],
+        );
+        let diff = Diff::between(&log, &trace);
+        assert!(
+            !diff.channels.contains_key("Root.A.Value")
+                && !diff.channels.contains_key("Root.B.Value"),
+            "ambiguously-matched channels must not be silently diffed"
+        );
+        assert_eq!(
+            diff.ambiguous,
+            vec!["Root.A.Value".to_string(), "Root.B.Value".to_string()],
+            "the ambiguity is reported, not swallowed"
+        );
+    }
+
+    #[test]
+    fn exact_match_wins_over_a_conflicting_fallback() {
+        // The log carries `Value` exactly; the trace has BOTH a channel exactly
+        // named `Value` and another whose leaf falls back to it. The exact match
+        // keeps its binding; only the fallback claimant is ambiguous-excluded.
+        let log = Log {
+            channels: vec![InputSeries {
+                channel: "Value".to_string(),
+                kind: InputKind::Series(vec![(0.0, Value::Float(1.0))]),
+            }],
+            meta: crate::log::LogMeta::default(),
+        };
+        let trace = trace_with(&[("Value", &[3.0]), ("Root.B.Value", &[4.0])], &[0.0]);
+        let diff = Diff::between(&log, &trace);
+        assert!(
+            diff.channels.contains_key("Value"),
+            "the exact match keeps its binding"
+        );
+        assert_eq!(diff.ambiguous, vec!["Root.B.Value".to_string()]);
+    }
+
+    #[test]
+    fn mapping_table_is_reported() {
+        // Every bound trace-channel → log-channel pair is visible in the diff
+        // metadata, so a reviewer can audit exactly which series was compared.
+        let log = Log {
+            channels: vec![InputSeries {
+                channel: "Sensor".to_string(),
+                kind: InputKind::Series(vec![(0.0, Value::Float(1.0))]),
+            }],
+            meta: crate::log::LogMeta::default(),
+        };
+        let trace = trace_with(&[("Root.CF.Sensor", &[3.0])], &[0.0]);
+        let diff = Diff::between(&log, &trace);
+        assert_eq!(
+            diff.mapping.get("Root.CF.Sensor").map(String::as_str),
+            Some("Sensor")
+        );
     }
 
     #[test]

--- a/src/log.rs
+++ b/src/log.rs
@@ -158,6 +158,50 @@ mod tests {
     use super::*;
     use crate::value::Value;
 
+    #[test]
+    fn duplicate_csv_headers_are_rejected() {
+        // Two columns named `Speed`: whichever the sampler later picked would be
+        // arbitrary. Fails loud naming the duplicate.
+        let csv = "time,Speed,Speed\n0.0,1.0,2.0\n";
+        let err = Log::from_csv(csv, "t").expect_err("duplicate headers must fail");
+        assert!(format!("{err}").contains("Speed"), "{err}");
+    }
+
+    #[test]
+    fn ragged_csv_row_width_is_rejected() {
+        // Row 2 carries more cells than the header declares — a shifted or
+        // corrupt export. (Fewer cells stays legal: trailing empty cells are the
+        // documented no-keyframe hold.)
+        let csv = "time,Speed\n0.0,1.0,99.0\n";
+        let err = Log::from_csv(csv, "t").expect_err("over-wide row must fail");
+        assert!(format!("{err}").to_lowercase().contains("row"), "{err}");
+    }
+
+    #[test]
+    fn non_finite_csv_time_is_rejected() {
+        let csv = "time,Speed\nNaN,1.0\n";
+        let err = Log::from_csv(csv, "t").expect_err("NaN time must fail");
+        assert!(format!("{err}").to_lowercase().contains("time"), "{err}");
+        let csv = "time,Speed\ninf,1.0\n";
+        Log::from_csv(csv, "t").expect_err("infinite time must fail");
+    }
+
+    #[test]
+    fn non_monotonic_csv_time_is_rejected() {
+        // The zero-order-hold sampler assumes ascending keyframes; accepting
+        // out-of-order times silently mis-samples every later lookup. Equal
+        // (duplicate) timestamps are rejected for the same reason.
+        let csv = "time,Speed\n0.0,1.0\n0.2,2.0\n0.1,3.0\n";
+        let err = Log::from_csv(csv, "t").expect_err("descending time must fail");
+        let msg = format!("{err}").to_lowercase();
+        assert!(
+            msg.contains("increas") || msg.contains("monotonic"),
+            "{err}"
+        );
+        let csv = "time,Speed\n0.0,1.0\n0.0,2.0\n";
+        Log::from_csv(csv, "t").expect_err("duplicate timestamp must fail");
+    }
+
     /// Build a hand-authored two-channel log: a `Sensor` ramp and an
     /// `Engine Speed` series (note the space in the channel name).
     fn hand_built_log() -> Log {

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -239,11 +239,25 @@ pub(crate) fn parse_time_series_csv(
             at: 0,
         });
     }
+    // Duplicate headers: whichever column the sampler later picked would be
+    // arbitrary — fail loud naming the duplicate.
+    {
+        let mut seen = std::collections::BTreeSet::new();
+        for c in &cols[1..] {
+            if !seen.insert(c.as_str()) {
+                return Err(EvalError::UnsupportedConstruct {
+                    kind: format!("CSV declares the column {c:?} more than once"),
+                    at: 0,
+                });
+            }
+        }
+    }
     // One accumulator per non-time column, in header order.
     let mut columns: Vec<(String, Vec<(f64, Value)>)> =
         cols[1..].iter().map(|c| (c.clone(), Vec::new())).collect();
     let mut units: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
     let mut seen_data_row = false;
+    let mut prev_time: Option<f64> = None;
 
     for (row_idx, line) in lines.enumerate() {
         if line.trim().is_empty() {
@@ -271,12 +285,47 @@ pub(crate) fn parse_time_series_csv(
         }
         seen_data_row = true;
 
+        // A row wider than the header is a shifted or corrupt export. (Fewer
+        // cells stays legal: trailing empty cells are the documented
+        // no-keyframe hold.)
+        if cells.len() > cols.len() {
+            return Err(EvalError::UnsupportedConstruct {
+                kind: format!(
+                    "CSV row {} has {} cells but the header declares {} columns",
+                    row_idx + 2,
+                    cells.len(),
+                    cols.len()
+                ),
+                at: 0,
+            });
+        }
         let t = first
             .parse::<f64>()
             .map_err(|_| EvalError::UnsupportedConstruct {
                 kind: format!("CSV row {} has a non-numeric time", row_idx + 2),
                 at: 0,
             })?;
+        // The zero-order-hold sampler assumes strictly ascending finite
+        // keyframes; a NaN/infinite or out-of-order/duplicate timestamp would
+        // silently mis-sample every later lookup.
+        if !t.is_finite() {
+            return Err(EvalError::UnsupportedConstruct {
+                kind: format!("CSV row {} has a non-finite time {t}", row_idx + 2),
+                at: 0,
+            });
+        }
+        if let Some(prev) = prev_time
+            && t <= prev
+        {
+            return Err(EvalError::UnsupportedConstruct {
+                kind: format!(
+                    "CSV row {} time {t} is not strictly increasing (previous {prev})",
+                    row_idx + 2
+                ),
+                at: 0,
+            });
+        }
+        prev_time = Some(t);
         for (i, acc) in columns.iter_mut().enumerate() {
             let Some(cell) = cells.get(i + 1) else {
                 continue;


### PR DESCRIPTION
Fixes #8 (P1.2 / B7 / B8 of the 2026-07-19 ecosystem review).

**Diff**

- Finite↔NaN/±Inf divergence per tick is now counted (`non_finite_mismatches`) and flags the channel `changed` — previously the non-finite deltas were filtered out before the max fold, so a finite→NaN divergence reported as *unchanged*.
- Ambiguous fallback matches are rejected and reported: two trace channels claiming the same log series via the `Root.`-stripped/bare-leaf fallback are excluded from the numeric diff into `Diff.ambiguous` (an exact match always keeps its binding; a lone fallback conflicting with an exact match is excluded too).
- `Diff.mapping` records the audited trace-channel → log-series binding. JSON output carries all three additions.

**Shared CSV parser (scenario inputs + log import)**

- Duplicate headers rejected; rows wider than the header rejected (fewer cells remains the documented no-keyframe hold); non-finite timestamps rejected; time must be strictly increasing (the ZOH sampler assumes ascending keyframes — the parser previously accepted non-monotonic time knowingly).

Tests: finite→NaN and finite→Inf flag changed with counts; ambiguous two-claimant case excluded+reported; exact-beats-fallback; mapping table; four CSV validation cases (each verified failing against the pre-change parser).