### PR TITLE
feat: add M1-width scalar representations

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,7 +95,8 @@ used verbatim and never split on whitespace, only on `.` for path segments.
 - **JSON** (`--out trace.json`, or no `--out`):
   `{ "time": [...], "channels": { path: [...] }, "external": [...] }`. The
   `external` list names channels whose values were externally driven (scenario-fed
-  or a Tier-3 stub) rather than computed.
+  or a Tier-3 stub) rather than computed. JSON has no non-finite numeric values,
+  so NaN and positive or negative infinity are written as `null`.
 - **CSV** (`--out trace.csv`): a `time` header column followed by one column per
   channel in sorted-name order, one row per tick.
 

--- a/src/builtins/calculate.rs
+++ b/src/builtins/calculate.rs
@@ -22,7 +22,7 @@
 //! fall through `dispatch` to a fail-loud `UnsupportedBuiltin`.
 
 use crate::error::EvalError;
-use crate::value::Value;
+use crate::value::{M1Scalar, Value};
 use m1_typecheck::types::{ValueType, numeric_join};
 
 /// Evaluate one `Calculate.<method>` call. Returns `Ok(None)` when `method` is
@@ -188,6 +188,9 @@ fn value_type(v: &Value) -> ValueType {
         Value::Int(_) => ValueType::Integer,
         Value::Uint(_) => ValueType::Unsigned,
         Value::Float(_) => ValueType::Float,
+        Value::M1(M1Scalar::Integer(_)) => ValueType::Integer,
+        Value::M1(M1Scalar::UnsignedInteger(_)) => ValueType::Unsigned,
+        Value::M1(M1Scalar::FloatingPoint(_) | M1Scalar::FixedPoint7dps(_)) => ValueType::Float,
         Value::Enum { id, .. } => ValueType::Enum(*id),
         Value::Str(_) => ValueType::String,
     }

--- a/src/builtins/limit.rs
+++ b/src/builtins/limit.rs
@@ -11,7 +11,7 @@
 //! paraphrased from our understanding of the M1 library, not copied.
 
 use crate::error::EvalError;
-use crate::value::Value;
+use crate::value::{M1Scalar, Value};
 use m1_typecheck::types::{ValueType, numeric_join};
 
 /// Evaluate one `Limit.<method>` call. Returns `Ok(None)` for any method not
@@ -71,6 +71,9 @@ fn value_type(v: &Value) -> ValueType {
         Value::Int(_) => ValueType::Integer,
         Value::Uint(_) => ValueType::Unsigned,
         Value::Float(_) => ValueType::Float,
+        Value::M1(M1Scalar::Integer(_)) => ValueType::Integer,
+        Value::M1(M1Scalar::UnsignedInteger(_)) => ValueType::Unsigned,
+        Value::M1(M1Scalar::FloatingPoint(_) | M1Scalar::FixedPoint7dps(_)) => ValueType::Float,
         Value::Enum { id, .. } => ValueType::Enum(*id),
         Value::Str(_) => ValueType::String,
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -27,7 +27,7 @@ use crate::calib::Calibration;
 use crate::env::{CallSite, Env, StateStore};
 use crate::error::EvalError;
 use crate::ident::{Target, classify};
-use crate::value::Value;
+use crate::value::{M1Scalar, Value};
 use m1_core::{Field, Kind, Node};
 use m1_typecheck::Project;
 use m1_typecheck::symbols::SymbolKind;
@@ -840,6 +840,9 @@ fn value_type(v: &Value) -> ValueType {
         Value::Int(_) => ValueType::Integer,
         Value::Uint(_) => ValueType::Unsigned,
         Value::Float(_) => ValueType::Float,
+        Value::M1(M1Scalar::Integer(_)) => ValueType::Integer,
+        Value::M1(M1Scalar::UnsignedInteger(_)) => ValueType::Unsigned,
+        Value::M1(M1Scalar::FloatingPoint(_) | M1Scalar::FixedPoint7dps(_)) => ValueType::Float,
         Value::Enum { id, .. } => ValueType::Enum(*id),
         Value::Str(_) => ValueType::String,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub mod error;
 pub use error::EvalError;
 
 pub mod value;
-pub use value::Value;
+pub use value::{FixedPoint7dps, LegacyNumericKind, M1Scalar, M1ScalarKind, Value};
 
 pub mod calib;
 pub use calib::{CalTable, Calibration};

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -26,7 +26,7 @@
 //! `time` column followed by one column per channel in sorted-name order so the
 //! output is reproducible across runs.
 
-use crate::value::Value;
+use crate::value::{M1Scalar, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// A column-oriented record of an evaluation run.
@@ -110,10 +110,12 @@ impl Trace {
 
     /// Serialise the channel columns + time axis to JSON. The shape is
     /// `{ "time": [...], "channels": { path: [...] }, "external": [...] }`,
-    /// values rendered by `value_json`. Deterministic ordering (BTree maps).
+    /// values rendered by `value_json`. JSON has no non-finite number syntax, so
+    /// NaN and positive or negative infinity are written as `null`. Deterministic
+    /// ordering comes from the `BTreeMap` and `BTreeSet` fields.
     pub fn to_json(&self) -> String {
         let mut out = String::from("{\"time\":[");
-        out.push_str(&join(self.time.iter().map(|t| fmt_f64(*t))));
+        out.push_str(&join(self.time.iter().map(|t| f64_json(*t))));
         out.push_str("],\"channels\":{");
         let mut first = true;
         for (path, col) in &self.channels {
@@ -145,7 +147,7 @@ impl Trace {
         }
         out.push('\n');
         for (i, t) in self.time.iter().enumerate() {
-            out.push_str(&fmt_f64(*t));
+            out.push_str(&f64_text(*t));
             for p in &paths {
                 out.push(',');
                 if let Some(v) = self.channels.get(*p).and_then(|c| c.get(i)) {
@@ -165,7 +167,7 @@ fn join(items: impl Iterator<Item = String>) -> String {
 
 /// Format an `f64` without a trailing `.0`-less ambiguity but deterministically.
 /// Integers print without a decimal point; others use the shortest round-trip.
-fn fmt_f64(x: f64) -> String {
+fn f64_text(x: f64) -> String {
     if x.is_nan() {
         "NaN".to_string()
     } else if x.is_infinite() {
@@ -176,6 +178,37 @@ fn fmt_f64(x: f64) -> String {
     }
 }
 
+/// Render an `f64` as a JSON number, or `null` when JSON cannot represent it.
+fn f64_json(value: f64) -> String {
+    if value.is_finite() {
+        value.to_string()
+    } else {
+        "null".to_string()
+    }
+}
+
+/// Render an M1-width scalar without widening binary32 before formatting.
+fn m1_scalar_text(value: M1Scalar) -> String {
+    match value {
+        M1Scalar::FloatingPoint(value) if value.is_nan() => "NaN".to_string(),
+        M1Scalar::FloatingPoint(value) if value.is_infinite() => {
+            if value > 0.0 { "Infinity" } else { "-Infinity" }.to_string()
+        }
+        M1Scalar::FloatingPoint(value) => value.to_string(),
+        M1Scalar::Integer(value) => value.to_string(),
+        M1Scalar::UnsignedInteger(value) => value.to_string(),
+        M1Scalar::FixedPoint7dps(value) => value.to_string(),
+    }
+}
+
+/// Render an M1 scalar as JSON. JSON cannot represent non-finite binary32 values.
+fn m1_scalar_json(value: M1Scalar) -> String {
+    match value {
+        M1Scalar::FloatingPoint(value) if !value.is_finite() => "null".to_string(),
+        _ => m1_scalar_text(value),
+    }
+}
+
 /// Render a [`Value`] as a JSON scalar. Numbers are bare; booleans `true`/`false`;
 /// enums and strings are JSON strings.
 fn value_json(v: &Value) -> String {
@@ -183,7 +216,8 @@ fn value_json(v: &Value) -> String {
         Value::Bool(b) => b.to_string(),
         Value::Int(x) => x.to_string(),
         Value::Uint(x) => x.to_string(),
-        Value::Float(x) => fmt_f64(*x),
+        Value::Float(x) => f64_json(*x),
+        Value::M1(value) => m1_scalar_json(*value),
         Value::Enum { member, .. } => json_string(member),
         Value::Str(s) => json_string(s),
     }
@@ -195,7 +229,8 @@ fn value_csv(v: &Value) -> String {
         Value::Bool(b) => b.to_string(),
         Value::Int(x) => x.to_string(),
         Value::Uint(x) => x.to_string(),
-        Value::Float(x) => fmt_f64(*x),
+        Value::Float(x) => f64_text(*x),
+        Value::M1(value) => m1_scalar_text(*value),
         Value::Enum { member, .. } => member.clone(),
         Value::Str(s) => s.clone(),
     }
@@ -295,6 +330,53 @@ mod tests {
         assert_eq!(
             json,
             "{\"time\":[0],\"channels\":{\"A\":[true],\"B\":[2]},\"external\":[\"A\"]}"
+        );
+    }
+
+    #[test]
+    fn m1_width_scalars_serialize_without_host_width_artifacts() {
+        let mut tr = Trace::new();
+        tr.push_tick(0.0);
+        tr.record_channel("Float", Value::M1(M1Scalar::FloatingPoint(0.1)));
+        tr.record_channel(
+            "Fixed",
+            Value::M1(M1Scalar::FixedPoint7dps(
+                crate::value::FixedPoint7dps::from_raw(1_000_001),
+            )),
+        );
+        tr.record_channel("Int", Value::M1(M1Scalar::Integer(i32::MIN)));
+        tr.record_channel("Uint", Value::M1(M1Scalar::UnsignedInteger(u32::MAX)));
+
+        assert_eq!(
+            tr.to_json(),
+            "{\"time\":[0],\"channels\":{\"Fixed\":[0.1000001],\"Float\":[0.1],\"Int\":[-2147483648],\"Uint\":[4294967295]},\"external\":[]}"
+        );
+    }
+
+    #[test]
+    fn non_finite_floats_serialize_as_valid_json_nulls() {
+        let mut tr = Trace::new();
+        for (legacy, m1) in [
+            (f64::NAN, f32::NAN),
+            (f64::INFINITY, f32::INFINITY),
+            (f64::NEG_INFINITY, f32::NEG_INFINITY),
+        ] {
+            tr.push_tick(legacy);
+            tr.record_channel("Legacy", Value::Float(legacy));
+            tr.record_channel("M1", Value::M1(M1Scalar::FloatingPoint(m1)));
+        }
+
+        let json = tr.to_json();
+        assert_eq!(
+            json,
+            "{\"time\":[null,null,null],\"channels\":{\"Legacy\":[null,null,null],\"M1\":[null,null,null]},\"external\":[]}"
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("trace output must be valid JSON");
+        assert_eq!(parsed["time"], serde_json::json!([null, null, null]));
+        assert_eq!(
+            parsed["channels"]["M1"],
+            serde_json::json!([null, null, null])
         );
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,23 +1,156 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-//! Runtime value type and strict coercions.
+//! Runtime value types and strict coercions.
 //!
 //! M1 is strongly typed: there is no implicit `int -> bool` or `bool -> int`
-//! coercion. The numeric coercions here (`Int`/`Uint`/`Float -> f64`) exist
-//! only to drive arithmetic and table interpolation, which operate on `f64`
-//! internally. Anything non-numeric (`Bool`, `Enum`, `Str`) is an explicit
-//! `EvalError::TypeError` rather than a silent fallback — the evaluator never
+//! coercion. [`M1Scalar`] holds the actual M1-width numeric forms. The legacy
+//! `i64`/`u64`/`f64` variants on [`Value`] remain temporarily so the evaluator
+//! can migrate one boundary at a time without changing existing callers.
+//!
+//! The numeric coercions here exist only to drive code that has not migrated
+//! yet. Anything non-numeric (`Bool`, `Enum`, `Str`) is an explicit
+//! `EvalError::TypeError` rather than a silent fallback. The evaluator never
 //! substitutes a guessed numeric value.
 
 use crate::error::EvalError;
 use m1_typecheck::Project;
 
+/// The signed, 32-bit storage used by M1's seven-decimal-place fixed-point
+/// scalar. A raw value of `1` represents `0.0000001`.
+///
+/// This type only models storage and exact scale conversion. Language-level
+/// rounding and saturation belong to the conversion builtin, not this type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FixedPoint7dps(i32);
+
+impl FixedPoint7dps {
+    pub const SCALE: i64 = 10_000_000;
+    pub const MIN: Self = Self(i32::MIN);
+    pub const MAX: Self = Self(i32::MAX);
+    pub const ZERO: Self = Self(0);
+
+    /// Construct a value from its signed, scaled storage representation.
+    pub const fn from_raw(raw: i32) -> Self {
+        Self(raw)
+    }
+
+    /// Return the signed, scaled storage representation.
+    pub const fn raw(self) -> i32 {
+        self.0
+    }
+
+    /// Convert to a host float for temporary compatibility boundaries.
+    pub fn as_f64(self) -> f64 {
+        f64::from(self.0) / Self::SCALE as f64
+    }
+}
+
+impl std::fmt::Display for FixedPoint7dps {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let raw = i64::from(self.0);
+        let negative = raw < 0;
+        let magnitude = raw.abs();
+        let integer = magnitude / Self::SCALE;
+        let fractional = magnitude % Self::SCALE;
+
+        if negative {
+            formatter.write_str("-")?;
+        }
+        write!(formatter, "{integer}")?;
+        if fractional != 0 {
+            let digits = format!("{fractional:07}");
+            write!(formatter, ".{}", digits.trim_end_matches('0'))?;
+        }
+        Ok(())
+    }
+}
+
+/// Numeric values with the widths used by the M1 runtime.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum M1Scalar {
+    /// IEEE-754 binary32.
+    FloatingPoint(f32),
+    /// Signed 32-bit integer.
+    Integer(i32),
+    /// Unsigned 32-bit integer.
+    UnsignedInteger(u32),
+    /// Signed 32-bit integer scaled by 10^-7.
+    FixedPoint7dps(FixedPoint7dps),
+}
+
+/// Identifies one of the four numeric scalar types used by M1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum M1ScalarKind {
+    FloatingPoint,
+    Integer,
+    UnsignedInteger,
+    FixedPoint7dps,
+}
+
+impl M1Scalar {
+    /// Return this scalar's M1 type.
+    pub const fn kind(self) -> M1ScalarKind {
+        match self {
+            Self::FloatingPoint(_) => M1ScalarKind::FloatingPoint,
+            Self::Integer(_) => M1ScalarKind::Integer,
+            Self::UnsignedInteger(_) => M1ScalarKind::UnsignedInteger,
+            Self::FixedPoint7dps(_) => M1ScalarKind::FixedPoint7dps,
+        }
+    }
+
+    /// Widen to the host numeric format used by the temporary evaluator path.
+    pub fn as_f64(self) -> f64 {
+        match self {
+            Self::FloatingPoint(value) => f64::from(value),
+            Self::Integer(value) => f64::from(value),
+            Self::UnsignedInteger(value) => f64::from(value),
+            Self::FixedPoint7dps(value) => value.as_f64(),
+        }
+    }
+
+    /// Convert to one of the legacy numeric [`Value`] variants.
+    ///
+    /// This is an explicit compatibility boundary scheduled for removal with
+    /// the legacy execution path. Widening the three binary forms is lossless;
+    /// fixed point is represented by its scaled decimal value as an `f64`.
+    /// [`Value::try_as_m1_scalar_for`] restores the original scalar when the
+    /// caller supplies this value's [`M1ScalarKind`].
+    pub fn into_legacy_value(self) -> Value {
+        match self {
+            Self::FloatingPoint(value) => Value::Float(f64::from(value)),
+            Self::Integer(value) => Value::Int(i64::from(value)),
+            Self::UnsignedInteger(value) => Value::Uint(u64::from(value)),
+            Self::FixedPoint7dps(value) => Value::Float(value.as_f64()),
+        }
+    }
+}
+
+/// Identifies a temporary host-width numeric variant so migration code can
+/// count the legacy values still crossing a boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacyNumericKind {
+    Int64,
+    Uint64,
+    Float64,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Bool(bool),
+    /// Temporary signed host-width representation. Use [`Value::M1`] for new
+    /// M1-width values.
     Int(i64),
+    /// Temporary unsigned host-width representation. Use [`Value::M1`] for new
+    /// M1-width values.
     Uint(u64),
+    /// Temporary host-width floating representation. Use [`Value::M1`] for new
+    /// M1-width values.
     Float(f64),
-    Enum { id: usize, member: String },
+    /// A numeric value represented with its actual M1 width and signedness.
+    M1(M1Scalar),
+    Enum {
+        id: usize,
+        member: String,
+    },
     Str(String),
 }
 
@@ -29,10 +162,92 @@ impl Value {
             Value::Float(x) => Ok(*x),
             Value::Int(x) => Ok(*x as f64),
             Value::Uint(x) => Ok(*x as f64),
+            Value::M1(value) => Ok(value.as_f64()),
             other => Err(EvalError::TypeError {
                 detail: format!("{other:?} is not numeric"),
             }),
         }
+    }
+
+    /// Convert a numeric value to its unambiguous M1-width representation.
+    ///
+    /// Existing M1 values pass through unchanged. Legacy `Int` and `Uint` values
+    /// map to their matching M1 integer types. A legacy [`Value::Float`] is
+    /// ambiguous because it may represent either M1 `FloatingPoint` or
+    /// `FixedPoint7dps`, so this convenience method rejects it. Use
+    /// [`Value::try_as_m1_scalar_for`] at typed migration boundaries.
+    pub fn try_as_m1_scalar(&self) -> Result<M1Scalar, EvalError> {
+        match self {
+            Value::M1(value) => Ok(*value),
+            Value::Int(_) => self.try_as_m1_scalar_for(M1ScalarKind::Integer),
+            Value::Uint(_) => self.try_as_m1_scalar_for(M1ScalarKind::UnsignedInteger),
+            Value::Float(_) => Err(EvalError::TypeError {
+                detail: format!(
+                    "{self:?} is ambiguous between M1 FloatingPoint and FixedPoint7dps; use Value::try_as_m1_scalar_for"
+                ),
+            }),
+            other => Err(EvalError::TypeError {
+                detail: format!("{other:?} is not numeric"),
+            }),
+        }
+    }
+
+    /// Restore a value at a typed legacy-to-M1 compatibility boundary.
+    ///
+    /// This conversion restores storage identity; it is not a language cast.
+    /// Legacy `Int`, `Uint`, and `Float` values must target their corresponding
+    /// storage family. `Float` may target either `FloatingPoint` or
+    /// `FixedPoint7dps`, which resolves the ambiguity in the legacy model.
+    /// Fixed Point restoration accepts only values exactly produced by the 7dps
+    /// scale, so it recovers the original raw `i32` without applying the rounding
+    /// or saturation rules owned by `Convert.ToFixed7DP`.
+    pub fn try_as_m1_scalar_for(&self, target: M1ScalarKind) -> Result<M1Scalar, EvalError> {
+        match (self, target) {
+            (Value::M1(value), target) if value.kind() == target => Ok(*value),
+            (Value::M1(value), target) => Err(incompatible_scalar_kind(*value, target)),
+            (Value::Int(value), M1ScalarKind::Integer) => i32::try_from(*value)
+                .map(M1Scalar::Integer)
+                .map_err(|_| numeric_width_error(self, "Integer (i32)")),
+            (Value::Uint(value), M1ScalarKind::UnsignedInteger) => u32::try_from(*value)
+                .map(M1Scalar::UnsignedInteger)
+                .map_err(|_| numeric_width_error(self, "UnsignedInteger (u32)")),
+            (Value::Float(value), M1ScalarKind::FloatingPoint) => {
+                let narrowed = *value as f32;
+                if value.is_finite() && narrowed.is_infinite() {
+                    Err(numeric_width_error(self, "FloatingPoint (binary32)"))
+                } else {
+                    Ok(M1Scalar::FloatingPoint(narrowed))
+                }
+            }
+            (Value::Float(value), M1ScalarKind::FixedPoint7dps) => {
+                restore_fixed_point_7dps(self, *value).map(M1Scalar::FixedPoint7dps)
+            }
+            (Value::Int(_) | Value::Uint(_) | Value::Float(_), target) => {
+                Err(incompatible_legacy_kind(self, target))
+            }
+            (other, _) => Err(EvalError::TypeError {
+                detail: format!("{other:?} is not numeric"),
+            }),
+        }
+    }
+
+    /// Identify the temporary host-width numeric form, if this value uses one.
+    /// This makes remaining legacy traffic countable during the migration.
+    pub const fn legacy_numeric_kind(&self) -> Option<LegacyNumericKind> {
+        match self {
+            Value::Int(_) => Some(LegacyNumericKind::Int64),
+            Value::Uint(_) => Some(LegacyNumericKind::Uint64),
+            Value::Float(_) => Some(LegacyNumericKind::Float64),
+            _ => None,
+        }
+    }
+
+    /// Whether this is either an M1-width or temporary legacy numeric value.
+    pub const fn is_numeric(&self) -> bool {
+        matches!(
+            self,
+            Value::Int(_) | Value::Uint(_) | Value::Float(_) | Value::M1(_)
+        )
     }
 
     /// Extract a boolean. M1 has no truthiness on numbers, so only `Bool`
@@ -79,6 +294,48 @@ impl Value {
                 ),
             })
     }
+}
+
+fn numeric_width_error(value: &Value, target: &str) -> EvalError {
+    EvalError::TypeError {
+        detail: format!("{value:?} is outside the range of M1 {target}"),
+    }
+}
+
+fn incompatible_scalar_kind(value: M1Scalar, target: M1ScalarKind) -> EvalError {
+    EvalError::TypeError {
+        detail: format!(
+            "M1 {:?} cannot be restored as M1 {target:?}; language casts are not compatibility conversions",
+            value.kind()
+        ),
+    }
+}
+
+fn incompatible_legacy_kind(value: &Value, target: M1ScalarKind) -> EvalError {
+    EvalError::TypeError {
+        detail: format!(
+            "{value:?} cannot restore M1 {target:?}; language casts are not compatibility conversions"
+        ),
+    }
+}
+
+fn restore_fixed_point_7dps(source: &Value, value: f64) -> Result<FixedPoint7dps, EvalError> {
+    if !value.is_finite() {
+        return Err(numeric_width_error(source, "FixedPoint7dps"));
+    }
+
+    let scaled = value * FixedPoint7dps::SCALE as f64;
+    if scaled < f64::from(i32::MIN) || scaled > f64::from(i32::MAX) {
+        return Err(numeric_width_error(source, "FixedPoint7dps"));
+    }
+
+    let restored = FixedPoint7dps::from_raw(scaled.round() as i32);
+    if restored.as_f64().to_bits() != value.to_bits() {
+        return Err(EvalError::TypeError {
+            detail: format!("{source:?} is not an exact M1 FixedPoint7dps compatibility value"),
+        });
+    }
+    Ok(restored)
 }
 
 #[cfg(test)]
@@ -147,7 +404,237 @@ mod tests {
         assert_eq!(Value::Float(2.5).as_f64().unwrap(), 2.5);
         assert_eq!(Value::Int(-3).as_f64().unwrap(), -3.0);
         assert_eq!(Value::Uint(7).as_f64().unwrap(), 7.0);
+        assert_eq!(
+            Value::M1(M1Scalar::FloatingPoint(2.5)).as_f64().unwrap(),
+            2.5
+        );
+        assert_eq!(
+            Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(
+                12_345_678
+            )))
+            .as_f64()
+            .unwrap(),
+            1.2345678
+        );
         assert!(Value::Str("x".into()).as_f64().is_err());
+    }
+
+    #[test]
+    fn m1_scalar_boundaries_are_explicit() {
+        assert_eq!(
+            Value::Int(i64::from(i32::MIN)).try_as_m1_scalar().unwrap(),
+            M1Scalar::Integer(i32::MIN)
+        );
+        assert_eq!(
+            Value::Int(i64::from(i32::MAX)).try_as_m1_scalar().unwrap(),
+            M1Scalar::Integer(i32::MAX)
+        );
+        assert!(
+            Value::Int(i64::from(i32::MIN) - 1)
+                .try_as_m1_scalar()
+                .is_err()
+        );
+        assert!(
+            Value::Int(i64::from(i32::MAX) + 1)
+                .try_as_m1_scalar()
+                .is_err()
+        );
+
+        assert_eq!(
+            Value::Uint(0).try_as_m1_scalar().unwrap(),
+            M1Scalar::UnsignedInteger(0)
+        );
+        assert_eq!(
+            Value::Uint(u64::from(u32::MAX)).try_as_m1_scalar().unwrap(),
+            M1Scalar::UnsignedInteger(u32::MAX)
+        );
+        assert!(
+            Value::Uint(u64::from(u32::MAX) + 1)
+                .try_as_m1_scalar()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn binary32_conversion_exposes_precision_and_range() {
+        let narrowed = Value::Float(16_777_217.0)
+            .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
+            .unwrap();
+        assert_eq!(narrowed, M1Scalar::FloatingPoint(16_777_216.0));
+        assert_eq!(narrowed.into_legacy_value(), Value::Float(16_777_216.0));
+
+        assert_eq!(
+            Value::Float(f64::from(f32::MIN))
+                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
+                .unwrap(),
+            M1Scalar::FloatingPoint(f32::MIN)
+        );
+        assert_eq!(
+            Value::Float(f64::from(f32::MAX))
+                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
+                .unwrap(),
+            M1Scalar::FloatingPoint(f32::MAX)
+        );
+        let smallest_subnormal = f32::from_bits(1);
+        assert_eq!(
+            Value::Float(f64::from(smallest_subnormal))
+                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
+                .unwrap(),
+            M1Scalar::FloatingPoint(smallest_subnormal)
+        );
+        let negative_zero = Value::Float(-0.0)
+            .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
+            .unwrap();
+        assert!(matches!(
+            negative_zero,
+            M1Scalar::FloatingPoint(value) if value.to_bits() == (-0.0_f32).to_bits()
+        ));
+        assert!(
+            Value::Float(f64::MAX)
+                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
+                .is_err()
+        );
+        assert!(matches!(
+            Value::Float(f64::NAN).try_as_m1_scalar_for(M1ScalarKind::FloatingPoint),
+            Ok(M1Scalar::FloatingPoint(value)) if value.is_nan()
+        ));
+        assert_eq!(
+            Value::Float(f64::NEG_INFINITY)
+                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
+                .unwrap(),
+            M1Scalar::FloatingPoint(f32::NEG_INFINITY)
+        );
+    }
+
+    #[test]
+    fn inferred_conversion_rejects_ambiguous_legacy_float_storage() {
+        assert!(Value::Float(1.0).try_as_m1_scalar().is_err());
+        assert_eq!(
+            Value::Int(-1).try_as_m1_scalar().unwrap(),
+            M1Scalar::Integer(-1)
+        );
+        assert_eq!(
+            Value::Uint(1).try_as_m1_scalar().unwrap(),
+            M1Scalar::UnsignedInteger(1)
+        );
+
+        let fixed = M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(1));
+        assert_eq!(Value::M1(fixed).try_as_m1_scalar().unwrap(), fixed);
+    }
+
+    #[test]
+    fn every_m1_scalar_has_an_explicit_legacy_compatibility_conversion() {
+        assert_eq!(
+            M1Scalar::Integer(i32::MIN).into_legacy_value(),
+            Value::Int(i64::from(i32::MIN))
+        );
+        assert_eq!(
+            M1Scalar::UnsignedInteger(u32::MAX).into_legacy_value(),
+            Value::Uint(u64::from(u32::MAX))
+        );
+        assert_eq!(
+            M1Scalar::FloatingPoint(f32::MIN_POSITIVE).into_legacy_value(),
+            Value::Float(f64::from(f32::MIN_POSITIVE))
+        );
+        assert_eq!(
+            M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(-1)).into_legacy_value(),
+            Value::Float(-0.0000001)
+        );
+    }
+
+    #[test]
+    fn every_m1_scalar_kind_round_trips_through_legacy_storage() {
+        let scalars = [
+            M1Scalar::FloatingPoint(-0.0),
+            M1Scalar::FloatingPoint(f32::from_bits(1)),
+            M1Scalar::FloatingPoint(f32::MIN),
+            M1Scalar::FloatingPoint(f32::MAX),
+            M1Scalar::Integer(i32::MIN),
+            M1Scalar::Integer(i32::MAX),
+            M1Scalar::UnsignedInteger(0),
+            M1Scalar::UnsignedInteger(u32::MAX),
+            M1Scalar::FixedPoint7dps(FixedPoint7dps::MIN),
+            M1Scalar::FixedPoint7dps(FixedPoint7dps::MAX),
+        ];
+
+        for scalar in scalars {
+            let legacy = scalar.into_legacy_value();
+            let restored = legacy.try_as_m1_scalar_for(scalar.kind()).unwrap();
+            assert_eq!(restored, scalar, "failed to restore {scalar:?}");
+        }
+    }
+
+    #[test]
+    fn fixed_point_legacy_round_trip_restores_exact_raw_storage() {
+        for raw in [i32::MIN, -12_345_678, -1, 0, 1, 12_345_678, i32::MAX] {
+            let scalar = M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(raw));
+            let legacy = scalar.into_legacy_value();
+            assert_eq!(
+                legacy
+                    .try_as_m1_scalar_for(M1ScalarKind::FixedPoint7dps)
+                    .unwrap(),
+                scalar,
+                "failed to restore fixed-point raw value {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_point_compatibility_restore_rejects_lossy_values_and_language_casts() {
+        for value in [1.23456789, -0.0, 214.7483648, f64::NAN, f64::INFINITY] {
+            assert!(
+                Value::Float(value)
+                    .try_as_m1_scalar_for(M1ScalarKind::FixedPoint7dps)
+                    .is_err(),
+                "unexpectedly restored {value:?} as exact fixed point"
+            );
+        }
+
+        assert!(
+            Value::Int(1)
+                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
+                .is_err()
+        );
+        assert!(
+            Value::M1(M1Scalar::Integer(1))
+                .try_as_m1_scalar_for(M1ScalarKind::UnsignedInteger)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn fixed_point_7dps_uses_signed_scaled_i32_storage() {
+        let positive = FixedPoint7dps::from_raw(12_345_678);
+        let negative = FixedPoint7dps::from_raw(-12_345_678);
+        assert_eq!(positive.raw(), 12_345_678);
+        assert_eq!(positive.as_f64(), 1.2345678);
+        assert_eq!(negative.as_f64(), -1.2345678);
+        assert_eq!(FixedPoint7dps::ZERO.as_f64(), 0.0);
+        assert_eq!(FixedPoint7dps::MIN.as_f64(), -214.7483648);
+        assert_eq!(FixedPoint7dps::MAX.as_f64(), 214.7483647);
+
+        assert_eq!(
+            M1Scalar::FixedPoint7dps(positive).into_legacy_value(),
+            Value::Float(1.2345678)
+        );
+    }
+
+    #[test]
+    fn legacy_numeric_forms_are_measurable() {
+        assert_eq!(
+            Value::Int(0).legacy_numeric_kind(),
+            Some(LegacyNumericKind::Int64)
+        );
+        assert_eq!(
+            Value::Uint(0).legacy_numeric_kind(),
+            Some(LegacyNumericKind::Uint64)
+        );
+        assert_eq!(
+            Value::Float(0.0).legacy_numeric_kind(),
+            Some(LegacyNumericKind::Float64)
+        );
+        assert_eq!(Value::M1(M1Scalar::Integer(0)).legacy_numeric_kind(), None);
+        assert_eq!(Value::Bool(false).legacy_numeric_kind(), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #36

## Summary
- add explicit binary32, signed 32-bit, unsigned 32-bit, and Fixed Point 7dps runtime scalar forms
- keep the legacy host-width variants behind named, range-checked compatibility conversions
- make remaining legacy values countable and serialize M1-width values without host-width formatting artifacts
- cover width, range, sign, precision, fixed-point scale, and compatibility boundaries

## Verification
- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked
- cargo test --locked --features ld
- RUSTDOCFLAGS=-D warnings cargo doc --locked --no-deps
- git diff --check