### PR TITLE
Add dependabot config (cargo + actions, daily)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      m1-toolchain:
+        patterns:
+          - "tree-sitter-m1"
+          - "m1-*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Every other toolchain repo runs dependabot daily as the backstop behind manual cross-repo bumps; this repo had no config at all. Adds the standard cargo + github-actions daily config with the m1-toolchain group.