### PR TITLE
docs: clarify evaluator maturity contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,46 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 # m1-eval
 
-A stepped, deterministic **evaluator/interpreter for the MoTeC M1 scripting
+A stepped, deterministic offline **evaluator/interpreter for the MoTeC M1 scripting
 language** (`.m1scr`). The rest of the toolchain can parse (`m1-core`) and
 type-check (`m1-typecheck`) M1; `m1-eval` adds the missing layer — it actually
 *runs* the scripts. Given a *scenario* (input channel/parameter values over
 time) it evaluates a project's expressions, table lookups, and stateful
-time-domain operators to produce **real numeric channel values over time**.
+time-domain operators to produce numeric channel values over time.
 
 It is built primarily as a **Rust library** (consumed by `m1-visualiser`, and
 later `m1-lsp`), with a thin CLI on top. The same engine drives a per-channel and
 per-expression value `Trace` that the visualiser overlays on a dependency graph.
+
+## Maturity contract
+
+These states describe evidence for compatibility with M1, not how much Rust test
+coverage a module has.
+
+| State | Meaning |
+| --- | --- |
+| **Verified** | A committed test compares the result with captured output from M1, M1 Sim, or an ECU. |
+| **Assumed** | The behavior is implemented and tested with synthetic fixtures or hand-derived values, but has not been compared with captured M1 output. |
+| **Stubbed** | Hardware behavior is not evaluated. An explicit scenario input may supply the value; otherwise the engine returns a documented offline value or a generic type-correct default and marks it externally driven. |
+| **Unsupported** | The engine does not implement the behavior. It reports the item through `--coverage` when possible and fails the run if execution reaches it. |
+
+No advertised evaluator area currently meets the **Verified** definition. The
+real-project and real-`.ld` tests are completion and structural smoke tests; they
+do not compare computed channel values with captured M1 results.
+
+| Advertised area | State | Current contract |
+| --- | --- | --- |
+| Expressions, statements, enums, and inline user functions | **Assumed** | Covered by unit and synthetic-project tests. M1 evaluation results have not been captured for comparison. |
+| `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | Parsing, interpolation, and edge clamping use synthetic fixtures. Use the matching calibration file for actual parameter and table values. |
+| `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, and table methods | **Assumed** | Implemented methods have hand-derived tests. `--coverage` remains authoritative for the methods a project uses. |
+| Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. |
+| `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Stubbed** | Scenario `[[io]]` values take precedence. Otherwise calls use documented or generic typed stubs; writes are offline no-ops. |
+| Scenario parsing, tick grids, trace output, and `--coverage` | **Assumed** | These are deterministic m1-eval contracts tested with synthetic data. A `Supported` coverage entry means implemented, not M1-verified. |
+| Single-function and upstream dependency-cone runners | **Assumed** | Selection, ordering, and zero-order hold are tested on synthetic projects. |
+| Whole-project multi-rate scheduling | **Assumed** | Trigger rates come from `Project.m1prj`; same-rate dependency order, fastest-first rate groups, startup order, and cross-rate stale reads are the evaluator's model. |
+| CSV log replay, overrides, downstream-cone recomputation, and diffs | **Assumed** | Synthetic tests cover import, resampling, source precedence, recomputation, and the no-op invariant. They do not establish M1 execution fidelity. |
+| Binary `.ld` import | **Assumed** | Synthetic decode tests run in CI. An optional real-log test checks structure and numeric plausibility only, not values against an independent oracle. |
+| Real-time/HIL execution, ECU budgets or preemption, watchdog behavior, live CAN/serial I/O, `.m1dbc` decoding, unlisted constructs or builtins, and LSP integration | **Unsupported** | These are outside the current evaluator. Unknown executable behavior fails loud rather than being inferred. |
 
 ## What it does (Phase 1)
 
@@ -70,7 +100,7 @@ The multi-rate model:
 - **Rate-correct `dt`.** A function's stateful operators (`Integral.Normal`,
   filters, derivatives, timers) are stepped by *its own* period
   (`1 / rate_hz`) — a 50 Hz integrator accumulates with `dt = 0.02`, not the
-  base `dt` — so time-domain results are faithful to the real schedule.
+  base `dt`, so time-domain operators use the configured function period.
 - **Zero-order hold between ticks.** A channel a function did not write this
   tick keeps its last value (the shared value store carries it forward), so a
   slow channel holds steady between its updates while fast channels move every
@@ -78,9 +108,9 @@ The multi-rate model:
 - **Same-rate dependency ordering, cross-rate stale-tolerance.** Within one
   rate group, a writer runs before any reader of its output (topological order).
   Across rates, no ordering edge is added: a faster reader of a slower writer
-  sees the slower function's *previous* value (stale between writer ticks),
-  matching how the real ECU schedule interleaves rate groups. Rate groups are
-  run fastest-first within a base tick.
+  sees the slower function's *previous* value (stale between writer ticks).
+  This ordering is an explicit evaluator assumption. Rate groups run
+  fastest-first within a base tick.
 - **Externally-driven IO still stubbed, still fail-loud.** CAN/sensor reads
   fall back to their documented stubs (flagged externally driven in the trace);
   any genuinely unsupported construct still aborts the run rather than guessing.
@@ -89,26 +119,24 @@ The multi-rate model:
 
 - **Deterministic.** A fixed tick grid and explicit `dt`, no wall-clock and no
   RNG: the same scenario always produces the same `Trace`.
-- **Fail-loud.** By default the evaluator never substitutes a guessed number. An
-  unimplemented builtin, an unsupported construct, an unresolved symbol, or a
-  missing scenario input all surface as an error and abort the run — never a
-  silently-wrong value. Whole-project mode may opt in to
+- **Strict channel inputs.** An unimplemented builtin, an unsupported construct,
+  an unresolved symbol, or an unseeded ordinary channel aborts the run by
+  default. Hardware-backed calls follow the **Stubbed** contract above, and an
+  unseeded parameter uses its type-correct calibration default. Whole-project
+  mode may also opt in to
   **`allow_default_inputs`** (scenario field or `--allow-default-inputs`):
   unseeded channel reads then fall back to their type-correct startup defaults,
-  and **every substitution is reported** (channel, substituted value, first
-  reading script) — visible guessing, never silent. Arithmetic errors are not
-  inputs: integer division/modulo by zero always fails loud, opt-in or not.
-  (An unseeded *parameter* still reads as its type-correct tunable default —
-  parameters are calibration values with real defaults in M1 Tune, not runtime
-  inputs.)
+  and every ordinary-channel substitution is reported (channel, substituted
+  value, first reading script). Missing table calibration follows a separate
+  fallback described in Quickstart. Arithmetic errors are not inputs: integer
+  division/modulo by zero always fails loud, opt-in or not.
 
 ### `--coverage`
 
 Before running, `m1-eval --coverage` reports, per project, which builtins and
-constructs each script uses and whether the engine **supports** them faithfully,
-**stubs** them (Tier-3 IO, externally driven), or does **not support** them
-(would fail loud at runtime). This tells you up front what is trustworthy versus
-externally driven.
+constructs each script uses and whether the engine **implements**, **stubs**, or
+does **not support** them. `Supported` is an implementation label, not a
+**Verified** maturity claim.
 
 The report also prints a **`Schedule:`** section: every script-backed function
 with its execution rate (`@ 500 Hz`, `@ 50 Hz`, …), or *unscheduled* for a
@@ -116,7 +144,34 @@ function with no periodic trigger. This makes a `whole-project` run transparent 
 you see exactly which functions the scheduler will run, at what rate, and which
 are excluded — before you run it.
 
-## Usage
+## Quickstart
+
+`m1-eval` runs offline. It does not connect to an ECU, sample sensors, emulate a
+CAN or serial bus, or reproduce firmware timing. A `Project.m1prj` is always
+required because it supplies symbols, types, and trigger rates. Pass the matching
+`.m1cfg` when a run needs real parameter values or table cells. Table lookup
+without its calibration fails in strict mode; an unseeded parameter instead uses
+a type-correct externally-driven default. The evaluator does not load `.m1dbc`
+files.
+
+Seed an ordinary hardware channel with scenario `[[inputs]]`. Seed a
+hardware-backed builtin call with `[[io]]`, using its exact `Object.Method` name.
+Without those seeds, function and cone runs fail on an ordinary missing channel,
+while Tier-3 calls use the **Stubbed** contract. Run `--coverage` first to see the
+implemented, stubbed, and unsupported calls in a project.
+
+Whole-project mode is strict about ordinary missing channels unless
+`allow_default_inputs = true` or `--allow-default-inputs` is set. The CLI then
+prints every substituted channel, value, and first-reading script to stderr.
+Library callers receive the same records in `Trace::defaulted`; the trace also
+marks those channels externally driven. Tier-3 stubs and absent-calibration
+parameter defaults are marked externally driven, but they are not part of that
+`allow_default_inputs` stderr summary. Missing table calibration is also handled
+separately: with the whole-project opt-in, `.Lookup()` and `.Get()` return the
+externally-driven float value `0.0` and add the table path to `Trace::external`.
+That table fallback is not added to `Trace::defaulted` and does not appear in the
+CLI substitution summary. Without the opt-in, missing table calibration remains
+a fail-loud `MissingCalibration` error.
 
 ```sh
 # Evaluate a scenario and write the trace as JSON (or .csv — format follows the
@@ -173,7 +228,7 @@ override, leave everything else at its logged value, and emit both the new
 - **Cone functions keep their declared rates.** Each cone function runs at its
   project rate (its trigger's Hz) on the replay grid, with its own period as
   `dt` — a 10 Hz state machine in the cone of a 100 Hz replay still runs every
-  10th tick with `dt = 0.1 s`, exactly as scheduled on the ECU. The default
+  10th tick with `dt = 0.1 s` under the evaluator's scheduling model. The default
   replay base is the lcm of the project's rates (the smallest grid every rate
   divides exactly); a pinned base that cannot represent a cone rate exactly is
   rejected loudly.
@@ -182,7 +237,7 @@ override, leave everything else at its logged value, and emit both the new
 - **Source precedence.** calibration < scenario < **log** < **override**.
 - **The no-op invariant.** A no-op override (or `--log` with no `--override`)
   reproduces the logged series within tolerance, and the changed-channel set is
-  empty — the load-bearing correctness guarantee of the whole pipeline.
+  empty. Synthetic regression tests enforce this evaluator invariant.
 
 ### The `ld` feature (clean-room `.ld` import)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ do not compare computed channel values with captured M1 results.
 | Advertised area | State | Current contract |
 | --- | --- | --- |
 | Expressions, statements, enums, and inline user functions | **Assumed** | Covered by unit and synthetic-project tests. M1 evaluation results have not been captured for comparison. |
-| `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | Parsing, interpolation, and edge clamping use synthetic fixtures. Use the matching calibration file for actual parameter and table values. |
+| `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | Parsing, interpolation, and edge clamping use synthetic fixtures. Use the matching calibration file for actual values. Without it, parameters use typed external defaults. Table `.Lookup()` and `.Get()` fail in strict modes; whole-project mode may opt in to an external `0.0` fallback. |
 | `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, and table methods | **Assumed** | Implemented methods have hand-derived tests. `--coverage` remains authoritative for the methods a project uses. |
 | Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. |
 | `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Stubbed** | Scenario `[[io]]` values take precedence. Otherwise calls use documented or generic typed stubs; writes are offline no-ops. |
@@ -148,9 +148,11 @@ are excluded — before you run it.
 `m1-eval` runs offline. It does not connect to an ECU, sample sensors, emulate a
 CAN or serial bus, or reproduce firmware timing. A `Project.m1prj` is always
 required because it supplies symbols, types, and trigger rates. Pass the matching
-`.m1cfg` when a run needs real parameter values or table cells. Table lookup
-without its calibration fails; an unseeded parameter instead uses a type-correct
-externally-driven default. The evaluator does not load `.m1dbc` files.
+`.m1cfg` when a run needs real parameter values or table cells. Without it, an
+unseeded parameter uses a type-correct externally-driven default. Table
+`.Lookup()` and `.Get()` fail in strict modes. In whole-project mode,
+`allow_default_inputs` also permits an externally-driven `0.0` table fallback.
+The evaluator does not load `.m1dbc` files.
 
 Seed an ordinary hardware channel with scenario `[[inputs]]`. Seed a
 hardware-backed builtin call with `[[io]]`, using its exact `Object.Method` name.
@@ -160,11 +162,12 @@ implemented, stubbed, and unsupported calls in a project.
 
 Whole-project mode is strict about ordinary missing channels unless
 `allow_default_inputs = true` or `--allow-default-inputs` is set. The CLI then
-prints every substituted channel, value, and first-reading script to stderr.
-Library callers receive the same records in `Trace::defaulted`; the trace also
-marks those channels externally driven. Tier-3 stubs and absent-calibration
-parameter defaults are marked externally driven, but they are not part of that
-`allow_default_inputs` stderr summary.
+prints every substituted ordinary channel, value, and first-reading script to
+stderr. Library callers receive the same records in `Trace::defaulted`; the
+trace also marks those channels externally driven. Tier-3 stubs,
+absent-calibration parameter defaults, and the opt-in table fallback are marked
+externally driven, but they are not part of that `allow_default_inputs` stderr
+summary.
 
 ```sh
 # Evaluate a scenario and write the trace as JSON (or .csv — format follows the

--- a/README.md
+++ b/README.md
@@ -1,16 +1,46 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 # m1-eval
 
-A stepped, deterministic **evaluator/interpreter for the MoTeC M1 scripting
+A stepped, deterministic offline **evaluator/interpreter for the MoTeC M1 scripting
 language** (`.m1scr`). The rest of the toolchain can parse (`m1-core`) and
 type-check (`m1-typecheck`) M1; `m1-eval` adds the missing layer — it actually
 *runs* the scripts. Given a *scenario* (input channel/parameter values over
 time) it evaluates a project's expressions, table lookups, and stateful
-time-domain operators to produce **real numeric channel values over time**.
+time-domain operators to produce numeric channel values over time.
 
 It is built primarily as a **Rust library** (consumed by `m1-visualiser`, and
 later `m1-lsp`), with a thin CLI on top. The same engine drives a per-channel and
 per-expression value `Trace` that the visualiser overlays on a dependency graph.
+
+## Maturity contract
+
+These states describe evidence for compatibility with M1, not how much Rust test
+coverage a module has.
+
+| State | Meaning |
+| --- | --- |
+| **Verified** | A committed test compares the result with captured output from M1, M1 Sim, or an ECU. |
+| **Assumed** | The behavior is implemented and tested with synthetic fixtures or hand-derived values, but has not been compared with captured M1 output. |
+| **Stubbed** | Hardware behavior is not evaluated. An explicit scenario input may supply the value; otherwise the engine returns a documented offline value or a generic type-correct default and marks it externally driven. |
+| **Unsupported** | The engine does not implement the behavior. It reports the item through `--coverage` when possible and fails the run if execution reaches it. |
+
+No advertised evaluator area currently meets the **Verified** definition. The
+real-project and real-`.ld` tests are completion and structural smoke tests; they
+do not compare computed channel values with captured M1 results.
+
+| Advertised area | State | Current contract |
+| --- | --- | --- |
+| Expressions, statements, enums, and inline user functions | **Assumed** | Covered by unit and synthetic-project tests. M1 evaluation results have not been captured for comparison. |
+| `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | Parsing, interpolation, and edge clamping use synthetic fixtures. Use the matching calibration file for actual parameter and table values. |
+| `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, and table methods | **Assumed** | Implemented methods have hand-derived tests. `--coverage` remains authoritative for the methods a project uses. |
+| Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. |
+| `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Stubbed** | Scenario `[[io]]` values take precedence. Otherwise calls use documented or generic typed stubs; writes are offline no-ops. |
+| Scenario parsing, tick grids, trace output, and `--coverage` | **Assumed** | These are deterministic m1-eval contracts tested with synthetic data. A `Supported` coverage entry means implemented, not M1-verified. |
+| Single-function and upstream dependency-cone runners | **Assumed** | Selection, ordering, and zero-order hold are tested on synthetic projects. |
+| Whole-project multi-rate scheduling | **Assumed** | Trigger rates come from `Project.m1prj`; same-rate dependency order, fastest-first rate groups, startup order, and cross-rate stale reads are the evaluator's model. |
+| CSV log replay, overrides, downstream-cone recomputation, and diffs | **Assumed** | Synthetic tests cover import, resampling, source precedence, recomputation, and the no-op invariant. They do not establish M1 execution fidelity. |
+| Binary `.ld` import | **Assumed** | Synthetic decode tests run in CI. An optional real-log test checks structure and numeric plausibility only, not values against an independent oracle. |
+| Real-time/HIL execution, ECU budgets or preemption, watchdog behavior, live CAN/serial I/O, `.m1dbc` decoding, unlisted constructs or builtins, and LSP integration | **Unsupported** | These are outside the current evaluator. Unknown executable behavior fails loud rather than being inferred. |
 
 ## What it does (Phase 1)
 
@@ -70,7 +100,7 @@ The multi-rate model:
 - **Rate-correct `dt`.** A function's stateful operators (`Integral.Normal`,
   filters, derivatives, timers) are stepped by *its own* period
   (`1 / rate_hz`) — a 50 Hz integrator accumulates with `dt = 0.02`, not the
-  base `dt` — so time-domain results are faithful to the real schedule.
+  base `dt`, so time-domain operators use the configured function period.
 - **Zero-order hold between ticks.** A channel a function did not write this
   tick keeps its last value (the shared value store carries it forward), so a
   slow channel holds steady between its updates while fast channels move every
@@ -78,9 +108,9 @@ The multi-rate model:
 - **Same-rate dependency ordering, cross-rate stale-tolerance.** Within one
   rate group, a writer runs before any reader of its output (topological order).
   Across rates, no ordering edge is added: a faster reader of a slower writer
-  sees the slower function's *previous* value (stale between writer ticks),
-  matching how the real ECU schedule interleaves rate groups. Rate groups are
-  run fastest-first within a base tick.
+  sees the slower function's *previous* value (stale between writer ticks).
+  This ordering is an explicit evaluator assumption. Rate groups run
+  fastest-first within a base tick.
 - **Externally-driven IO still stubbed, still fail-loud.** CAN/sensor reads
   fall back to their documented stubs (flagged externally driven in the trace);
   any genuinely unsupported construct still aborts the run rather than guessing.
@@ -89,26 +119,23 @@ The multi-rate model:
 
 - **Deterministic.** A fixed tick grid and explicit `dt`, no wall-clock and no
   RNG: the same scenario always produces the same `Trace`.
-- **Fail-loud.** By default the evaluator never substitutes a guessed number. An
-  unimplemented builtin, an unsupported construct, an unresolved symbol, or a
-  missing scenario input all surface as an error and abort the run — never a
-  silently-wrong value. Whole-project mode may opt in to
+- **Strict channel inputs.** An unimplemented builtin, an unsupported construct,
+  an unresolved symbol, or an unseeded ordinary channel aborts the run by
+  default. Hardware-backed calls follow the **Stubbed** contract above, and an
+  unseeded parameter uses its type-correct calibration default. Whole-project
+  mode may also opt in to
   **`allow_default_inputs`** (scenario field or `--allow-default-inputs`):
   unseeded channel reads then fall back to their type-correct startup defaults,
   and **every substitution is reported** (channel, substituted value, first
   reading script) — visible guessing, never silent. Arithmetic errors are not
   inputs: integer division/modulo by zero always fails loud, opt-in or not.
-  (An unseeded *parameter* still reads as its type-correct tunable default —
-  parameters are calibration values with real defaults in M1 Tune, not runtime
-  inputs.)
 
 ### `--coverage`
 
 Before running, `m1-eval --coverage` reports, per project, which builtins and
-constructs each script uses and whether the engine **supports** them faithfully,
-**stubs** them (Tier-3 IO, externally driven), or does **not support** them
-(would fail loud at runtime). This tells you up front what is trustworthy versus
-externally driven.
+constructs each script uses and whether the engine **implements**, **stubs**, or
+does **not support** them. `Supported` is an implementation label, not a
+**Verified** maturity claim.
 
 The report also prints a **`Schedule:`** section: every script-backed function
 with its execution rate (`@ 500 Hz`, `@ 50 Hz`, …), or *unscheduled* for a
@@ -116,7 +143,28 @@ function with no periodic trigger. This makes a `whole-project` run transparent 
 you see exactly which functions the scheduler will run, at what rate, and which
 are excluded — before you run it.
 
-## Usage
+## Quickstart
+
+`m1-eval` runs offline. It does not connect to an ECU, sample sensors, emulate a
+CAN or serial bus, or reproduce firmware timing. A `Project.m1prj` is always
+required because it supplies symbols, types, and trigger rates. Pass the matching
+`.m1cfg` when a run needs real parameter values or table cells. Table lookup
+without its calibration fails; an unseeded parameter instead uses a type-correct
+externally-driven default. The evaluator does not load `.m1dbc` files.
+
+Seed an ordinary hardware channel with scenario `[[inputs]]`. Seed a
+hardware-backed builtin call with `[[io]]`, using its exact `Object.Method` name.
+Without those seeds, function and cone runs fail on an ordinary missing channel,
+while Tier-3 calls use the **Stubbed** contract. Run `--coverage` first to see the
+implemented, stubbed, and unsupported calls in a project.
+
+Whole-project mode is strict about ordinary missing channels unless
+`allow_default_inputs = true` or `--allow-default-inputs` is set. The CLI then
+prints every substituted channel, value, and first-reading script to stderr.
+Library callers receive the same records in `Trace::defaulted`; the trace also
+marks those channels externally driven. Tier-3 stubs and absent-calibration
+parameter defaults are marked externally driven, but they are not part of that
+`allow_default_inputs` stderr summary.
 
 ```sh
 # Evaluate a scenario and write the trace as JSON (or .csv — format follows the
@@ -173,7 +221,7 @@ override, leave everything else at its logged value, and emit both the new
 - **Cone functions keep their declared rates.** Each cone function runs at its
   project rate (its trigger's Hz) on the replay grid, with its own period as
   `dt` — a 10 Hz state machine in the cone of a 100 Hz replay still runs every
-  10th tick with `dt = 0.1 s`, exactly as scheduled on the ECU. The default
+  10th tick with `dt = 0.1 s` under the evaluator's scheduling model. The default
   replay base is the lcm of the project's rates (the smallest grid every rate
   divides exactly); a pinned base that cannot represent a cone rate exactly is
   rejected loudly.
@@ -182,7 +230,7 @@ override, leave everything else at its logged value, and emit both the new
 - **Source precedence.** calibration < scenario < **log** < **override**.
 - **The no-op invariant.** A no-op override (or `--log` with no `--override`)
   reproduces the logged series within tolerance, and the changed-channel set is
-  empty — the load-bearing correctness guarantee of the whole pipeline.
+  empty. Synthetic regression tests enforce this evaluator invariant.
 
 ### The `ld` feature (clean-room `.ld` import)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,7 +19,7 @@ m1-eval [--project P] [--config C]
 | Flag | Meaning |
 | --- | --- |
 | `--project <PATH>` | The `Project.m1prj`. Defaults to the nearest one upward from the cwd, or `$M1_PROJECT`. |
-| `--config <PATH>` | The calibration file (`.m1cfg`) supplying parameter values and table cells. Required for any run that reads a parameter or does a table `.Lookup()`. |
+| `--config <PATH>` | The calibration file (`.m1cfg`) supplying parameter values and table cells. Required for table lookup and for actual tunable values; without it, parameters use externally-driven type defaults. |
 | `--scenario <PATH>` | The scenario file (TOML or JSON; parser chosen by extension) describing how to drive the run. |
 | `--function <NAME>` | Override the scenario's mode: run this single function each tick. Mutually exclusive with `--target` and `--whole-project`. |
 | `--target <CHANNEL>` | Override the scenario's mode: run this target channel plus its upstream dependency cone. Mutually exclusive with `--function` and `--whole-project`. |
@@ -38,6 +38,11 @@ A run requires `--scenario` (to evaluate), `--log` (to replay a log), or
 `--function` / `--target` / `--whole-project` override the `mode`/`target`
 declared in the scenario file; at most one may be given (combining two is a usage
 error, exit `2`). `--override` and `--diff` require `--log`.
+
+The `Supported` bucket from `--coverage` means the evaluator has an
+implementation. It does not mean the behavior has been verified against M1.
+See the [README maturity contract](../README.md#maturity-contract) for the
+evidence labels and current status of each evaluator area.
 
 ## Scenario file
 
@@ -94,8 +99,9 @@ used verbatim and never split on whitespace, only on `.` for path segments.
 
 - **JSON** (`--out trace.json`, or no `--out`):
   `{ "time": [...], "channels": { path: [...] }, "external": [...] }`. The
-  `external` list names channels whose values were externally driven (scenario-fed
-  or a Tier-3 stub) rather than computed.
+  `external` list names channels whose values were externally driven rather than
+  computed, including scenario inputs, Tier-3 stubs, parameter defaults, and
+  opt-in defaults for unseeded channels.
 - **CSV** (`--out trace.csv`): a `time` header column followed by one column per
   channel in sorted-name order, one row per tick.
 
@@ -111,8 +117,10 @@ These follow the shared toolchain contract (`m1-tools/docs/cli.md`):
 | `1` | The engine ran and **has something to report**: a project/calibration that would not load, a scenario that would not parse, or a fail-loud evaluation error (an unsupported builtin, a missing calibration value, an unresolved symbol, a missing input). |
 | `2` | A **usage error** — an unrecognised flag, no resolvable project, or neither `--scenario` nor `--coverage` given. |
 
-So `$? != 0` means "do not trust the output." The engine **fails loud**: it never
-emits a guessed or default number in place of something it cannot evaluate.
+So `$? != 0` means "do not trust the output." Unsupported behavior fails loud.
+The documented hardware stubs, parameter defaults, and opt-in unseeded-channel
+defaults are exceptions; the trace marks them externally driven, and the CLI
+reports every `--allow-default-inputs` substitution on stderr.
 
 A fail-loud evaluation error also says **where** it happened — the failing
 script and the tick instant (`in ECU.Update.m1scr at t = 0.125 s: type error:
@@ -149,8 +157,8 @@ overrides the log.
 
 **The no-op invariant.** `--log` with no `--override` (or an identity override
 like `CH=CH`) reproduces the logged series within floating-point tolerance, and
-the diff's changed-channel set is empty. This is the load-bearing correctness
-guarantee of the whole pipeline.
+the diff's changed-channel set is empty. Synthetic regression tests enforce this
+evaluator invariant; it is not a comparison with an M1 execution result.
 
 **Fail-loud.** A malformed log, a non-numeric value cell, an override of a
 channel that no in-project function reads (nothing downstream to recompute), or an

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,12 +19,12 @@ m1-eval [--project P] [--config C]
 | Flag | Meaning |
 | --- | --- |
 | `--project <PATH>` | The `Project.m1prj`. Defaults to the nearest one upward from the cwd, or `$M1_PROJECT`. |
-| `--config <PATH>` | The calibration file (`.m1cfg`) supplying parameter values and table cells. Required for table lookup and for actual tunable values; without it, parameters use externally-driven type defaults. |
+| `--config <PATH>` | The calibration file (`.m1cfg`) supplying parameter values and table cells. Required for actual tunable and table values. Without it, parameters use externally-driven type defaults; table reads fail unless whole-project mode opts in to default inputs, which supplies an external `0.0`. |
 | `--scenario <PATH>` | The scenario file (TOML or JSON; parser chosen by extension) describing how to drive the run. |
 | `--function <NAME>` | Override the scenario's mode: run this single function each tick. Mutually exclusive with `--target` and `--whole-project`. |
 | `--target <CHANNEL>` | Override the scenario's mode: run this target channel plus its upstream dependency cone. Mutually exclusive with `--function` and `--whole-project`. |
 | `--whole-project` | Override the scenario's mode: run the whole-project multi-rate scheduler (every periodically-scheduled function at its own rate; `On Startup` functions run once first). Mutually exclusive with `--function` and `--target`. |
-| `--allow-default-inputs` | Whole-project mode: substitute type-correct startup defaults for unseeded channel reads instead of failing loud. Every substitution is reported on stderr. Strict fail-loud is the default. |
+| `--allow-default-inputs` | Whole-project mode: substitute type-correct startup defaults for unseeded channel reads instead of failing loud. Ordinary channel substitutions are reported on stderr. Missing table cells instead produce an external `0.0` recorded only in trace metadata. Strict fail-loud is the default. |
 | `--out <PATH>` | Where to write the trace. Format follows the extension: `.csv` writes CSV, anything else (including `.json`) writes JSON. Without `--out`, the trace prints to stdout as JSON. |
 | `--log <PATH>` | Counterfactual replay: a recorded MoTeC log held as ground truth (`.csv`, or `.ld` with `--features ld`). Triggers a counterfactual run instead of a scenario run. |
 | `--override <CH=expr>` | Pin a logged channel to a constant or expression for the counterfactual run, recomputing only its downstream cone. Repeatable (override several channels). Requires `--log`. |
@@ -100,8 +100,8 @@ used verbatim and never split on whitespace, only on `.` for path segments.
 - **JSON** (`--out trace.json`, or no `--out`):
   `{ "time": [...], "channels": { path: [...] }, "external": [...] }`. The
   `external` list names channels whose values were externally driven rather than
-  computed, including scenario inputs, Tier-3 stubs, parameter defaults, and
-  opt-in defaults for unseeded channels.
+  computed, including scenario inputs, Tier-3 stubs, parameter defaults, opt-in
+  table fallbacks, and opt-in defaults for unseeded channels.
 - **CSV** (`--out trace.csv`): a `time` header column followed by one column per
   channel in sorted-name order, one row per tick.
 
@@ -118,9 +118,10 @@ These follow the shared toolchain contract (`m1-tools/docs/cli.md`):
 | `2` | A **usage error** — an unrecognised flag, no resolvable project, or neither `--scenario` nor `--coverage` given. |
 
 So `$? != 0` means "do not trust the output." Unsupported behavior fails loud.
-The documented hardware stubs, parameter defaults, and opt-in unseeded-channel
-defaults are exceptions; the trace marks them externally driven, and the CLI
-reports every `--allow-default-inputs` substitution on stderr.
+The documented hardware stubs, parameter defaults, opt-in table fallbacks, and
+opt-in unseeded-channel defaults are exceptions. The trace marks them externally
+driven. The CLI reports each ordinary unseeded-channel substitution on stderr;
+the table fallback appears only in the trace's external metadata.
 
 A fail-loud evaluation error also says **where** it happened — the failing
 script and the tick instant (`in ECU.Update.m1scr at t = 0.125 s: type error:

--- a/docs/plans/2026-06-23-phase-2-plan.md
+++ b/docs/plans/2026-06-23-phase-2-plan.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Close the real-data builtin gaps the EV-M1 `--coverage` run surfaces (**Phase 1.5**), then build the **whole-project multi-rate scheduler** — the faithful mini-ECU (**Phase 2**). Phase 1.5 makes a real EV-M1 control script runnable end-to-end (pure `Calculate` overloads, enum `.AsInteger` conversions, project-object method routing, inline user-function calls). Phase 2 adds a `RunMode::WholeProject` that runs every scheduled function each base tick at its own rate (500/200/50/10/2 Hz) in dependency-then-rate order over a fixed duration, producing a deterministic `Trace`.
+**Goal:** Close the real-data builtin gaps the EV-M1 `--coverage` run surfaces (**Phase 1.5**), then build the **whole-project multi-rate scheduler** as a deterministic offline schedule model (**Phase 2**). Phase 1.5 makes a real EV-M1 control script runnable end-to-end (pure `Calculate` overloads, enum `.AsInteger` conversions, project-object method routing, inline user-function calls). Phase 2 adds a `RunMode::WholeProject` that runs every scheduled function each base tick at its own rate (500/200/50/10/2 Hz) in dependency-then-rate order over a fixed duration, producing a deterministic `Trace`.
 
 **Architecture:** Unchanged from Phase 1 — a tree-walking interpreter over `m1-core`'s CST using `m1-typecheck`'s `Project`/`SymbolTable`/`resolve`/`ValueType`. Phase 1.5 extends the builtin **dispatch** seam (`builtins::dispatch`, case 5: `dispatch_object_method`) and the **call** seam (`expr::eval_call`) — no new core. Phase 2 adds a third runner alongside the single-function and dependency-cone runners in `runner.rs`, reusing `summary::io_sets` for ordering and the existing `Env`/`StateStore`/tick loop for execution.
 
@@ -12,7 +12,7 @@
 
 - **Dependency pins (unchanged):** `m1-core` = `v0.12.0`, `m1-typecheck` = `v0.36.0`. No upstream `m1-typecheck` change is required or permitted — everything is built inside `m1-eval` against the existing public API.
 - **License:** `GPL-3.0-or-later`. Every new source file carries `// SPDX-License-Identifier: GPL-3.0-or-later`.
-- **Fail loud, never silently wrong:** every new construct either evaluates faithfully, returns a documented externally-driven stub (flagged in the `Trace`), or returns an `EvalError`. No guessed numeric value, ever.
+- **Fail loud, never silently wrong:** every new construct is implemented under a documented assumption, returns a documented externally-driven stub (flagged in the `Trace`), or returns an `EvalError`. No guessed numeric value, ever.
 - **No proprietary text:** never copy MoTeC M1 manual text into code/comments/fixtures. Semantics are paraphrased.
 - **M1 identifiers may contain spaces** (`Drive State`, `AMK Inverter Boot State`, `Service Bits`) — only ever split paths on `.`, never whitespace.
 - **Determinism:** fixed tick grid + explicit per-tick `dt`; no wall-clock, no RNG. Same inputs ⇒ identical `Trace`. (Phase 2's multi-rate scheduler is the strongest test of this.)
@@ -214,7 +214,7 @@ These are externally-driven: a CAN message object's `.Tx/.TxOpen/.TxInitialise/.
 
 # PHASE 2 — Whole-project multi-rate scheduler
 
-> The faithful mini-ECU: every periodically scheduled function runs each base tick at its own rate, in dependency-then-rate order, over a fixed duration, producing one deterministic `Trace`. Built entirely on the Phase-1 + Phase-1.5 core — a new `RunMode`, a schedule builder, and a rate-gated generalisation of the existing `tick_loop`.
+> Deterministic offline schedule model: every periodically scheduled function runs each base tick at its own rate, in dependency-then-rate order, over a fixed duration, producing one deterministic `Trace`. Built entirely on the Phase-1 + Phase-1.5 core using a new `RunMode`, a schedule builder, and a rate-gated generalisation of the existing `tick_loop`.
 
 ## Milestone P2-A — `RunMode::WholeProject`
 
@@ -312,8 +312,8 @@ The base tick rate is `scenario.base_rate_hz` (default to the fastest scheduled 
 
 - Log-driven counterfactual replay (CSV/`.ld` import, logged channels as ground truth, override + downstream diff) — that is **Phase 3** (spec §"Phase plan").
 - LSP hover/inlay — **Phase 4**.
-- `.m1dbc` value loading (`with_dbc`) — DBC CAN objects are handled as externally-driven IO stubs (Task 7); faithful DBC decode is not required and is part of the later log/CAN-feed work.
-- Faithful CAN-bus/Serial emulation — stubbed/scenario-fed only.
+- `.m1dbc` value loading (`with_dbc`) — DBC CAN objects are handled as externally-driven IO stubs (Task 7); DBC decode is not required and is part of the later log/CAN-feed work.
+- CAN-bus/Serial emulation — stubbed/scenario-fed only.
 - Matching MoTeC M1 Sim's exact intra-tick ordering to the cycle — the same-rate-topological + descending-rate model is the documented Phase-2 approximation (spec Risks: "Scheduling fidelity"), validated against M1 Sim as a later fidelity follow-up, not a Phase-2 gate.
 
 ## Self-Review (run by author)

--- a/docs/plans/2026-06-23-phase-2-plan.md
+++ b/docs/plans/2026-06-23-phase-2-plan.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Close the real-data builtin gaps the EV-M1 `--coverage` run surfaces (**Phase 1.5**), then build the **whole-project multi-rate scheduler** — the faithful mini-ECU (**Phase 2**). Phase 1.5 makes a real EV-M1 control script runnable end-to-end (pure `Calculate` overloads, enum `.AsInteger` conversions, project-object method routing, inline user-function calls). Phase 2 adds a `RunMode::WholeProject` that runs every scheduled function each base tick at its own rate (500/200/50/10/2 Hz) in dependency-then-rate order over a fixed duration, producing a deterministic `Trace`.
+**Goal:** Close the real-data builtin gaps the EV-M1 `--coverage` run surfaces (**Phase 1.5**), then build the **whole-project multi-rate scheduler** — the deterministic evaluator model (**Phase 2**). Phase 1.5 makes a real EV-M1 control script runnable end-to-end (pure `Calculate` overloads, enum `.AsInteger` conversions, project-object method routing, inline user-function calls). Phase 2 adds a `RunMode::WholeProject` that runs every scheduled function each base tick at its own rate (500/200/50/10/2 Hz) in dependency-then-rate order over a fixed duration, producing a deterministic `Trace`.
 
 **Architecture:** Unchanged from Phase 1 — a tree-walking interpreter over `m1-core`'s CST using `m1-typecheck`'s `Project`/`SymbolTable`/`resolve`/`ValueType`. Phase 1.5 extends the builtin **dispatch** seam (`builtins::dispatch`, case 5: `dispatch_object_method`) and the **call** seam (`expr::eval_call`) — no new core. Phase 2 adds a third runner alongside the single-function and dependency-cone runners in `runner.rs`, reusing `summary::io_sets` for ordering and the existing `Env`/`StateStore`/tick loop for execution.
 
@@ -12,7 +12,7 @@
 
 - **Dependency pins (unchanged):** `m1-core` = `v0.12.0`, `m1-typecheck` = `v0.36.0`. No upstream `m1-typecheck` change is required or permitted — everything is built inside `m1-eval` against the existing public API.
 - **License:** `GPL-3.0-or-later`. Every new source file carries `// SPDX-License-Identifier: GPL-3.0-or-later`.
-- **Fail loud, never silently wrong:** every new construct either evaluates faithfully, returns a documented externally-driven stub (flagged in the `Trace`), or returns an `EvalError`. No guessed numeric value, ever.
+- **Fail loud or mark substitutions:** every new construct is implemented under an explicit assumption, returns a documented externally-driven stub or default, or returns an `EvalError`. The trace must not present a substituted value as computed.
 - **No proprietary text:** never copy MoTeC M1 manual text into code/comments/fixtures. Semantics are paraphrased.
 - **M1 identifiers may contain spaces** (`Drive State`, `AMK Inverter Boot State`, `Service Bits`) — only ever split paths on `.`, never whitespace.
 - **Determinism:** fixed tick grid + explicit per-tick `dt`; no wall-clock, no RNG. Same inputs ⇒ identical `Trace`. (Phase 2's multi-rate scheduler is the strongest test of this.)
@@ -214,7 +214,7 @@ These are externally-driven: a CAN message object's `.Tx/.TxOpen/.TxInitialise/.
 
 # PHASE 2 — Whole-project multi-rate scheduler
 
-> The faithful mini-ECU: every periodically scheduled function runs each base tick at its own rate, in dependency-then-rate order, over a fixed duration, producing one deterministic `Trace`. Built entirely on the Phase-1 + Phase-1.5 core — a new `RunMode`, a schedule builder, and a rate-gated generalisation of the existing `tick_loop`.
+> The deterministic evaluator model: every periodically scheduled function runs each base tick at its own rate, in dependency-then-rate order, over a fixed duration, producing one deterministic `Trace`. Built entirely on the Phase-1 + Phase-1.5 core — a new `RunMode`, a schedule builder, and a rate-gated generalisation of the existing `tick_loop`.
 
 ## Milestone P2-A — `RunMode::WholeProject`
 
@@ -312,8 +312,8 @@ The base tick rate is `scenario.base_rate_hz` (default to the fastest scheduled 
 
 - Log-driven counterfactual replay (CSV/`.ld` import, logged channels as ground truth, override + downstream diff) — that is **Phase 3** (spec §"Phase plan").
 - LSP hover/inlay — **Phase 4**.
-- `.m1dbc` value loading (`with_dbc`) — DBC CAN objects are handled as externally-driven IO stubs (Task 7); faithful DBC decode is not required and is part of the later log/CAN-feed work.
-- Faithful CAN-bus/Serial emulation — stubbed/scenario-fed only.
+- `.m1dbc` value loading (`with_dbc`) — DBC CAN objects are handled as externally-driven IO stubs (Task 7); DBC decode is not required and is part of the later log/CAN-feed work.
+- CAN-bus/Serial emulation — stubbed/scenario-fed only.
 - Matching MoTeC M1 Sim's exact intra-tick ordering to the cycle — the same-rate-topological + descending-rate model is the documented Phase-2 approximation (spec Risks: "Scheduling fidelity"), validated against M1 Sim as a later fidelity follow-up, not a Phase-2 gate.
 
 ## Self-Review (run by author)

--- a/docs/plans/2026-06-23-phase-3-plan.md
+++ b/docs/plans/2026-06-23-phase-3-plan.md
@@ -268,8 +268,8 @@ impl Diff {
 ## Out of scope (do NOT build here)
 
 - **`.ldx` import** — the sidecar is lap/beacon markers + summary details (XML), not channel values; `motec-i2`'s reader ignores it and so do we. Lap-aware analysis is a later concern.
-- **Faithful `.ld` *writing* of real runs** — the writer is used only to generate the tiny synthetic CI fixture; we do not export real traces back to `.ld`.
-- **`.m1dbc` CAN decode / faithful CAN-bus replay** — logged CAN channels can be fed as ordinary log channels; bit-level DBC decode is not required here.
+- **`.ld` *writing* of real runs** — the writer is used only to generate the tiny synthetic CI fixture; we do not export real traces back to `.ld`.
+- **`.m1dbc` CAN decode / CAN-bus replay** — logged CAN channels can be fed as ordinary log channels; bit-level DBC decode is not required here.
 - **LSP hover/inlay** — Phase 4.
 - **Non-zero-order-hold resampling** (linear/spline interpolation of logs) — zero-order hold is the documented, deterministic rule; richer interpolation is a fidelity follow-up, not a Phase-3 gate.
 - **Multi-lap / time-reset logs** (`.ldx` beacon-driven lap segmentation) — single monotonic time axis only in v1.

--- a/docs/specs/2026-06-23-m1-eval-design.md
+++ b/docs/specs/2026-06-23-m1-eval-design.md
@@ -61,7 +61,7 @@ From surveying the grammar, `m1-typecheck`, the M1 manuals, and ~80 real EV-M1 s
   require that file as an input.
 - **Scripts run as scheduled functions at fixed rates** (500/200/50/10/2 Hz); rate
   determines `dt` and cross-function ordering.
-- Rough size of a faithful engine: **~3–5k lines of Rust**, medium-large, with correctness
+- Rough size of the intended engine: **~3–5k lines of Rust**, medium-large, with correctness
   risk concentrated in the time-domain math.
 
 The language itself (operators, `if/else`, `when/is`, `expand/to`, `local/static local`,
@@ -72,7 +72,7 @@ and scripts have side effects (channel writes, `Output.SetState(...)`).
 ## Goals / Non-goals
 
 ### Goals
-- Real numeric evaluation of M1 scripts, faithful enough to be trusted for analysis.
+- Real numeric evaluation of M1 scripts, with evidence labels that identify what users can trust for analysis.
 - Three execution granularities sharing one core: single-function, dependency-cone,
   whole-project ECU sim.
 - Scenario-driven inputs (constants + time series) and **log-driven counterfactual replay**
@@ -84,7 +84,7 @@ and scripts have side effects (channel writes, `Output.SetState(...)`).
 
 ### Non-goals (v1, YAGNI)
 - A real-time / hardware-in-the-loop simulator. This is offline, deterministic evaluation.
-- Faithful CAN bus / Serial IO emulation. Those are stubbed or scenario-fed.
+- CAN bus / Serial IO emulation. Those are stubbed or scenario-fed.
 - Re-implementing or driving MoTeC's GUI tools. (M1 Sim is used only as a validation
   oracle, see Fidelity.)
 - Editing/writing `.m1cfg` or `.m1prj`. The engine reads; it does not mutate the project.
@@ -190,8 +190,8 @@ silently-wrong number):
   real EV-M1 scripts, using tolerance-based floating-point comparison; divergences
   documented.
 - **`m1-eval --coverage <project>`** reports, before running, which builtins/constructs
-  each script uses and whether the engine supports them faithfully or stubs them — so the
-  user knows what is trustworthy versus externally driven.
+  each script uses and whether the engine implements or stubs them — so the user knows
+  what is implemented versus externally driven.
 
 ## Interfaces & ecosystem integration
 
@@ -228,7 +228,7 @@ Each phase is independently useful and shippable.
 1. **Core + single-function/cone runner + CLI + library API.** Expression/statement eval,
    Tier-1 + Tier-2 builtins, table lookup from `.m1cfg`, scenario input (constants + time
    series). Tier-3 IO stubbed/scenario-fed. *This is what `m1-visualiser` hooks into first.*
-2. **Whole-project multi-rate scheduler** — the faithful mini-ECU.
+2. **Whole-project multi-rate scheduler** — the deterministic evaluator model.
 3. **Log-driven counterfactual** — CSV + `.ld` import, logged channels as ground truth,
    channel overrides, downstream re-evaluation, diff vs log. The headline feature.
 4. **LSP integration** — hover-to-evaluate + inline value hints via `m1-lsp`, reusing the

--- a/docs/specs/2026-06-23-m1-eval-design.md
+++ b/docs/specs/2026-06-23-m1-eval-design.md
@@ -61,7 +61,7 @@ From surveying the grammar, `m1-typecheck`, the M1 manuals, and ~80 real EV-M1 s
   require that file as an input.
 - **Scripts run as scheduled functions at fixed rates** (500/200/50/10/2 Hz); rate
   determines `dt` and cross-function ordering.
-- Rough size of a faithful engine: **~3–5k lines of Rust**, medium-large, with correctness
+- Rough size of the proposed engine: **~3–5k lines of Rust**, medium-large, with correctness
   risk concentrated in the time-domain math.
 
 The language itself (operators, `if/else`, `when/is`, `expand/to`, `local/static local`,
@@ -72,7 +72,8 @@ and scripts have side effects (channel writes, `Output.SetState(...)`).
 ## Goals / Non-goals
 
 ### Goals
-- Real numeric evaluation of M1 scripts, faithful enough to be trusted for analysis.
+- Real numeric evaluation of M1 scripts, with trust gated by captured M1 evidence and
+  the maturity states in the README.
 - Three execution granularities sharing one core: single-function, dependency-cone,
   whole-project ECU sim.
 - Scenario-driven inputs (constants + time series) and **log-driven counterfactual replay**
@@ -84,7 +85,7 @@ and scripts have side effects (channel writes, `Output.SetState(...)`).
 
 ### Non-goals (v1, YAGNI)
 - A real-time / hardware-in-the-loop simulator. This is offline, deterministic evaluation.
-- Faithful CAN bus / Serial IO emulation. Those are stubbed or scenario-fed.
+- CAN bus / Serial IO emulation. Those are stubbed or scenario-fed.
 - Re-implementing or driving MoTeC's GUI tools. (M1 Sim is used only as a validation
   oracle, see Fidelity.)
 - Editing/writing `.m1cfg` or `.m1prj`. The engine reads; it does not mutate the project.
@@ -190,7 +191,7 @@ silently-wrong number):
   real EV-M1 scripts, using tolerance-based floating-point comparison; divergences
   documented.
 - **`m1-eval --coverage <project>`** reports, before running, which builtins/constructs
-  each script uses and whether the engine supports them faithfully or stubs them — so the
+  each script uses and whether the engine implements or stubs them, so the
   user knows what is trustworthy versus externally driven.
 
 ## Interfaces & ecosystem integration
@@ -228,7 +229,7 @@ Each phase is independently useful and shippable.
 1. **Core + single-function/cone runner + CLI + library API.** Expression/statement eval,
    Tier-1 + Tier-2 builtins, table lookup from `.m1cfg`, scenario input (constants + time
    series). Tier-3 IO stubbed/scenario-fed. *This is what `m1-visualiser` hooks into first.*
-2. **Whole-project multi-rate scheduler** — the faithful mini-ECU.
+2. **Whole-project multi-rate scheduler** - a deterministic offline schedule model.
 3. **Log-driven counterfactual** — CSV + `.ld` import, logged channels as ground truth,
    channel overrides, downstream re-evaluation, diff vs log. The headline feature.
 4. **LSP integration** — hover-to-evaluate + inline value hints via `m1-lsp`, reusing the

--- a/src/builtins/calculate.rs
+++ b/src/builtins/calculate.rs
@@ -149,8 +149,8 @@ fn abs(args: &[Value]) -> Result<Value, EvalError> {
 
 /// `Average(a, b)` — the arithmetic mean `(a + b) / 2`. Always a [`Value::Float`]:
 /// the mean of two integers is generally fractional, so we never round it back to
-/// an integer (the intrinsic return tag is `Integer|FloatingPoint`, but a faithful
-/// mean keeps the fractional part — a documented divergence from the raw tag).
+/// an integer (the intrinsic return tag is `Integer|FloatingPoint`, but retaining
+/// the fractional part is this evaluator's documented assumption).
 fn average(args: &[Value]) -> Result<Value, EvalError> {
     let a = args[0].as_f64()?;
     let b = args[1].as_f64()?;

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -115,8 +115,8 @@ pub fn dispatch(
         //     flagged `calibrationOnly` in the intrinsics) and is not, strictly,
         //     valid in ECU `.m1scr` scripts — yet real EV-M1 control scripts
         //     reference `Math.atan2`. We route that one function to the same
-        //     `y.atan2(x)` as `Calculate.InverseTan2` (a pragmatic, faithful
-        //     evaluation) and flag it `Stubbed` in coverage so the user sees it is
+        //     `y.atan2(x)` as `Calculate.InverseTan2` (a pragmatic implementation)
+        //     and flag it `Stubbed` in coverage so the user sees it is
         //     a calibration-only object surfaced in an ECU script. Every other
         //     `Math.*` method is left to fail loud (we do not implement the
         //     calibration maths library wholesale).
@@ -518,7 +518,7 @@ fn unsupported(object: &str, method: &str) -> EvalError {
 /// (it would fail loud at runtime).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinSupport {
-    /// Evaluated faithfully by the dispatch table.
+    /// Implemented by the dispatch table under the documented maturity contract.
     Supported,
     /// A Tier-3 IO object handled as a documented/scenario-fed stub.
     Stubbed,
@@ -526,7 +526,7 @@ pub enum BuiltinSupport {
     Unsupported,
 }
 
-/// Library/object methods implemented faithfully (Tier-1 + Tier-2). Kept in sync
+/// Library/object methods implemented by the evaluator (Tier-1 + Tier-2). Kept in sync
 /// with the dispatch arms above; this is the single source of truth the coverage
 /// report consults so it never disagrees with what `dispatch` actually evaluates.
 const SUPPORTED_METHODS: &[(&str, &str)] = &[
@@ -608,7 +608,7 @@ const SUPPORTED_OBJECT_METHODS: &[&str] =
     &["AsInteger", "Set", "Start", "Stop", "Reset", "Remaining"];
 
 /// The Tier-3 IO library objects: their methods are handled as documented/
-/// scenario-fed stubs (flagged externally driven), not faithfully evaluated.
+/// scenario-fed stubs (flagged externally driven), not evaluated as hardware.
 const STUB_OBJECTS: &[&str] = &["CanComms", "Serial", "System", "Logging"];
 
 /// Individual `(object, method)` pairs handled as documented stubs even though

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -3,7 +3,7 @@
 //! engine *supports*.
 //!
 //! Before a run, a user wants to know which parts of their project the evaluator
-//! will compute faithfully, which it will only stub (Tier-3 IO, externally
+//! implements, which it will only stub (Tier-3 IO, externally
 //! driven), and which it cannot handle at all (and would fail loud on). This
 //! module walks every script's CST and answers that, statically:
 //!
@@ -48,7 +48,7 @@ pub enum ItemKind {
 /// unsupported. Each list is de-duplicated and sorted for a deterministic report.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CoverageReport {
-    /// Items the engine evaluates faithfully.
+    /// Items the engine implements under its documented maturity contract.
     pub supported: Vec<CoverageItem>,
     /// Items handled as documented/scenario-fed stubs (Tier-3 IO).
     pub stubbed: Vec<CoverageItem>,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -201,7 +201,7 @@ impl Engine {
     /// periodic call rate, or 100 Hz when no function schedules periodically (so a
     /// project of purely event/startup functions still grids at a sane rate). A
     /// counterfactual recomputes only the override cone, but the grid rate governs
-    /// stateful-operator `dt`, so a project-derived default is the faithful choice.
+    /// stateful-operator `dt`, so the project-derived rate is the documented model.
     fn default_counterfactual_rate(&self) -> f64 {
         // The lcm of the declared rates — the smallest grid every cone function
         // divides exactly, mirroring the whole-project auto base. The fastest

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -197,11 +197,11 @@ impl Engine {
         Ok(Counterfactual { trace, diff })
     }
 
-    /// The default base tick rate for a counterfactual run: the project's fastest
-    /// periodic call rate, or 100 Hz when no function schedules periodically (so a
-    /// project of purely event/startup functions still grids at a sane rate). A
-    /// counterfactual recomputes only the override cone, but the grid rate governs
-    /// stateful-operator `dt`, so the project-derived rate is the documented model.
+    /// The default base tick rate for a counterfactual run: the least common multiple
+    /// of the project's periodic call rates, or 100 Hz when no exact common base
+    /// exists or no function schedules periodically. A counterfactual recomputes only
+    /// the override cone, but the grid rate governs stateful-operator `dt`, so the
+    /// project-derived rate is the documented model.
     fn default_counterfactual_rate(&self) -> f64 {
         // The lcm of the declared rates — the smallest grid every cone function
         // divides exactly, mirroring the whole-project auto base. The fastest

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -9,8 +9,8 @@
 //! - **dependency-cone** ([`RunMode::Cone`]): the target channel's upstream cone
 //!   of functions executes each tick, in topological (writer-before-reader) order;
 //! - **whole-project** ([`RunMode::WholeProject`]): every periodically-scheduled
-//!   function executes at its **own** rate, in dependency-then-rate order — the
-//!   faithful mini-ECU.
+//!   function executes at its **own** rate, in dependency-then-rate order using
+//!   the documented offline schedule model.
 //!
 //! The grid advances at `base_rate_hz` (tick step `1 / base_rate_hz`). For the
 //! single-function and cone runners every function shares that base rate, so it

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -65,7 +65,7 @@ pub enum RunMode {
     Cone(String),
     /// Run *every* periodically-scheduled function (those whose trigger resolves
     /// to a `call_rate_hz`) each base tick at its own rate, in dependency-then-rate
-    /// order. The faithful mini-ECU: no single target — the runner schedules the
+    /// order. The offline schedule model has no single target: the runner schedules the
     /// whole project.
     WholeProject,
 }


### PR DESCRIPTION
Closes #34

## Summary
- define Verified, Assumed, Stubbed, and Unsupported evidence states
- classify every advertised evaluator area and remove unsupported fidelity claims
- document offline inputs, calibration requirements, hardware limits, and reported substitutions

## Verification
- cargo fmt --all -- --check
- cargo test --locked
- cargo test --locked --features ld
- RUSTDOCFLAGS=-D warnings cargo doc --locked --no-deps
- git diff --check