### PR TITLE
Bump m1-typecheck to v0.49.0; version 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "m1-eval"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -309,8 +309,8 @@ dependencies = [
 
 [[package]]
 name = "m1-typecheck"
-version = "0.48.0"
-source = "git+https://github.com/C-Nucifora/m1-typecheck.git?tag=v0.48.0#e031a248b337c3eb16889b630b661fe8434be886"
+version = "0.49.0"
+source = "git+https://github.com/C-Nucifora/m1-typecheck.git?tag=v0.49.0#5e9bec87dca19bf6ec9ddf4f1287b175e3b56367"
 dependencies = [
  "clap",
  "m1-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1-eval"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 rust-version = "1.88"
 description = "Evaluator/interpreter for the MoTeC M1 scripting language"
@@ -27,7 +27,7 @@ serde_json = "1"
 toml = "0.8"
 roxmltree = "0.20"
 m1-core = { git = "https://github.com/C-Nucifora/m1-core.git", tag = "v0.15.0" }
-m1-typecheck = { git = "https://github.com/C-Nucifora/m1-typecheck.git", tag = "v0.48.0" }
+m1-typecheck = { git = "https://github.com/C-Nucifora/m1-typecheck.git", tag = "v0.49.0" }
 # MIT, GPL-3.0-compatible, pure-std clean-room `.ld`/`.ldx` file-format
 # reader+writer. Optional: only compiled in under the `ld` feature. We use its
 # reader to import `.ld` telemetry and its writer to generate the tiny synthetic


### PR DESCRIPTION
Picks up the .m1dbc hex attribute fix (CANId/StartBit/Length are hexadecimal without a prefix, new `CanMeta::extended`). Full test suite, clippy, fmt green.