### PR TITLE
Release v0.4.1 with m1-typecheck v0.50.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "m1-eval"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -309,8 +309,8 @@ dependencies = [
 
 [[package]]
 name = "m1-typecheck"
-version = "0.49.1"
-source = "git+https://github.com/C-Nucifora/m1-typecheck.git?tag=v0.49.1#bdab5fd90a10649b1b87a51fc62babf35394f05b"
+version = "0.50.0"
+source = "git+https://github.com/C-Nucifora/m1-typecheck.git?tag=v0.50.0#d08d0fc77aa939d25aae243d68d4752500265f13"
 dependencies = [
  "clap",
  "m1-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1-eval"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Evaluator/interpreter for the MoTeC M1 scripting language"
@@ -27,7 +27,7 @@ serde_json = "1"
 toml = "1.1"
 roxmltree = "0.21"
 m1-core = { git = "https://github.com/C-Nucifora/m1-core.git", tag = "v0.15.0" }
-m1-typecheck = { git = "https://github.com/C-Nucifora/m1-typecheck.git", tag = "v0.49.1" }
+m1-typecheck = { git = "https://github.com/C-Nucifora/m1-typecheck.git", tag = "v0.50.0" }
 # MIT, GPL-3.0-compatible, pure-std clean-room `.ld`/`.ldx` file-format
 # reader+writer. Optional: only compiled in under the `ld` feature. We use its
 # reader to import `.ld` telemetry and its writer to generate the tiny synthetic


### PR DESCRIPTION
Bumps the pinned m1-typecheck dependency to v0.50.0, refreshes the lockfile, and bumps m1-eval to v0.4.1 for the downstream release cascade.\n\nVerified with the full Rust test, clippy, format, and rustdoc gates.