### PR TITLE
Name the failing script and tick instant in fail-loud eval errors

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -100,6 +100,11 @@ These follow the shared toolchain contract (`m1-tools/docs/cli.md`):
 So `$? != 0` means "do not trust the output." The engine **fails loud**: it never
 emits a guessed or default number in place of something it cannot evaluate.
 
+A fail-loud evaluation error also says **where** it happened — the failing
+script and the tick instant (`in ECU.Update.m1scr at t = 0.125 s: type error:
+division or modulo by zero`, or `at startup` for the once-only initialisation
+pass) — so a multi-script whole-project abort points at the script to inspect.
+
 ## Counterfactual replay (`--log` / `--override` / `--diff`)
 
 `--log` imports a recorded run as **ground truth**: every logged channel is held

--- a/src/builtins/userfn.rs
+++ b/src/builtins/userfn.rs
@@ -165,6 +165,14 @@ pub fn call(
     //    operator state all persist across the call, keyed by the callee's own
     //    symbol/script — so isolation is automatic). The result is captured so the
     //    caller frame is always restored, even on an error.
+    // A trace tick is already open for normal and counterfactual execution.
+    // Capture its instant before borrowing the trace mutably for the callee.
+    // During the once-only startup pass no trace exists, so `None` retains the
+    // explicit `at startup` rendering.
+    let t = ctx
+        .trace
+        .as_deref()
+        .and_then(|trace| trace.time.last().copied());
     let exec_result = {
         let mut callee_ctx = EvalCtx {
             project: ctx.project,
@@ -179,7 +187,7 @@ pub fn call(
             depth: ctx.depth + 1,
             trace: ctx.trace.as_deref_mut(),
         };
-        exec_script(&callee_root, &mut callee_ctx)
+        exec_script(&callee_root, &mut callee_ctx).map_err(|e| e.in_script(&callee_script_name, t))
     };
 
     // 4. Read the return value (the `Out` slot), then 5. restore the caller frame.
@@ -188,7 +196,9 @@ pub fn call(
     ctx.env.locals = saved_locals;
     ctx.env.out = saved_out;
 
-    // Surface a callee error only after the caller frame is restored.
+    // Surface a callee error only after the caller frame is restored. It already
+    // carries the callee script context; outer inline-call and runner boundaries
+    // preserve that deepest context rather than replacing or nesting it.
     exec_result?;
 
     Ok(Some(return_value.unwrap_or_else(unit)))
@@ -340,8 +350,15 @@ mod tests {
         // `Recur.Loop` calls itself unconditionally (`Out = Recur.Loop(In.n)`).
         // Without a guard this overflows the stack; the depth guard turns it into
         // a fail-loud UnsupportedConstruct instead.
-        match h.call("Root.Recur.Loop", &[Value::Float(1.0)]) {
-            Err(EvalError::UnsupportedConstruct { kind, .. }) => {
+        let err = h
+            .call("Root.Recur.Loop", &[Value::Float(1.0)])
+            .expect_err("unbounded recursion fails loud");
+        assert!(
+            err.to_string().contains("Recur.Loop.m1scr"),
+            "callee context names the recursively failing script: {err}"
+        );
+        match err.root_cause() {
+            EvalError::UnsupportedConstruct { kind, .. } => {
                 assert!(
                     kind.contains("recursive"),
                     "expected a recursion error, got {kind:?}"

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,8 +19,8 @@ pub enum EvalError {
     BadCall { detail: String },
     /// An error wrapped with *where* it happened: the script whose execution
     /// failed and the tick instant (`None` for the once-only startup pass).
-    /// The runner attaches this at its execution boundary so a fail-loud abort
-    /// names the failing script and time instead of surfacing bare.
+    /// Execution boundaries attach this so a fail-loud abort names the deepest
+    /// failing script and time instead of surfacing bare.
     InScript {
         script: String,
         t: Option<f64>,
@@ -30,13 +30,17 @@ pub enum EvalError {
 
 impl EvalError {
     /// Wrap this error with the script it escaped from and the tick instant it
-    /// happened at (`None` = the startup pass). Runner-boundary context only —
-    /// inner evaluation never wraps, so there is exactly one layer.
+    /// happened at (`None` = the startup pass). If a deeper execution boundary
+    /// already attached context, preserve it so there is exactly one layer and
+    /// it names the script where the error actually arose.
     pub(crate) fn in_script(self, script: &str, t: Option<f64>) -> EvalError {
-        EvalError::InScript {
-            script: script.to_string(),
-            t,
-            source: Box::new(self),
+        match self {
+            already @ EvalError::InScript { .. } => already,
+            source => EvalError::InScript {
+                script: script.to_string(),
+                t,
+                source: Box::new(source),
+            },
         }
     }
 
@@ -108,6 +112,19 @@ mod tests {
         assert_eq!(wrapped.root_cause(), &inner);
         // An unwrapped error is its own root cause.
         assert_eq!(inner.root_cause(), &inner);
+    }
+
+    #[test]
+    fn outer_boundary_preserves_deeper_script_context() {
+        let inner = EvalError::TypeError {
+            detail: "bad operand".to_string(),
+        }
+        .in_script("Helper.Compute.m1scr", Some(0.25));
+        let outer = inner.clone().in_script("Caller.Update.m1scr", Some(0.25));
+        assert_eq!(
+            outer, inner,
+            "the deepest failing script remains authoritative"
+        );
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,38 @@ pub enum EvalError {
     MissingInput { channel: String },
     /// Wrong argument count/kind for a builtin call.
     BadCall { detail: String },
+    /// An error wrapped with *where* it happened: the script whose execution
+    /// failed and the tick instant (`None` for the once-only startup pass).
+    /// The runner attaches this at its execution boundary so a fail-loud abort
+    /// names the failing script and time instead of surfacing bare.
+    InScript {
+        script: String,
+        t: Option<f64>,
+        source: Box<EvalError>,
+    },
+}
+
+impl EvalError {
+    /// Wrap this error with the script it escaped from and the tick instant it
+    /// happened at (`None` = the startup pass). Runner-boundary context only —
+    /// inner evaluation never wraps, so there is exactly one layer.
+    pub(crate) fn in_script(self, script: &str, t: Option<f64>) -> EvalError {
+        EvalError::InScript {
+            script: script.to_string(),
+            t,
+            source: Box::new(self),
+        }
+    }
+
+    /// The innermost error, looking through any [`EvalError::InScript`] context
+    /// layer — match on this when deciding *what* went wrong rather than
+    /// *where* it happened.
+    pub fn root_cause(&self) -> &EvalError {
+        match self {
+            EvalError::InScript { source, .. } => source.root_cause(),
+            other => other,
+        }
+    }
 }
 
 impl std::fmt::Display for EvalError {
@@ -35,7 +67,58 @@ impl std::fmt::Display for EvalError {
             EvalError::TypeError { detail } => write!(f, "type error: {detail}"),
             EvalError::MissingInput { channel } => write!(f, "missing scenario input: {channel}"),
             EvalError::BadCall { detail } => write!(f, "bad call: {detail}"),
+            EvalError::InScript { script, t, source } => match t {
+                Some(t) => write!(f, "in {script} at t = {t:.3} s: {source}"),
+                None => write!(f, "in {script} at startup: {source}"),
+            },
         }
     }
 }
-impl std::error::Error for EvalError {}
+impl std::error::Error for EvalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            EvalError::InScript { source, .. } => Some(source.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_script_displays_tick_time_and_inner_error() {
+        let err = EvalError::TypeError {
+            detail: "division or modulo by zero".to_string(),
+        }
+        .in_script("ECU.Update.m1scr", Some(0.125));
+        assert_eq!(
+            err.to_string(),
+            "in ECU.Update.m1scr at t = 0.125 s: type error: division or modulo by zero"
+        );
+    }
+
+    #[test]
+    fn root_cause_looks_through_the_context_layer() {
+        let inner = EvalError::MissingInput {
+            channel: "Root.Demo.Speed".to_string(),
+        };
+        let wrapped = inner.clone().in_script("Demo.Update.m1scr", Some(0.0));
+        assert_eq!(wrapped.root_cause(), &inner);
+        // An unwrapped error is its own root cause.
+        assert_eq!(inner.root_cause(), &inner);
+    }
+
+    #[test]
+    fn in_script_displays_startup_phase_when_no_tick_is_open() {
+        let err = EvalError::MissingInput {
+            channel: "Root.Demo.Speed".to_string(),
+        }
+        .in_script("MR.Init.m1scr", None);
+        assert_eq!(
+            err.to_string(),
+            "in MR.Init.m1scr at startup: missing scenario input: Root.Demo.Speed"
+        );
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1420,6 +1420,7 @@ mod tests {
                 ]),
             }],
             overrides: vec![],
+            io: vec![],
             allow_default_inputs: false,
         };
         let err = run(&loaded, &scenario).expect_err("string arithmetic fails loud");
@@ -1449,6 +1450,7 @@ mod tests {
             base_rate_hz: 100.0,
             inputs: vec![],
             overrides: vec![],
+            io: vec![],
             allow_default_inputs: false,
         };
         let err = run(&loaded, &scenario).expect_err("unseeded input fails loud");
@@ -1461,6 +1463,40 @@ mod tests {
             msg.contains("missing scenario input"),
             "inner error preserved: {msg}"
         );
+    }
+
+    #[test]
+    fn eval_error_names_nested_failing_script() {
+        // Caller.Update invokes Helper.Compute inline. Passing a string reaches
+        // the helper and fails in its arithmetic, so the context must name the
+        // helper script where the error actually arose, not the outer caller.
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/userfn");
+        let loaded = load(&dir.join("Project.m1prj"), None).expect("userfn fixture loads");
+        let scenario = Scenario::from_toml_str(
+            r#"
+mode = "function"
+target = "Caller.Update"
+duration_s = 0.01
+base_rate_hz = 100.0
+
+[[inputs]]
+channel = "Root.Caller.Input"
+const = "oops"
+"#,
+        )
+        .expect("scenario parses");
+
+        let err = run(&loaded, &scenario).expect_err("helper arithmetic fails loud");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Helper.Compute.m1scr") && msg.contains("t = 0.000 s"),
+            "error names the nested script and current tick: {msg}"
+        );
+        assert!(
+            !msg.contains("Caller.Update.m1scr"),
+            "outer runner context must not replace or wrap the callee: {msg}"
+        );
+        assert!(msg.contains("type error"), "inner error preserved: {msg}");
     }
 
     fn mini() -> Loaded {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -504,7 +504,7 @@ fn tick_loop(
                 // axis. Startup writes surface via the tick-0 zero-order hold.
                 trace: None,
             };
-            exec_script(&root, &mut ctx)?;
+            exec_script(&root, &mut ctx).map_err(|e| e.in_script(&sched.script.name, None))?;
         }
     }
 
@@ -550,7 +550,7 @@ fn tick_loop(
                 depth: 0,
                 trace: Some(&mut trace),
             };
-            exec_script(&root, &mut ctx)?;
+            exec_script(&root, &mut ctx).map_err(|e| e.in_script(&sched.script.name, Some(t)))?;
         }
 
         // 4. Record any channel a scheduled function *holds* this tick (it did not
@@ -1168,7 +1168,7 @@ pub fn run_counterfactual(
                 depth: 0,
                 trace: Some(&mut trace),
             };
-            exec_script(&root, &mut ctx)?;
+            exec_script(&root, &mut ctx).map_err(|e| e.in_script(&sched.script.name, Some(t)))?;
         }
 
         // 5. Record every channel that did not record this tick by holding its env
@@ -1390,6 +1390,68 @@ mod tests {
         assert_eq!(flag.last().and_then(|v| v.as_f64().ok()), Some(1.0));
     }
 
+    #[test]
+    fn eval_error_names_failing_script_and_tick_time() {
+        // A fail-loud abort must say WHERE it happened: the script and the tick
+        // instant. Drive Speed with a series that turns non-numeric at t = 0.5 s
+        // — the first three ticks evaluate, then `Speed * Gain` is arithmetic
+        // on a string, and the error names Demo.Update at that tick (not tick 0).
+        let loaded = mini();
+        let scenario = Scenario {
+            mode: RunMode::Function("Demo.Update".to_string()),
+            duration_s: 1.0,
+            base_rate_hz: 10.0,
+            inputs: vec![InputSeries {
+                channel: "Root.Demo.Speed".to_string(),
+                kind: InputKind::Series(vec![
+                    (0.0, Value::Float(1.0)),
+                    (0.5, Value::Str("oops".to_string())),
+                ]),
+            }],
+            overrides: vec![],
+            allow_default_inputs: false,
+        };
+        let err = run(&loaded, &scenario).expect_err("string arithmetic fails loud");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Demo.Update.m1scr"),
+            "error names the failing script: {msg}"
+        );
+        assert!(
+            msg.contains("t = 0.500 s"),
+            "error names the failing tick instant: {msg}"
+        );
+        assert!(msg.contains("type error"), "inner error preserved: {msg}");
+        // The inner error stays reachable for callers that match on it.
+        let source = std::error::Error::source(&err).expect("wrapped error has a source");
+        assert!(source.to_string().contains("type error"));
+    }
+
+    #[test]
+    fn missing_input_error_names_script_at_first_tick() {
+        // An unseeded strict-mode read fails loud on the first tick — and the
+        // error still says which script was reading.
+        let loaded = mini();
+        let scenario = Scenario {
+            mode: RunMode::Function("Demo.Update".to_string()),
+            duration_s: 0.02,
+            base_rate_hz: 100.0,
+            inputs: vec![],
+            overrides: vec![],
+            allow_default_inputs: false,
+        };
+        let err = run(&loaded, &scenario).expect_err("unseeded input fails loud");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Demo.Update.m1scr") && msg.contains("t = 0.000 s"),
+            "error names script and first tick: {msg}"
+        );
+        assert!(
+            msg.contains("missing scenario input"),
+            "inner error preserved: {msg}"
+        );
+    }
+
     fn mini() -> Loaded {
         let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mini");
         load(
@@ -1487,7 +1549,7 @@ const = 3.0
         let scenario = Scenario::from_toml_str(toml).unwrap();
         let err = run(&loaded, &scenario).expect_err("unseeded channel must fail loud");
         assert!(
-            matches!(err, EvalError::MissingInput { .. }),
+            matches!(err.root_cause(), EvalError::MissingInput { .. }),
             "expected MissingInput, got {err:?}"
         );
     }


### PR DESCRIPTION
A fail-loud abort used to surface bare. The whole-project AV-M1 run died with:

```
m1-eval: type error: division or modulo by zero
```

— no script, no tick, and 19 scheduled scripts to suspect (finding the real culprit meant grepping the vehicle scripts for `/` and `%` by hand). Now:

```
m1-eval: in ECU.Update.m1scr at t = 0.000 s: type error: division or modulo by zero
```

## Changes

- **`EvalError::InScript { script, t, source }`** — the runner wraps any error escaping a script execution at its three boundaries (scheduled tick, once-only startup pass, counterfactual replay) with the script name and tick instant; `t: None` renders as `at startup`. The wrap is runner-boundary-only, so there is exactly one context layer.
- **`Error::source()`** now returns the wrapped inner error, and **`EvalError::root_cause()`** looks through the context layer — match on it when deciding *what* went wrong rather than *where*. (Callers matching `run()` errors directly against a bare variant need `root_cause()` now — the one in-repo test doing so is updated.)
- **Docs** — `docs/cli.md` exit-code section notes that evaluation errors name the failing script and instant.

## Verification

- TDD: red observed first — a `mini`-fixture run driving `Speed` into a string at t = 0.5 s asserts the error names `Demo.Update.m1scr` and `t = 0.500 s` (proving the wrap carries the *current* tick, not tick 0); a strict-mode unseeded read asserts script + `t = 0.000 s`; Display for both `t` variants and `root_cause()` unit-tested.
- `cargo test`: full suite green, `cargo fmt --check`, `cargo clippy --all-targets`, rustdoc all clean.
- Real-world demo: the AV-M1 whole-project abort above (this branch, without the `[[io]]` overrides) prints the `in ECU.Update.m1scr at t = 0.000 s` form.

## Note

Independent of the `[[io]]` scenario-overrides PR (same files, different regions); either merges first and the other rebases trivially.
