### PR TITLE
Scenario [[io]] overrides: drive Tier-3 IO calls from the scenario file

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,6 +71,20 @@ series = [[0.0, 0.0], [0.5, 4000.0]]
 [[overrides]]
 channel = "Root.Engine.Output"
 const = 0.0
+
+# IO overrides drive a hardware-backed builtin call directly: the value the
+# call returns, keyed by its "Object.Method" spelling (a call key, not a
+# channel path — never canonicalised). Resampled every tick like an input,
+# and consulted before any documented or generic typed stub — so a scenario
+# can feed a CAN read (`Receive`/`GetBit`) or a system read (FlashSize)
+# without seeding the decoded channels around the reading script.
+[[io]]
+call = "DBC PC.Dash Switches.Receive"
+const = true
+
+[[io]]
+call = "System.FlashSize"
+const = 8388608
 ```
 
 Identifiers may contain spaces (e.g. `Cooling Fan.Output`); channel names are

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -486,6 +486,9 @@ fn tick_loop(
         for (path, series) in &overrides {
             env.set(path.clone(), series.sample(0.0));
         }
+        for io in &scenario.io {
+            env.set_io_override(io.call.clone(), io.sample(0.0));
+        }
         for sched in &startup {
             let root = sched.script.cst.root();
             let mut ctx = EvalCtx {
@@ -523,6 +526,13 @@ fn tick_loop(
         for (path, series) in &overrides {
             let value = crate::expr::coerce_for_channel(path, series.sample(t), &loaded.project);
             env.set(path.clone(), value);
+        }
+        // IO-call overrides are resampled on the same grid. The key is a call
+        // spelling (`"Object.Method"`), not a symbol path — no canonicalisation,
+        // no channel-type coercion; the evaluator's IO dispatch reads it back
+        // verbatim (`Env::io_override`) before any documented or typed stub.
+        for io in &scenario.io {
+            env.set_io_override(io.call.clone(), io.sample(t));
         }
 
         // 2. Open the tick.
@@ -1383,6 +1393,7 @@ mod tests {
                 kind: InputKind::Const(Value::Int(2)),
             }],
             overrides: vec![],
+            io: vec![],
             allow_default_inputs: false,
         };
         let trace = run(&loaded, &scenario).expect("enum-seeded run evaluates");

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -4,8 +4,9 @@
 //! A scenario chooses the run mode (which runner, against which function or
 //! target channel), the time grid (`duration_s` + `base_rate_hz`), the input
 //! sources for the channels the engine does not itself compute (constants or
-//! piecewise time series), and any channel overrides that pin a value over the
-//! top of everything else.
+//! piecewise time series), any channel overrides that pin a value over the
+//! top of everything else, and any IO-call overrides (`[[io]]`) that drive a
+//! hardware-backed builtin read directly.
 //!
 //! ## Wire formats
 //!
@@ -30,6 +31,10 @@
 //! [[overrides]]
 //! channel = "Root.Demo.Output"
 //! const = 0.0
+//!
+//! [[io]]
+//! call = "CanComms.GetFloat"          # a Tier-3 IO call spelling, not a path
+//! series = [[0.0, 12.5], [0.5, 99.0]]
 //! ```
 //!
 //! ## Time-series resampling
@@ -84,15 +89,48 @@ pub enum InputKind {
     Series(Vec<(f64, Value)>),
 }
 
-impl InputSeries {
-    /// Sample this input at tick time `t` (seconds). A constant returns its value
-    /// at every `t`; a series returns the most recent keyframe value at or before
-    /// `t` (zero-order hold), or the first keyframe before the series begins.
+impl InputKind {
+    /// Sample this source at tick time `t` (seconds). A constant returns its
+    /// value at every `t`; a series returns the most recent keyframe value at or
+    /// before `t` (zero-order hold), or the first keyframe before the series
+    /// begins.
     pub fn sample(&self, t: f64) -> Value {
-        match &self.kind {
+        match self {
             InputKind::Const(v) => v.clone(),
             InputKind::Series(points) => sample_series(points, t),
         }
+    }
+}
+
+impl InputSeries {
+    /// Sample this input at tick time `t` (seconds) — see [`InputKind::sample`].
+    pub fn sample(&self, t: f64) -> Value {
+        self.kind.sample(t)
+    }
+}
+
+/// One scenario-driven Tier-3 IO call override: the call spelling plus the
+/// value the call returns over time. Sampled per tick exactly like an input;
+/// the evaluator's IO dispatch consults these overrides before any documented
+/// or generic typed stub ([`crate::env::Env::io_override`]), so the scenario —
+/// not the offline default — supplies what the hardware "reads".
+#[derive(Debug, Clone, PartialEq)]
+pub struct IoSeries {
+    /// The IO call this drives, spelled `"Object.Method"` (e.g.
+    /// `"CanComms.GetFloat"`, `"System.FlashSize"`, `"DBC PC.Dash
+    /// Switches.Receive"`) — the same key the coverage report and trace use for
+    /// Tier-3 calls. It is a call spelling, not a symbol path: never
+    /// canonicalised, spaces preserved verbatim.
+    pub call: String,
+    /// Whether it is a constant or a time series.
+    pub kind: InputKind,
+}
+
+impl IoSeries {
+    /// Sample this override at tick time `t` (seconds) — see
+    /// [`InputKind::sample`].
+    pub fn sample(&self, t: f64) -> Value {
+        self.kind.sample(t)
     }
 }
 
@@ -134,6 +172,10 @@ pub struct Scenario {
     /// Channels pinned to a constant or series, layered *over* the inputs and
     /// any computed value. Same shape as [`Scenario::inputs`].
     pub overrides: Vec<InputSeries>,
+    /// Scenario-driven Tier-3 IO call overrides (`[[io]]`): what a
+    /// hardware-backed builtin call returns, keyed by its `"Object.Method"`
+    /// spelling and resampled every tick. See [`IoSeries`].
+    pub io: Vec<IoSeries>,
     /// Whole-project mode only: substitute type-correct startup defaults for
     /// unseeded channel reads (each substitution is reported on the trace)
     /// instead of failing loud. **Off by default** — strict fail-loud is the
@@ -405,6 +447,8 @@ struct RawScenario {
     inputs: Vec<RawInput>,
     #[serde(default)]
     overrides: Vec<RawInput>,
+    #[serde(default)]
+    io: Vec<RawIo>,
     /// Opt-in unseeded-channel defaulting for whole-project mode (strict
     /// fail-loud when absent/false).
     #[serde(default)]
@@ -415,6 +459,18 @@ struct RawScenario {
 #[derive(Debug, Deserialize)]
 struct RawInput {
     channel: String,
+    #[serde(default)]
+    #[serde(rename = "const")]
+    constant: Option<RawValue>,
+    #[serde(default)]
+    series: Option<Vec<(f64, RawValue)>>,
+}
+
+/// A raw `[[io]]` entry: an IO call spelling plus exactly one of
+/// `const`/`series` — the same value shape as an input, keyed by `call`.
+#[derive(Debug, Deserialize)]
+struct RawIo {
+    call: String,
     #[serde(default)]
     #[serde(rename = "const")]
     constant: Option<RawValue>,
@@ -508,53 +564,75 @@ impl RawScenario {
             .into_iter()
             .map(RawInput::into_input)
             .collect::<Result<Vec<_>, _>>()?;
+        let io = self
+            .io
+            .into_iter()
+            .map(RawIo::into_io)
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(Scenario {
             mode,
             inputs,
             duration_s: self.duration_s,
             base_rate_hz: self.base_rate_hz,
             overrides,
+            io,
             allow_default_inputs: self.allow_default_inputs,
         })
     }
 }
 
+/// Validate a raw `const`/`series` pair into an [`InputKind`]: exactly one of
+/// the two must be set, and a series must be non-empty. `what`/`name` label the
+/// entry in the fail-loud message (`input "Root.Demo.Gain"`, `io
+/// "CanComms.GetFloat"`).
+fn raw_kind(
+    what: &str,
+    name: &str,
+    constant: Option<RawValue>,
+    series: Option<Vec<(f64, RawValue)>>,
+) -> Result<InputKind, EvalError> {
+    match (constant, series) {
+        (Some(c), None) => Ok(InputKind::Const(c.into_value())),
+        (None, Some(points)) => {
+            if points.is_empty() {
+                return Err(EvalError::UnsupportedConstruct {
+                    kind: format!("{what} {name:?} has an empty series"),
+                    at: 0,
+                });
+            }
+            Ok(InputKind::Series(
+                points
+                    .into_iter()
+                    .map(|(t, v)| (t, v.into_value()))
+                    .collect(),
+            ))
+        }
+        (Some(_), Some(_)) => Err(EvalError::UnsupportedConstruct {
+            kind: format!("{what} {name:?} sets both `const` and `series` (choose one)"),
+            at: 0,
+        }),
+        (None, None) => Err(EvalError::UnsupportedConstruct {
+            kind: format!("{what} {name:?} sets neither `const` nor `series`"),
+            at: 0,
+        }),
+    }
+}
+
 impl RawInput {
     fn into_input(self) -> Result<InputSeries, EvalError> {
-        let kind = match (self.constant, self.series) {
-            (Some(c), None) => InputKind::Const(c.into_value()),
-            (None, Some(points)) => {
-                if points.is_empty() {
-                    return Err(EvalError::UnsupportedConstruct {
-                        kind: format!("input {:?} has an empty series", self.channel),
-                        at: 0,
-                    });
-                }
-                InputKind::Series(
-                    points
-                        .into_iter()
-                        .map(|(t, v)| (t, v.into_value()))
-                        .collect(),
-                )
-            }
-            (Some(_), Some(_)) => {
-                return Err(EvalError::UnsupportedConstruct {
-                    kind: format!(
-                        "input {:?} sets both `const` and `series` (choose one)",
-                        self.channel
-                    ),
-                    at: 0,
-                });
-            }
-            (None, None) => {
-                return Err(EvalError::UnsupportedConstruct {
-                    kind: format!("input {:?} sets neither `const` nor `series`", self.channel),
-                    at: 0,
-                });
-            }
-        };
+        let kind = raw_kind("input", &self.channel, self.constant, self.series)?;
         Ok(InputSeries {
             channel: self.channel,
+            kind,
+        })
+    }
+}
+
+impl RawIo {
+    fn into_io(self) -> Result<IoSeries, EvalError> {
+        let kind = raw_kind("io", &self.call, self.constant, self.series)?;
+        Ok(IoSeries {
+            call: self.call,
             kind,
         })
     }
@@ -778,5 +856,77 @@ duration_s = 1.0
 base_rate_hz = 0.0
 "#;
         assert!(Scenario::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn parses_io_overrides() {
+        let toml = r#"
+mode = "whole-project"
+duration_s = 1.0
+
+[[io]]
+call = "DBC PC.Dash Switches.Receive"
+const = true
+
+[[io]]
+call = "System.FlashSize"
+series = [[0.0, 4194304], [0.5, 8388608]]
+"#;
+        let sc = Scenario::from_toml_str(toml).expect("valid scenario");
+        assert_eq!(sc.io.len(), 2);
+
+        // The constant override holds its value at every t.
+        let receive = sc
+            .io
+            .iter()
+            .find(|o| o.call == "DBC PC.Dash Switches.Receive")
+            .unwrap();
+        assert_eq!(receive.sample(0.0), Value::Bool(true));
+        assert_eq!(receive.sample(0.9), Value::Bool(true));
+
+        // The series override steps by zero-order hold, like an input.
+        let flash = sc.io.iter().find(|o| o.call == "System.FlashSize").unwrap();
+        assert_eq!(flash.sample(0.0), Value::Int(4_194_304));
+        assert_eq!(flash.sample(0.49), Value::Int(4_194_304));
+        assert_eq!(flash.sample(0.5), Value::Int(8_388_608));
+    }
+
+    #[test]
+    fn io_override_rejects_both_const_and_series() {
+        let toml = r#"
+mode = "whole-project"
+duration_s = 1.0
+
+[[io]]
+call = "CanComms.GetFloat"
+const = 1.0
+series = [[0.0, 2.0]]
+"#;
+        assert!(Scenario::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn io_override_rejects_neither_const_nor_series() {
+        let toml = r#"
+mode = "whole-project"
+duration_s = 1.0
+
+[[io]]
+call = "CanComms.GetFloat"
+"#;
+        assert!(Scenario::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn io_override_in_json_parses_the_same_shape() {
+        let json = r#"{
+            "mode": "whole-project",
+            "duration_s": 0.5,
+            "io": [{ "call": "CanComms.GetFloat", "const": 12.5 }]
+        }"#;
+        let sc = Scenario::from_json_str(json).expect("valid JSON scenario");
+        assert_eq!(sc.io.len(), 1);
+        assert_eq!(sc.io[0].call, "CanComms.GetFloat");
+        assert_eq!(sc.io[0].sample(0.0), Value::Float(12.5));
     }
 }

--- a/tests/can_stub.rs
+++ b/tests/can_stub.rs
@@ -105,3 +105,78 @@ base_rate_hz = 100.0
         Some(&vec![Value::Float(0.0); 3])
     );
 }
+
+#[test]
+fn scenario_io_overrides_drive_can_reads_per_tick() {
+    let engine = can_stub_engine();
+
+    // An `[[io]]` override replaces the documented stub for a Tier-3 IO call:
+    // the scenario, not the offline default, supplies what the bus "reads". A
+    // series is resampled every tick (zero-order hold), so the value the script
+    // sees can change mid-run — here at t = 0.03 s.
+    let scenario = Scenario::from_toml_str(
+        r#"
+mode = "whole-project"
+duration_s = 0.05
+base_rate_hz = 100.0
+
+[[io]]
+call = "CanComms.GetFloat"
+series = [[0.0, 12.5], [0.03, 99.0]]
+"#,
+    )
+    .expect("io-override scenario parses");
+
+    let trace = engine.run(&scenario).expect("io-driven run completes");
+
+    // 5 ticks at 100 Hz: 12.5 on t = 0.00/0.01/0.02, then 99.0 on t = 0.03/0.04.
+    let bus_value = trace
+        .channels
+        .get("Root.CanDemo.Bus Value")
+        .expect("Bus Value channel present in the trace");
+    assert_eq!(
+        bus_value,
+        &vec![
+            Value::Float(12.5),
+            Value::Float(12.5),
+            Value::Float(12.5),
+            Value::Float(99.0),
+            Value::Float(99.0),
+        ],
+        "Bus Value follows the [[io]] series, resampled each tick"
+    );
+
+    // A scenario-driven IO call is still simulated input, not evaluated output.
+    assert!(
+        trace.is_external("CanComms.GetFloat"),
+        "an overridden IO call stays flagged externally driven"
+    );
+}
+
+#[test]
+fn scenario_io_override_feeds_single_function_mode() {
+    let engine = can_stub_engine();
+
+    // The same seeding applies outside whole-project mode: a single-function
+    // run reads the overridden value instead of the documented stub.
+    let scenario = Scenario::from_toml_str(
+        r#"
+mode = "function"
+target = "Root.CanDemo.Read"
+duration_s = 0.02
+base_rate_hz = 100.0
+
+[[io]]
+call = "CanComms.GetFloat"
+const = 7.25
+"#,
+    )
+    .expect("io-override scenario parses");
+
+    let trace = engine.run(&scenario).expect("io-driven run completes");
+    assert_eq!(
+        trace.channels.get("Root.CanDemo.Bus Value"),
+        Some(&vec![Value::Float(7.25); 2]),
+        "Bus Value reads the [[io]] const in function mode"
+    );
+}


### PR DESCRIPTION
Implements the scenario-file IO overrides proposed in the AV-M1 whole-project brief (the "nice-to-have" that #27 left open): `Env::io_overrides` existed — and the evaluator's IO dispatch already consulted it override-first — but nothing in a scenario file could populate it.

This closes the last gap in the brief's acceptance test. After #27, the AV-M1 whole-project run aborted on `ECU.Update.m1scr`'s flash-usage computation: `(System.FlashSize() - System.FlashFree()) / System.FlashSize()` is an integer division by zero under the generic typed stub's `0`. No firmware documentation substantiates a divide-by-zero-yields-zero semantic (per the deliberate fail-loud stance in `apply_binary_values`), so the fail-loud-respecting way through is to let the scenario say what the hardware read returns — which is exactly what the brief proposed.

## Changes

- **`[[io]]` scenario section** — each entry names a Tier-3 IO call by its `"Object.Method"` spelling (`call = "System.FlashSize"`, `"DBC PC.Dash Switches.Receive"` — the same key the coverage report and trace use) with the same `const`/`series` value shape as an input, validated exactly-one-of. The key is a call spelling, not a symbol path: never canonicalised.
- **`IoSeries`** on the parsed `Scenario` (`io: Vec<IoSeries>`), with the zero-order-hold sampling extracted to a shared `InputKind::sample` so inputs and IO overrides sample identically.
- **Runner seeding** — `Env::set_io_override` before the startup pass and re-sampled on every tick in the shared tick loop, so a series can change what a `Receive()`/`GetBit()`/`FlashSize()` returns mid-run. Works in all three scenario modes (the loop is shared); an overridden call stays flagged externally driven on the trace.
- **Docs** — `docs/cli.md` scenario-file section and the `scenario` module example.

## Verification

- TDD: red observed before green for the parse layer (`[[io]]` previously ignored silently) and the runner layer (parse green, run still stubbed) separately.
- `cargo test`: full suite green (362 lib tests + all integration suites), `cargo fmt --check`, `cargo clippy --all-targets`, and rustdoc all clean.
- **AV-M1 acceptance**: with two `[[io]]` entries (`System.FlashSize` = 8 MiB, `System.FlashFree` = 2 MiB), `--whole-project --config parameters.m1cfg` now runs to completion — exit 0, 2000 ticks at the derived 1000 Hz base, a 126-channel `trace.csv` — with every defaulted channel reported on stderr. The brief's acceptance criterion is met.

## Note

Independent of the error-context PR (same files, different regions); either merges first and the other rebases trivially.
