### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "m1-eval"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1-eval"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Evaluator/interpreter for the MoTeC M1 scripting language"


### PR DESCRIPTION
Cuts v0.3.0, carrying the 2026-07-19 review fixes:

- #9 exact integer rate divisors (auto base = lcm of scheduled rates; inexact pinned bases rejected)
- #10 counterfactual replay preserves declared function rates
- #11 On Startup runs once; unseeded defaulting is an explicit reported opt-in; division by zero always fails loud
- #12 diff flags non-finite divergence and rejects ambiguous log matches; CSV time/header/width validation

Minor bump: scheduling results change (correctly) for non-dividing rate sets, whole-project strictness is a behaviour change, and `Scenario`/`Trace`/`Diff` gained fields.