### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "m1-eval"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1-eval"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Evaluator/interpreter for the MoTeC M1 scripting language"


### PR DESCRIPTION
Release the scenario IO overrides, complete AV-M1 builtin coverage, and fail-loud script/tick context already merged on main. This also publishes the merged m1-typecheck v0.49.1 pin needed to clear the scheduled m1-tools skew guard.

This repository has no automated release workflow, so this PR prepares the versioned source but does not create a tag or GitHub release.

Verification:
- `cargo test` (394 passed, 2 corpus tests ignored as documented)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `git diff --check`