### PR TITLE
Release v0.3.2 — m1-typecheck v0.47.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "m1-eval"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -309,8 +309,8 @@ dependencies = [
 
 [[package]]
 name = "m1-typecheck"
-version = "0.46.0"
-source = "git+https://github.com/C-Nucifora/m1-typecheck.git?tag=v0.46.0#469ce2a78fcb42f435cb7a0fad5c6617c1b44694"
+version = "0.47.0"
+source = "git+https://github.com/C-Nucifora/m1-typecheck.git?tag=v0.47.0#91f4407536853e86a005fbb2cb102032686a6411"
 dependencies = [
  "clap",
  "m1-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1-eval"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Evaluator/interpreter for the MoTeC M1 scripting language"
@@ -27,7 +27,7 @@ serde_json = "1"
 toml = "0.8"
 roxmltree = "0.20"
 m1-core = { git = "https://github.com/C-Nucifora/m1-core.git", tag = "v0.15.0" }
-m1-typecheck = { git = "https://github.com/C-Nucifora/m1-typecheck.git", tag = "v0.46.0" }
+m1-typecheck = { git = "https://github.com/C-Nucifora/m1-typecheck.git", tag = "v0.47.0" }
 # MIT, GPL-3.0-compatible, pure-std clean-room `.ld`/`.ldx` file-format
 # reader+writer. Optional: only compiled in under the `ld` feature. We use its
 # reader to import `.ld` telemetry and its writer to generate the tiny synthetic


### PR DESCRIPTION
Bumps the in-process m1-typecheck dependency to v0.47.0 so evaluator consumers share the released T065 intrinsic overload model. Also bumps m1-eval to v0.3.2 for release.\n\nValidation: cargo test; cargo clippy --all-targets -- -D warnings; cargo fmt --all -- --check.