### PR TITLE
Use one project-aware capability model for dispatch and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,17 @@ The multi-rate model:
 ### `--coverage`
 
 Before running, `m1-eval --coverage` reports, per project, which builtins and
-constructs each script uses and whether the engine **implements**, **stubs**, or
-does **not support** them. `Supported` is an implementation label, not a
+constructs each script uses and whether the engine **implements** them directly,
+evaluates them under a documented **assumption** that still needs M1 conformance
+evidence, **stubs** them (Tier-3 IO, externally driven), or does **not support**
+them (would fail loud at runtime). `Supported` is an implementation label, not a
 **Verified** maturity claim.
 
 The report also prints a **`Schedule:`** section: every script-backed function
-with its execution rate (`@ 500 Hz`, `@ 50 Hz`, …), or *unscheduled* for a
-function with no periodic trigger. This makes a `whole-project` run transparent —
-you see exactly which functions the scheduler will run, at what rate, and which
-are excluded — before you run it.
+with its execution rate (`@ 500 Hz`, `@ 50 Hz`, …), `startup, runs once`, or
+*unscheduled*. This makes a `whole-project` run transparent — you see exactly
+which functions the scheduler will run, at what rate, and which are excluded —
+before you run it.
 
 ## Quickstart
 
@@ -159,7 +161,7 @@ Seed an ordinary hardware channel with scenario `[[inputs]]`. Seed a
 hardware-backed builtin call with `[[io]]`, using its exact `Object.Method` name.
 Without those seeds, function and cone runs fail on an ordinary missing channel,
 while Tier-3 calls use the **Stubbed** contract. Run `--coverage` first to see the
-implemented, stubbed, and unsupported calls in a project.
+implemented, assumed, stubbed, and unsupported calls in a project.
 
 Whole-project mode is strict about ordinary missing channels unless
 `allow_default_inputs = true` or `--allow-default-inputs` is set. The CLI then

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,7 +29,7 @@ m1-eval [--project P] [--config C]
 | `--log <PATH>` | Counterfactual replay: a recorded MoTeC log held as ground truth (`.csv`, or `.ld` with `--features ld`). Triggers a counterfactual run instead of a scenario run. |
 | `--override <CH=expr>` | Pin a logged channel to a constant or expression for the counterfactual run, recomputing only its downstream cone. Repeatable (override several channels). Requires `--log`. |
 | `--diff <PATH>` | Where to write the per-channel logged-vs-counterfactual delta. Format follows the extension (`.csv` / `.json`). Requires `--log`. |
-| `--coverage` | Print the coverage report (supported / stubbed / unsupported builtins and constructs, plus the per-function execution `Schedule:`) instead of, or alongside, a run. |
+| `--coverage` | Print the coverage report (supported / assumed / stubbed / unsupported builtins and constructs, plus the per-function execution `Schedule:`) instead of, or alongside, a run. |
 | `--version`, `-V` | Print the version and exit `0`. |
 | `--help`, `-h` | Print usage and exit `0`. |
 

--- a/docs/specs/2026-06-23-m1-eval-design.md
+++ b/docs/specs/2026-06-23-m1-eval-design.md
@@ -191,8 +191,9 @@ silently-wrong number):
   real EV-M1 scripts, using tolerance-based floating-point comparison; divergences
   documented.
 - **`m1-eval --coverage <project>`** reports, before running, which builtins/constructs
-  each script uses and whether the engine implements or stubs them — so the user knows
-  what is implemented versus externally driven.
+  each script uses and whether the engine implements them directly, evaluates them under
+  a documented assumption, stubs them, or has no implementation. `Supported` does not
+  imply M1 verification.
 
 ## Interfaces & ecosystem integration
 

--- a/src/bin/m1_eval.rs
+++ b/src/bin/m1_eval.rs
@@ -86,7 +86,7 @@ struct Args {
     out: Option<PathBuf>,
 
     /// Print the coverage report (which constructs/builtins are supported,
-    /// stubbed, or unsupported) instead of, or alongside, running.
+    /// assumed, stubbed, or unsupported) instead of, or alongside, running.
     #[arg(long)]
     coverage: bool,
 

--- a/src/builtins/io_stub.rs
+++ b/src/builtins/io_stub.rs
@@ -35,14 +35,18 @@ use crate::expr::EvalCtx;
 use crate::value::Value;
 use m1_typecheck::intrinsics;
 
-/// Evaluate one Tier-3 IO call. See the module docs for the resolution order.
+/// Evaluate one Tier-3 IO call. `library_object` is the canonical intrinsic
+/// catalog object. `source_object` keeps the exact spelling used for scenario
+/// overrides, trace keys, and errors. See the module docs for the resolution
+/// order.
 pub fn call(
-    object: &str,
+    library_object: &str,
+    source_object: &str,
     method: &str,
     args: &[Value],
     ctx: &mut EvalCtx,
 ) -> Result<Value, EvalError> {
-    let key = format!("{object}.{method}");
+    let key = format!("{source_object}.{method}");
 
     // 1. Scenario override wins.
     if let Some(v) = ctx.env.io_override(&key).cloned() {
@@ -51,7 +55,7 @@ pub fn call(
     }
 
     // 2. Specific documented offline stubs (a *meaningful* offline value).
-    if let Some(v) = documented_stub(object, method, args, ctx)? {
+    if let Some(v) = documented_stub(library_object, method, args, ctx)? {
         mark_external(ctx, &key);
         return Ok(v);
     }
@@ -61,7 +65,7 @@ pub fn call(
     //    value, but a determinate return *type* — so return the type-correct
     //    default rather than abort the run on the first CAN read. The default is
     //    the externally-driven value a scenario / log replay would override.
-    if let Some(v) = typed_io_default(object, method) {
+    if let Some(v) = typed_io_default(library_object, method) {
         mark_external(ctx, &key);
         return Ok(v);
     }
@@ -69,7 +73,7 @@ pub fn call(
     // 4. Fail loud — the method is not in the registry for this object, so it is
     //    genuinely unknown. We never fabricate a value for an unknown method.
     Err(EvalError::UnsupportedBuiltin {
-        object: object.to_string(),
+        object: source_object.to_string(),
         method: method.to_string(),
     })
 }
@@ -369,6 +373,25 @@ mod tests {
             Value::Float(12.5)
         );
         assert!(h.trace.is_external("CanComms.GetFloat"));
+    }
+
+    #[test]
+    fn library_anchor_keeps_source_spelling_for_io_override_and_trace() {
+        let mut h = Harness::new();
+        h.env
+            .set_io_override("Library.CanComms.GetFloat", Value::Float(12.5));
+
+        assert_eq!(
+            h.io(
+                "Library.CanComms",
+                "GetFloat",
+                &[Value::Uint(0), Value::Int(0)]
+            )
+            .unwrap(),
+            Value::Float(12.5)
+        );
+        assert!(h.trace.is_external("Library.CanComms.GetFloat"));
+        assert!(!h.trace.is_external("CanComms.GetFloat"));
     }
 
     #[test]

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -32,8 +32,11 @@ use crate::error::EvalError;
 use crate::expr::EvalCtx;
 use crate::ident::{Target, classify};
 use crate::value::Value;
+use m1_typecheck::Project;
 use m1_typecheck::intrinsics;
+use m1_typecheck::parsed::ParsedScript;
 use m1_typecheck::symbols::SymbolKind;
+use std::collections::HashMap;
 
 /// Dispatch one builtin call `object.method(args)`.
 ///
@@ -43,12 +46,9 @@ use m1_typecheck::symbols::SymbolKind;
 /// to key per-occurrence state. `ctx` carries the evaluation environment
 /// (project model, calibration, value/state stores, `dt`, lexical context).
 ///
-/// Resolution order:
-/// 1. A `Lookup` method on a project [`SymbolKind::Table`] object → table
-///    interpolation over the calibration.
-/// 2. A pure library object (`Calculate`/`Limit`/`Convert`) → the matching
-///    submodule, after arity validation against the intrinsic library.
-/// 3. Anything else → fail loud ([`EvalError::UnsupportedBuiltin`]).
+/// The shared capability model first resolves the receiver and selects the
+/// concrete route: user function, library implementation, project table/enum/
+/// channel/timer, documented IO stub, or fail-loud unsupported call.
 pub fn dispatch(
     object: &str,
     method: &str,
@@ -56,36 +56,33 @@ pub fn dispatch(
     site: CallSite,
     ctx: &mut EvalCtx,
 ) -> Result<Value, EvalError> {
-    // 1. Table `.Lookup()` — the object is a project table symbol, not a library
-    //    object. Classify it against the project; a Table + `Lookup` interpolates.
-    if method == "Lookup"
-        && let Some(value) = try_table_lookup(object, args, ctx)?
-    {
-        return Ok(value);
-    }
-    // 1b. Table `.Get(site)` — a raw read of one body cell by flat site index
-    //     (row-major), no interpolation. Same object classification as Lookup.
-    if method == "Get"
-        && let Some(value) = try_table_get(object, args, ctx)?
-    {
-        return Ok(value);
-    }
+    let capability = {
+        let scope = CapabilityScope {
+            project: Some(ctx.project),
+            group: ctx.group,
+            fn_symbol: ctx.fn_symbol,
+            locals: Some(&ctx.env.locals),
+            scripts: ctx.scripts,
+        };
+        classify_member_call(object, method, &scope)
+    };
 
-    // 2. Pure library objects. Validate arity against the intrinsic signatures
-    //    first (a wrong arg count is a BadCall, an unknown method an
-    //    UnsupportedBuiltin), then route to the implementing submodule.
-    match object {
-        "Calculate" | "Limit" | "Convert" => {
-            validate_arity(object, method, args.len())?;
-            // A stateful `Calculate.*` method (Stable/Hysteresis/Between/Beyond)
-            // is a time-domain operator, not a pure one: route it to the stateful
-            // engine. The pure `Calculate.*` math stays in its own submodule.
-            if object == "Calculate"
-                && let Some(v) = stateful::call(object, method, args, site.clone(), ctx)?
-            {
-                return Ok(v);
-            }
-            let result = match object {
+    match capability.route {
+        CallRoute::UserFunction(canon) => match userfn::call(&canon, args, ctx)? {
+            Some(value) => Ok(value),
+            None => Err(unsupported(object, method)),
+        },
+        CallRoute::TableLookup => match try_table_lookup(object, args, ctx)? {
+            Some(value) => Ok(value),
+            None => Err(unsupported(object, method)),
+        },
+        CallRoute::TableGet => match try_table_get(object, args, ctx)? {
+            Some(value) => Ok(value),
+            None => Err(unsupported(object, method)),
+        },
+        CallRoute::PureLibrary(library_object) => {
+            validate_arity(&library_object, object, method, args.len())?;
+            let result = match library_object.as_str() {
                 "Calculate" => calculate::call(method, args)?,
                 "Limit" => limit::call(method, args)?,
                 "Convert" => convert::call(method, args)?,
@@ -98,30 +95,18 @@ pub fn dispatch(
                 None => Err(unsupported(object, method)),
             }
         }
-        // 3. Stateful (time-domain) library objects: each is a state machine keyed
-        //    by `site` and advanced by `ctx.dt`. Validate arity, then evaluate.
-        "Filter" | "Integral" | "Derivative" | "Debounce" | "Delay" | "Change" => {
-            validate_arity(object, method, args.len())?;
-            match stateful::call(object, method, args, site, ctx)? {
+        CallRoute::StatefulLibrary(library_object) => {
+            validate_arity(&library_object, object, method, args.len())?;
+            match stateful::call(&library_object, method, args, site, ctx)? {
                 Some(v) => Ok(v),
-                // The object is stateful but this specific method is not yet
-                // implemented (e.g. the buffered `Delay.SignalN`): fail loud.
                 None => Err(unsupported(object, method)),
             }
         }
-        // 4. Tier-3 IO objects: scenario-fed / documented stubs.
-        "CanComms" | "Serial" | "System" | "Logging" => io_stub::call(object, method, args, ctx),
-        // 4b. `Math` is a *calibration-only* library object (its functions are
-        //     flagged `calibrationOnly` in the intrinsics) and is not, strictly,
-        //     valid in ECU `.m1scr` scripts — yet real EV-M1 control scripts
-        //     reference `Math.atan2`. We route that one function to the same
-        //     `y.atan2(x)` as `Calculate.InverseTan2` (a pragmatic implementation)
-        //     and flag it `Stubbed` in coverage so the user sees it is
-        //     a calibration-only object surfaced in an ECU script. Every other
-        //     `Math.*` method is left to fail loud (we do not implement the
-        //     calibration maths library wholesale).
-        "Math" => {
-            validate_arity(object, method, args.len())?;
+        CallRoute::IoLibrary(library_object) => {
+            io_stub::call(&library_object, object, method, args, ctx)
+        }
+        CallRoute::MathAssumption(library_object) => {
+            validate_arity(&library_object, object, method, args.len())?;
             match method {
                 "atan2" => {
                     let y = args[0].as_f64()?;
@@ -135,72 +120,58 @@ pub fn dispatch(
                 _ => Err(unsupported(object, method)),
             }
         }
-        // 5. Not a library object and not a table lookup. It may be a project
-        //    object (e.g. a `Timer`) carrying an intrinsic object-method, or
-        //    something genuinely unsupported.
-        _ => dispatch_object_method(object, method, args, site, ctx),
+        CallRoute::EnumAsInteger => {
+            validate_object_arity(object, method, args.len())?;
+            match enum_conv::as_integer(object, ctx)? {
+                Some(value) => Ok(value),
+                None => Err(unsupported(object, method)),
+            }
+        }
+        CallRoute::ChannelSet => match try_channel_set(object, args, ctx)? {
+            Some(value) => Ok(value),
+            None => Err(unsupported(object, method)),
+        },
+        CallRoute::Timer => {
+            validate_object_arity(object, method, args.len())?;
+            let object_key = timer_object_key(object, ctx);
+            match stateful::timer(method, args, object_key, ctx)? {
+                Some(value) => Ok(value),
+                None => Err(unsupported(object, method)),
+            }
+        }
+        CallRoute::ProjectIo => io_stub::project_object_call(object, method, args, ctx),
+        CallRoute::Unsupported => Err(unsupported(object, method)),
     }
 }
 
-/// Dispatch a method call whose `object` is not a firmware library object — it is
-/// a project object (a `Timer`, an enum source, a CAN signal, …) carrying an
-/// *object method* (`AsInteger`/`Start`/`Remaining`/`Receive`/…) from the
-/// intrinsic registry. The enum `.AsInteger` accessor and the stateful `Timer`
-/// methods are implemented; everything else fails loud.
-fn dispatch_object_method(
-    object: &str,
-    method: &str,
+/// Dispatch a bare user-function call such as `Update(...)`. Bare callees cannot
+/// name a library builtin, so the shared capability model either resolves a
+/// script-backed function or rejects the call.
+pub(crate) fn dispatch_bare(
+    callee: &str,
     args: &[Value],
-    _site: CallSite,
+    site: CallSite,
     ctx: &mut EvalCtx,
 ) -> Result<Value, EvalError> {
-    // Enum `.AsInteger()` — always called with empty parens. The object is either
-    // an enum-type-qualified member literal (`Drive State.Idle`) or a
-    // value-holding enum source (an enum channel / value-compound). Resolved at
-    // runtime against the enum model; an object that is no enum source returns
-    // `Ok(None)` here and falls through to the Timer attempt below. An object that
-    // *is* an enum source but cannot convert (unknown member, unset channel)
-    // fails loud inside `as_integer`.
-    if method == "AsInteger"
-        && args.is_empty()
-        && let Some(v) = enum_conv::as_integer(object, ctx)?
+    let capability = {
+        let scope = CapabilityScope {
+            project: Some(ctx.project),
+            group: ctx.group,
+            fn_symbol: ctx.fn_symbol,
+            locals: Some(&ctx.env.locals),
+            scripts: ctx.scripts,
+        };
+        classify_bare_call(callee, &scope)
+    };
+    if let CallRoute::UserFunction(canon) = capability.route
+        && let Some(value) = userfn::call(&canon, args, ctx)?
     {
-        return Ok(v);
+        return Ok(value);
     }
-
-    // Channel `.Set(value)` — the imperative setter. When the object resolves to a
-    // `Channel`/`Parameter` symbol, this is a *write* of that channel (exactly
-    // what `m1-typecheck` `schedule.rs` and `summary::io_sets` treat `Chan.Set*`
-    // as), not a fail-loud unknown method. Falls through to IO/Timer routing when
-    // the object is not a channel.
-    if method == "Set"
-        && let Some(v) = try_channel_set(object, args, ctx)?
-    {
-        return Ok(v);
-    }
-
-    // Project-object IO (DBC CAN messages/signals, a `Service Bits` GroupCompound
-    // push, a package `Output.SetState`, a buzzer's `.Buzze`). These are the
-    // project-object analogue of the Tier-3 library stubs: externally driven,
-    // never truly evaluated offline. Route an object that classifies to a
-    // package/group/reference symbol — or an unresolved DBC object (no `.m1dbc`
-    // loaded) — through the IO stub, *before* the Timer fallback so a real Timer
-    // (which resolves to its own object) is never swallowed by a stub method that
-    // a Timer does not carry.
-    if is_io_stub_object(object, ctx) && is_project_object_io_method(method) {
-        return io_stub::project_object_call(object, method, args, ctx);
-    }
-
-    // The Timer object methods (Start/Stop/Reset/Remaining) are stateful and must
-    // share one countdown across all of an object's method calls — so key the
-    // state by the object *path*, not the individual call site. A canonical path
-    // is preferred (so `This.MyTimer` and `Root.Demo.MyTimer` address the same
-    // timer); fall back to the source spelling if the object does not resolve.
-    let object_key = timer_object_key(object, ctx);
-    if let Some(v) = stateful::timer(method, args, object_key, ctx)? {
-        return Ok(v);
-    }
-    Err(unsupported(object, method))
+    Err(EvalError::UnsupportedConstruct {
+        kind: format!("call to non-function {callee:?}"),
+        at: site.offset(),
+    })
 }
 
 /// Attempt a channel `.Set(value)` imperative setter. Returns `Ok(Some(unit))`
@@ -252,47 +223,6 @@ fn try_channel_set(
     // The setter is a statement-level write; reuse the unit value the IO void
     // writers return so an expression-statement call succeeds.
     Ok(Some(Value::Bool(true)))
-}
-
-/// Whether `method` is a project-object IO stub method (a CAN Tx/Get/Receive, a
-/// GroupCompound `.Update`, an `Output.SetState`, a buzzer `.Buzze`).
-fn is_project_object_io_method(method: &str) -> bool {
-    io_stub::PROJECT_OBJECT_STUB_METHODS.contains(&method)
-}
-
-/// Whether `object` is a project object whose IO methods are externally-driven
-/// stubs: it classifies to a package/group/reference symbol (`Object`/`Group`/
-/// `Reference`/`Other`) — or it does not resolve at all, which is how a DBC CAN
-/// object appears when no `.m1dbc` is loaded. A library object, a channel, a
-/// table, or a function is *not* an IO-stub object (each has its own route).
-fn is_io_stub_object(object: &str, ctx: &EvalCtx) -> bool {
-    match classify(
-        object,
-        ctx.group,
-        ctx.fn_symbol,
-        ctx.project,
-        &ctx.env.locals,
-    ) {
-        Target::Symbol(canon) => ctx
-            .project
-            .symbols()
-            .get(&canon)
-            .map(|s| {
-                matches!(
-                    s.kind,
-                    SymbolKind::Object
-                        | SymbolKind::Group
-                        | SymbolKind::Reference
-                        | SymbolKind::Other
-                )
-            })
-            .unwrap_or(false),
-        // An unresolved object spelling is the DBC case (the CAN message/signal is
-        // sourced from a `.m1dbc` we did not load). A builtin/library object or a
-        // resolved local is handled elsewhere and is never an IO-stub object.
-        Target::Unresolved => true,
-        Target::Local(_) | Target::Builtin { .. } => false,
-    }
 }
 
 /// The state key for a Timer object: a [`CallSite`] whose script slot is the
@@ -472,10 +402,36 @@ fn try_table_get(
 /// signature registry. The method must exist on the object (else
 /// [`EvalError::UnsupportedBuiltin`]) and `argc` must match some overload's
 /// parameter count (else [`EvalError::BadCall`]).
-fn validate_arity(object: &str, method: &str, argc: usize) -> Result<(), EvalError> {
-    let overloads = intrinsics::get().library_overloads(object, method);
+fn validate_arity(
+    library_object: &str,
+    source_object: &str,
+    method: &str,
+    argc: usize,
+) -> Result<(), EvalError> {
+    let overloads = intrinsics::get().library_overloads(library_object, method);
     if overloads.is_empty() {
         // The registry lists no such method on this object.
+        return Err(unsupported(source_object, method));
+    }
+    let accepted: Vec<usize> = overloads.iter().map(|o| o.params.len()).collect();
+    if accepted.contains(&argc) {
+        Ok(())
+    } else {
+        Err(EvalError::BadCall {
+            detail: format!(
+                "{source_object}.{method} expects {} argument(s), got {argc}",
+                arities_display(&accepted)
+            ),
+        })
+    }
+}
+
+/// Validate a resolved project-object method against the object-method catalog.
+/// Receiver eligibility has already been decided by the capability model; this
+/// check only enforces the declared argument count.
+fn validate_object_arity(object: &str, method: &str, argc: usize) -> Result<(), EvalError> {
+    let overloads = intrinsics::get().object_method(method);
+    if overloads.is_empty() {
         return Err(unsupported(object, method));
     }
     let accepted: Vec<usize> = overloads.iter().map(|o| o.params.len()).collect();
@@ -511,25 +467,68 @@ fn unsupported(object: &str, method: &str) -> EvalError {
     }
 }
 
-/// How the engine handles a given builtin `Object.Method`. Drives the `--coverage`
-/// report (Task 28): a method is **supported** when the dispatch table evaluates
-/// it directly, **stubbed** when a Tier-3 IO object returns a documented offline
-/// value (or is scenario-fed), and **unsupported** when no branch implements it
-/// (it would fail loud at runtime).
+/// What the evaluator does with a resolved call. Runtime dispatch and coverage
+/// both consume this classification, so the report describes the route that will
+/// actually run for this receiver in this project.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinSupport {
     /// Implemented by the dispatch table under the documented maturity contract.
     Supported,
+    /// A deterministic implementation whose exact M1 behavior still needs
+    /// conformance evidence.
+    Assumed,
     /// A Tier-3 IO object handled as a documented/scenario-fed stub.
     Stubbed,
     /// Not implemented — fails loud at runtime.
     Unsupported,
 }
 
-/// Library/object methods implemented by the evaluator (Tier-1 + Tier-2). Kept in sync
-/// with the dispatch arms above; this is the single source of truth the coverage
-/// report consults so it never disagrees with what `dispatch` actually evaluates.
-const SUPPORTED_METHODS: &[(&str, &str)] = &[
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CallRoute {
+    UserFunction(String),
+    PureLibrary(String),
+    StatefulLibrary(String),
+    IoLibrary(String),
+    MathAssumption(String),
+    TableLookup,
+    TableGet,
+    EnumAsInteger,
+    ChannelSet,
+    Timer,
+    ProjectIo,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CallCapability {
+    pub(crate) support: BuiltinSupport,
+    route: CallRoute,
+}
+
+/// The lexical and project information needed to resolve a call. Runtime supplies
+/// the active frame for bare callees. Member calls resolve the complete dotted
+/// callee first, matching the type checker: a scalar local cannot shadow a
+/// qualified library call such as `Calculate.Max`.
+pub(crate) struct CapabilityScope<'a> {
+    pub(crate) project: Option<&'a Project>,
+    pub(crate) group: Option<&'a str>,
+    pub(crate) fn_symbol: Option<&'a str>,
+    pub(crate) locals: Option<&'a HashMap<String, Value>>,
+    pub(crate) scripts: &'a [ParsedScript],
+}
+
+fn capability(support: BuiltinSupport, route: CallRoute) -> CallCapability {
+    CallCapability { support, route }
+}
+
+fn unsupported_capability() -> CallCapability {
+    capability(BuiltinSupport::Unsupported, CallRoute::Unsupported)
+}
+
+/// Direct pure-library implementations. The method catalog lives here, not in
+/// coverage, and dispatch refuses any library call that this model does not
+/// route.
+const SUPPORTED_PURE_METHODS: &[(&str, &str)] = &[
     // Calculate.* pure math.
     ("Calculate", "Max"),
     ("Calculate", "Min"),
@@ -554,18 +553,28 @@ const SUPPORTED_METHODS: &[(&str, &str)] = &[
     ("Calculate", "InverseCos"),
     ("Calculate", "InverseTan"),
     ("Calculate", "InverseTan2"),
-    // Calculate.* stateful predicates.
+    // Limit.*.
+    ("Limit", "Range"),
+    ("Limit", "Max"),
+    ("Limit", "Min"),
+];
+
+/// Pure implementations with a documented outstanding conformance question.
+const ASSUMED_PURE_METHODS: &[(&str, &str)] = &[
+    // The current conversion code truncates; exact M1 rounding is awaiting
+    // conformance vectors.
+    ("Convert", "ToInteger"),
+    ("Convert", "ToUnsignedInteger"),
+];
+
+/// Time-domain implementations based on the evaluator's documented Phase-1
+/// model. They run deterministically, but remain assumptions until checked
+/// against M1 Sim. Keep this list aligned with `stateful::call`.
+const ASSUMED_STATEFUL_METHODS: &[(&str, &str)] = &[
     ("Calculate", "Stable"),
     ("Calculate", "Hysteresis"),
     ("Calculate", "Between"),
     ("Calculate", "Beyond"),
-    // Limit.* and Convert.*.
-    ("Limit", "Range"),
-    ("Limit", "Max"),
-    ("Limit", "Min"),
-    ("Convert", "ToInteger"),
-    ("Convert", "ToUnsignedInteger"),
-    // Stateful Filter/Integral/Derivative.
     ("Filter", "FirstOrder"),
     ("Filter", "Maximum"),
     ("Filter", "Minimum"),
@@ -580,6 +589,7 @@ const SUPPORTED_METHODS: &[(&str, &str)] = &[
     ("Debounce", "Stable"),
     ("Debounce", "Fast"),
     ("Debounce", "Verify"),
+    ("Debounce", "Filter"),
     ("Change", "By"),
     ("Change", "Up"),
     ("Change", "Down"),
@@ -588,69 +598,232 @@ const SUPPORTED_METHODS: &[(&str, &str)] = &[
     ("Change", "Either"),
 ];
 
-/// Project-object methods supported regardless of the object's *name* — the
-/// object varies per project (a timer is `Startup Delay`, an enum source is
-/// `Drive State.Idle` or `Control.Drive State`), but the method name fixes the
-/// runtime route, so coverage classifies on the method alone:
-///
-/// - `AsInteger` is the enum→integer accessor (P15-B): resolved at runtime
-///   against the enum model. Like `Lookup`, coverage cannot see the value, so it
-///   is reported supported and the runtime fails loud if the object is not an
-///   enum source.
-/// - `Start`/`Stop`/`Reset`/`Remaining` are the project `Timer` object methods,
-///   evaluated by `stateful::timer` at runtime. They were already evaluated but
-///   the coverage report formerly flagged them unsupported; listing them here
-///   reconciles coverage with what `dispatch_object_method` actually does.
-/// - `Set` is the imperative channel setter (P15-C): resolved at runtime to a
-///   channel write. Like `AsInteger`, coverage classifies on the method alone and
-///   the runtime fails loud if the object is not a channel.
-const SUPPORTED_OBJECT_METHODS: &[&str] =
-    &["AsInteger", "Set", "Start", "Stop", "Reset", "Remaining"];
-
 /// The Tier-3 IO library objects: their methods are handled as documented/
 /// scenario-fed stubs (flagged externally driven), not evaluated as hardware.
 const STUB_OBJECTS: &[&str] = &["CanComms", "Serial", "System", "Logging"];
 
-/// Individual `(object, method)` pairs handled as documented stubs even though
-/// their object is not a whole stub object. `Math.atan2` is the calibration-only
-/// `Math` object surfaced in an ECU script: it is routed (to `y.atan2(x)`) but
-/// flagged external/stubbed so coverage stays honest about its provenance.
-const STUB_METHODS: &[(&str, &str)] = &[("Math", "atan2"), ("Math", "fabs")];
+/// Calibration-only `Math` methods that real ECU scripts nevertheless use. They
+/// have deterministic standard-library implementations here, but remain explicit
+/// assumptions because their ECU-script validity and exact M1 behavior are not
+/// established.
+const ASSUMED_MATH_METHODS: &[(&str, &str)] = &[("Math", "atan2"), ("Math", "fabs")];
 
-/// Classify a builtin `object.method` for the coverage report.
-///
-/// A `Lookup` method on any object is treated as **supported** here — it is the
-/// table-interpolation path, resolved at runtime against a project table symbol
-/// (coverage cannot see the calibration, so it reports the construct as supported
-/// and the runtime fails loud if the specific object is not a table).
-pub fn classify_builtin(object: &str, method: &str) -> BuiltinSupport {
-    // `Lookup` (interpolation) and `Get` (raw site read) are the table paths,
-    // resolved at runtime against a project table symbol — classified on the
-    // method alone; the runtime fails loud if the object is not a table.
-    if method == "Lookup" || method == "Get" {
-        return BuiltinSupport::Supported;
+/// Classify a member call with the same receiver resolution runtime dispatch
+/// uses. A user function is checked first because `Service Bits.Update` and a
+/// script-backed `Slip Control.Update` share a method spelling but take different
+/// routes.
+pub(crate) fn classify_member_call(
+    object: &str,
+    method: &str,
+    scope: &CapabilityScope<'_>,
+) -> CallCapability {
+    let full_path = format!("{object}.{method}");
+    if let Some(canon) = script_backed_user_function(&full_path, scope) {
+        return capability(BuiltinSupport::Supported, CallRoute::UserFunction(canon));
     }
-    // Object-name-independent project-object methods (`AsInteger` enum accessor,
-    // the `Timer` Start/Stop/Reset/Remaining) — classified on the method alone,
-    // because the object spelling is the project symbol's name, not a fixed
-    // library object.
-    if SUPPORTED_OBJECT_METHODS.contains(&method) {
-        return BuiltinSupport::Supported;
+
+    let Some(project) = scope.project else {
+        return classify_without_project(object, method);
+    };
+
+    // Resolve the complete callee before the receiver. The M1 resolver only
+    // applies local shadowing to a single-segment path, so a local named
+    // `Calculate` does not turn `Calculate.Max` into a call on that scalar. This
+    // also normalizes the explicit `Library.Calculate.Max` spelling to the
+    // canonical `Calculate` catalog object.
+    let no_locals = HashMap::new();
+    let locals = scope.locals.unwrap_or(&no_locals);
+    if let Target::Builtin {
+        object: library_object,
+    } = classify(&full_path, scope.group, scope.fn_symbol, project, locals)
+    {
+        return classify_library(&library_object, method);
     }
-    if SUPPORTED_METHODS.contains(&(object, method)) {
-        return BuiltinSupport::Supported;
+
+    if method == "AsInteger" && is_enum_literal(object, project) {
+        return capability(BuiltinSupport::Supported, CallRoute::EnumAsInteger);
     }
-    // Project-object IO methods (DBC CAN Tx/Get/Receive, GroupCompound `.Update`,
-    // `Output.SetState`, a buzzer `.Buzze`) are externally-driven documented stubs.
-    // Classified on the method name alone — the object varies per project, but the
-    // method fixes the offline route (matching `dispatch_object_method`).
+
+    // `Library.` explicitly selects the intrinsic namespace. An unknown object
+    // under that anchor cannot fall through to the project-object stub catalog.
+    if object == "Library" || object.starts_with("Library.") {
+        return unsupported_capability();
+    }
+
+    match classify(object, scope.group, scope.fn_symbol, project, locals) {
+        Target::Builtin { object: builtin } => classify_library(&builtin, method),
+        Target::Symbol(canon) => classify_project_method(&canon, method, project),
+        Target::Unresolved => classify_unresolved_project_method(method),
+        Target::Local(_) => unsupported_capability(),
+    }
+}
+
+/// Classify a bare callee. Only a project function or method with a discovered
+/// script is executable through this syntax.
+pub(crate) fn classify_bare_call(callee: &str, scope: &CapabilityScope<'_>) -> CallCapability {
+    match script_backed_user_function(callee, scope) {
+        Some(canon) => capability(BuiltinSupport::Supported, CallRoute::UserFunction(canon)),
+        None => unsupported_capability(),
+    }
+}
+
+fn classify_without_project(object: &str, method: &str) -> CallCapability {
+    if let Some(library_object) = canonical_library_object(object) {
+        return classify_library(library_object, method);
+    }
+    if object == "Library" || object.starts_with("Library.") {
+        return unsupported_capability();
+    }
+    classify_unresolved_project_method(method)
+}
+
+/// Normalize a source receiver that directly names a library object. The
+/// explicit `Library.` anchor is source syntax, not part of the intrinsic
+/// catalog key.
+fn canonical_library_object(object: &str) -> Option<&'static str> {
+    let candidate = object.strip_prefix("Library.").unwrap_or(object);
+    if candidate.contains('.') {
+        return None;
+    }
+    intrinsics::get().library_object_name(candidate)
+}
+
+fn classify_library(object: &str, method: &str) -> CallCapability {
+    let pair = (object, method);
+    if SUPPORTED_PURE_METHODS.contains(&pair) {
+        return capability(
+            BuiltinSupport::Supported,
+            CallRoute::PureLibrary(object.to_string()),
+        );
+    }
+    if ASSUMED_PURE_METHODS.contains(&pair) {
+        return capability(
+            BuiltinSupport::Assumed,
+            CallRoute::PureLibrary(object.to_string()),
+        );
+    }
+    if ASSUMED_STATEFUL_METHODS.contains(&pair) {
+        return capability(
+            BuiltinSupport::Assumed,
+            CallRoute::StatefulLibrary(object.to_string()),
+        );
+    }
+    if ASSUMED_MATH_METHODS.contains(&pair) {
+        return capability(
+            BuiltinSupport::Assumed,
+            CallRoute::MathAssumption(object.to_string()),
+        );
+    }
+    if STUB_OBJECTS.contains(&object)
+        && !intrinsics::get()
+            .library_overloads(object, method)
+            .is_empty()
+    {
+        return capability(
+            BuiltinSupport::Stubbed,
+            CallRoute::IoLibrary(object.to_string()),
+        );
+    }
+    unsupported_capability()
+}
+
+fn classify_project_method(canon: &str, method: &str, project: &Project) -> CallCapability {
+    let Some(symbol) = project.symbols().get(canon) else {
+        return unsupported_capability();
+    };
+
+    if symbol.kind == SymbolKind::Table {
+        return match method {
+            "Lookup" => capability(BuiltinSupport::Assumed, CallRoute::TableLookup),
+            "Get" => capability(BuiltinSupport::Supported, CallRoute::TableGet),
+            _ => unsupported_capability(),
+        };
+    }
+    if method == "AsInteger" && is_enum_source(canon, project) {
+        return capability(BuiltinSupport::Supported, CallRoute::EnumAsInteger);
+    }
+    if method == "Set" && matches!(symbol.kind, SymbolKind::Channel | SymbolKind::Parameter) {
+        return capability(BuiltinSupport::Supported, CallRoute::ChannelSet);
+    }
+    if symbol.classname.as_deref() == Some("BuiltIn.Timer")
+        && matches!(method, "Start" | "Stop" | "Reset" | "Remaining")
+    {
+        return capability(BuiltinSupport::Assumed, CallRoute::Timer);
+    }
+    if matches!(
+        symbol.kind,
+        SymbolKind::Object | SymbolKind::Group | SymbolKind::Reference | SymbolKind::Other
+    ) && io_stub::PROJECT_OBJECT_STUB_METHODS.contains(&method)
+    {
+        return capability(BuiltinSupport::Stubbed, CallRoute::ProjectIo);
+    }
+    unsupported_capability()
+}
+
+fn classify_unresolved_project_method(method: &str) -> CallCapability {
     if io_stub::PROJECT_OBJECT_STUB_METHODS.contains(&method) {
-        return BuiltinSupport::Stubbed;
+        capability(BuiltinSupport::Stubbed, CallRoute::ProjectIo)
+    } else {
+        unsupported_capability()
     }
-    if STUB_OBJECTS.contains(&object) || STUB_METHODS.contains(&(object, method)) {
-        return BuiltinSupport::Stubbed;
+}
+
+fn is_enum_literal(object: &str, project: &Project) -> bool {
+    object.rsplit_once('.').is_some_and(|(prefix, member)| {
+        project
+            .symbols()
+            .enum_by_name(prefix)
+            .is_some_and(|id| project.symbols().enum_has_member(id, member))
+    })
+}
+
+fn is_enum_source(canon: &str, project: &Project) -> bool {
+    let Some(symbol) = project.symbols().get(canon) else {
+        return false;
+    };
+    match symbol.kind {
+        SymbolKind::Channel | SymbolKind::Parameter => symbol.value_type.is_enum(),
+        SymbolKind::Group => project
+            .symbols()
+            .get(&format!("{canon}.Value"))
+            .is_some_and(|value| value.value_type.is_enum()),
+        _ => false,
     }
-    BuiltinSupport::Unsupported
+}
+
+fn script_backed_user_function(callee: &str, scope: &CapabilityScope<'_>) -> Option<String> {
+    let project = scope.project?;
+    let no_locals = HashMap::new();
+    let locals = scope.locals.unwrap_or(&no_locals);
+    let Target::Symbol(canon) = classify(callee, scope.group, scope.fn_symbol, project, locals)
+    else {
+        return None;
+    };
+    let symbol = project.symbols().get(&canon)?;
+    if !matches!(symbol.kind, SymbolKind::Function | SymbolKind::Method) {
+        return None;
+    }
+    scope
+        .scripts
+        .iter()
+        .any(|script| project.function_symbol_for_script(&script.name).as_deref() == Some(&canon))
+        .then_some(canon)
+}
+
+/// Project-free compatibility helper. New runtime and coverage paths call the
+/// project-aware classifier above. Without a project, receiver-specific methods
+/// are conservative: an unresolved IO writer is a stub, while table, enum,
+/// channel, and timer methods are unsupported because their receiver kind cannot
+/// be proven.
+pub fn classify_builtin(object: &str, method: &str) -> BuiltinSupport {
+    let scope = CapabilityScope {
+        project: None,
+        group: None,
+        fn_symbol: None,
+        locals: None,
+        scripts: &[],
+    };
+    classify_member_call(object, method, &scope).support
 }
 
 #[cfg(test)]
@@ -659,6 +832,7 @@ mod tests {
     use crate::calib::Calibration;
     use crate::env::{Env, StateStore};
     use m1_typecheck::Project;
+    use m1_typecheck::parsed::parse_all;
     use std::path::Path;
 
     /// Load the synthetic mini fixture project (with calibration) for the
@@ -670,6 +844,23 @@ mod tests {
             Some(&dir.join("parameters.m1cfg")),
         )
         .expect("mini fixture loads")
+    }
+
+    fn support_in(
+        loaded: &crate::loader::Loaded,
+        group: Option<&str>,
+        fn_symbol: Option<&str>,
+        object: &str,
+        method: &str,
+    ) -> BuiltinSupport {
+        let scope = CapabilityScope {
+            project: Some(&loaded.project),
+            group,
+            fn_symbol,
+            locals: None,
+            scripts: &loaded.scripts,
+        };
+        classify_member_call(object, method, &scope).support
     }
 
     /// A harness owning the stores so a fresh `EvalCtx` can be built per call.
@@ -730,6 +921,66 @@ mod tests {
                 .unwrap(),
             Value::Int(3)
         );
+    }
+
+    #[test]
+    fn local_named_calculate_does_not_shadow_qualified_builtin_call() {
+        let mut h = Harness::new();
+        h.env.set_local("Calculate", Value::Int(0));
+
+        assert_eq!(
+            h.call("Calculate", "Max", &[Value::Int(1), Value::Int(2)])
+                .unwrap(),
+            Value::Int(2)
+        );
+    }
+
+    #[test]
+    fn library_qualified_calls_dispatch_through_canonical_objects() {
+        let mut h = Harness::new();
+
+        assert_eq!(
+            h.call("Library.Calculate", "Max", &[Value::Int(1), Value::Int(2)])
+                .unwrap(),
+            Value::Int(2)
+        );
+        assert_eq!(
+            h.call(
+                "Library.Debounce",
+                "Filter",
+                &[Value::Bool(true), Value::Float(0.1)]
+            )
+            .unwrap(),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            h.call("Library.Math", "fabs", &[Value::Float(-3.5)])
+                .unwrap(),
+            Value::Float(3.5)
+        );
+        assert_eq!(
+            h.call(
+                "Library.CanComms",
+                "GetFloat",
+                &[Value::Uint(1), Value::Int(2)]
+            )
+            .unwrap(),
+            Value::Float(0.0)
+        );
+    }
+
+    #[test]
+    fn unknown_library_anchored_object_does_not_fall_through_to_project_stub() {
+        assert_eq!(
+            classify_builtin("Library.NoSuchObject", "Set"),
+            BuiltinSupport::Unsupported
+        );
+
+        let mut h = Harness::new();
+        assert!(matches!(
+            h.call("Library.NoSuchObject", "Set", &[Value::Int(1)]),
+            Err(EvalError::UnsupportedBuiltin { .. })
+        ));
     }
 
     #[test]
@@ -817,6 +1068,24 @@ mod tests {
     }
 
     #[test]
+    fn debounce_filter_is_classified_and_dispatched_as_assumed() {
+        let mut h = Harness::new();
+        assert_eq!(
+            classify_builtin("Debounce", "Filter"),
+            BuiltinSupport::Assumed
+        );
+        assert_eq!(
+            h.call(
+                "Debounce",
+                "Filter",
+                &[Value::Bool(true), Value::Float(0.1)]
+            )
+            .unwrap(),
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
     fn stateful_wrong_arity_is_bad_call() {
         let mut h = Harness::new();
         // Integral.Normal needs five arguments; fewer is a BadCall, not a guess.
@@ -856,7 +1125,8 @@ mod tests {
         let mut h = Harness::new();
         // atan2(1, 1) = pi/4. The calibration-only `Math` object is surfaced in
         // real ECU scripts; we route its `atan2` to the same evaluation as
-        // Calculate.InverseTan2 (and flag it Stubbed for coverage).
+        // Calculate.InverseTan2. Coverage marks the calibration-only route as an
+        // assumption, not a hardware stub.
         match h.call("Math", "atan2", &[Value::Float(1.0), Value::Float(1.0)]) {
             Ok(Value::Float(x)) => assert!((x - std::f64::consts::FRAC_PI_4).abs() < 1e-12),
             other => panic!("expected Float(pi/4), got {other:?}"),
@@ -874,24 +1144,27 @@ mod tests {
     }
 
     #[test]
-    fn math_atan2_is_classified_stubbed() {
-        // Coverage flags Math.atan2 as a stub: it is a calibration-only object
-        // surfaced in an ECU script, routed pragmatically but marked external.
-        assert_eq!(classify_builtin("Math", "atan2"), BuiltinSupport::Stubbed);
+    fn math_atan2_is_classified_assumed() {
+        assert_eq!(classify_builtin("Math", "atan2"), BuiltinSupport::Assumed);
     }
 
     #[test]
-    fn math_fabs_is_classified_stubbed() {
+    fn math_fabs_is_classified_assumed() {
         // Same provenance rationale as atan2: routed, but calibration-only.
-        assert_eq!(classify_builtin("Math", "fabs"), BuiltinSupport::Stubbed);
+        assert_eq!(classify_builtin("Math", "fabs"), BuiltinSupport::Assumed);
     }
 
     #[test]
     fn table_get_is_classified_supported() {
-        // `.Get` is the raw-site-read path, resolved at runtime against a
-        // project table symbol — classified on the method alone, like Lookup.
+        let loaded = mini_loaded();
         assert_eq!(
-            classify_builtin("Demo.Map", "Get"),
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Map",
+                "Get"
+            ),
             BuiltinSupport::Supported
         );
     }
@@ -958,6 +1231,18 @@ mod tests {
         match h.call("Map", "Lookup", &[Value::Float(0.0), Value::Float(0.0)]) {
             Err(EvalError::MissingCalibration { .. }) => {}
             other => panic!("expected MissingCalibration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_on_a_table_is_unsupported() {
+        let mut h = Harness::new();
+        match h.call("Map", "Set", &[Value::Int(1)]) {
+            Err(EvalError::UnsupportedBuiltin { object, method }) => {
+                assert_eq!(object, "Map");
+                assert_eq!(method, "Set");
+            }
+            other => panic!("expected receiver-aware UnsupportedBuiltin, got {other:?}"),
         }
     }
 
@@ -1137,27 +1422,69 @@ mod tests {
 
     #[test]
     fn as_integer_is_classified_supported() {
-        // Coverage reports `.AsInteger` supported on any object (resolved at
-        // runtime against the enum model, like `Lookup`).
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums");
+        let loaded =
+            crate::loader::load(&dir.join("Project.m1prj"), None).expect("enums fixture loads");
         assert_eq!(
-            classify_builtin("Drive State.Idle", "AsInteger"),
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Drive State.Idle",
+                "AsInteger"
+            ),
             BuiltinSupport::Supported
         );
         assert_eq!(
-            classify_builtin("Control.Drive State", "AsInteger"),
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Mode",
+                "AsInteger"
+            ),
             BuiltinSupport::Supported
+        );
+        assert_eq!(
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Precharge State",
+                "AsInteger"
+            ),
+            BuiltinSupport::Unsupported,
+            "a non-enum channel is not an AsInteger receiver"
         );
     }
 
     #[test]
-    fn timer_methods_are_classified_supported() {
-        // The project Timer methods are evaluated by `stateful::timer` at runtime;
-        // coverage now matches reality and reports them supported.
+    fn timer_methods_require_a_timer_receiver_and_are_assumed() {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums");
+        let loaded =
+            crate::loader::load(&dir.join("Project.m1prj"), None).expect("enums fixture loads");
         for method in ["Start", "Stop", "Reset", "Remaining"] {
             assert_eq!(
-                classify_builtin("Startup Delay", method),
-                BuiltinSupport::Supported,
-                "Timer.{method} should be supported"
+                support_in(
+                    &loaded,
+                    Some("Root.Demo"),
+                    Some("Root.Demo.Update"),
+                    "Startup Delay",
+                    method
+                ),
+                BuiltinSupport::Assumed,
+                "Timer.{method} should use the documented timer assumption"
+            );
+            assert_eq!(
+                support_in(
+                    &loaded,
+                    Some("Root.Demo"),
+                    Some("Root.Demo.Update"),
+                    "Precharge State",
+                    method
+                ),
+                BuiltinSupport::Unsupported,
+                "a channel cannot use Timer.{method}"
             );
         }
     }
@@ -1257,13 +1584,161 @@ mod tests {
     }
 
     #[test]
-    fn set_is_classified_supported() {
-        // Coverage reports `.Set` supported on any object (resolved at runtime to a
-        // channel write; the runtime fails loud if the object is not a channel).
+    fn timer_dispatch_requires_a_timer_receiver() {
+        let mut h = ProjectObjHarness::new();
         assert_eq!(
-            classify_builtin("Precharge State", "Set"),
+            h.call("Startup Delay", "Start", &[Value::Float(0.03)])
+                .unwrap(),
+            Value::Bool(true)
+        );
+        let remaining = h
+            .call("Startup Delay", "Remaining", &[])
+            .unwrap()
+            .as_f64()
+            .unwrap();
+        assert!((remaining - 0.02).abs() < 1e-12);
+        match h.call("Precharge State", "Start", &[Value::Float(0.03)]) {
+            Err(EvalError::UnsupportedBuiltin { .. }) => {}
+            other => panic!("expected channel.Start to be unsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_is_classified_supported() {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums");
+        let loaded =
+            crate::loader::load(&dir.join("Project.m1prj"), None).expect("enums fixture loads");
+        assert_eq!(
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Precharge State",
+                "Set"
+            ),
             BuiltinSupport::Supported
         );
+        assert_eq!(
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Fan Output",
+                "Set"
+            ),
+            BuiltinSupport::Stubbed
+        );
+    }
+
+    #[test]
+    fn project_object_catalog_matches_coverage_and_runtime_dispatch() {
+        let mut harness = ProjectObjHarness::new();
+        let scripts = parse_all(&[(
+            "Demo.Update.m1scr".to_string(),
+            "Mode.AsInteger();\n\
+             Precharge State.Set(1);\n\
+             Startup Delay.Start(1.0);\n\
+             Startup Delay.Stop();\n\
+             Startup Delay.Reset();\n\
+             Startup Delay.Remaining();\n\
+             Service Bits.Update();\n\
+             Fan Output.Set(1);\n\
+             DashVals.TxOpen();\n\
+             DashVals.Aux Switch.GetScaled();\n\
+             DashVals.Aux Switch.Receive();\n"
+                .to_string(),
+        )]);
+        let report = crate::coverage::CoverageReport::analyse_in(&scripts, Some(&harness.project));
+
+        for name in ["Mode.AsInteger", "Precharge State.Set"] {
+            assert!(
+                report.supported.iter().any(|item| item.name == name),
+                "{name} should be supported: {report:?}"
+            );
+        }
+        for name in [
+            "Startup Delay.Start",
+            "Startup Delay.Stop",
+            "Startup Delay.Reset",
+            "Startup Delay.Remaining",
+        ] {
+            assert!(
+                report.assumed.iter().any(|item| item.name == name),
+                "{name} should be assumed: {report:?}"
+            );
+        }
+        for name in [
+            "Service Bits.Update",
+            "Fan Output.Set",
+            "DashVals.TxOpen",
+            "DashVals.Aux Switch.GetScaled",
+            "DashVals.Aux Switch.Receive",
+        ] {
+            assert!(
+                report.stubbed.iter().any(|item| item.name == name),
+                "{name} should be stubbed: {report:?}"
+            );
+        }
+
+        let enum_id = harness
+            .project
+            .symbols()
+            .enum_by_name("Drive State")
+            .unwrap();
+        harness.env.set(
+            "Root.Demo.Mode",
+            Value::Enum {
+                id: enum_id,
+                member: "Idle".to_string(),
+            },
+        );
+        let calls = [
+            ("Mode", "AsInteger", vec![]),
+            ("Precharge State", "Set", vec![Value::Int(1)]),
+            ("Startup Delay", "Start", vec![Value::Float(1.0)]),
+            ("Startup Delay", "Stop", vec![]),
+            ("Startup Delay", "Reset", vec![]),
+            ("Startup Delay", "Remaining", vec![]),
+            ("Service Bits", "Update", vec![]),
+            ("Fan Output", "Set", vec![Value::Int(1)]),
+            ("DashVals", "TxOpen", vec![]),
+            ("DashVals.Aux Switch", "GetScaled", vec![]),
+            ("DashVals.Aux Switch", "Receive", vec![]),
+        ];
+        for (object, method, args) in calls {
+            if let Err(error) = harness.call(object, method, &args) {
+                panic!(
+                    "coverage classified {object}.{method} executable, dispatch failed: {error}"
+                );
+            }
+        }
+
+        let mini = mini_loaded();
+        let table_scripts = parse_all(&[(
+            "Demo.Update.m1scr".to_string(),
+            "Map.Lookup(0.0, 0.0);\nMap.Get(0);\n".to_string(),
+        )]);
+        let table_report =
+            crate::coverage::CoverageReport::analyse_in(&table_scripts, Some(&mini.project));
+        assert!(
+            table_report
+                .assumed
+                .iter()
+                .any(|item| item.name == "Map.Lookup")
+        );
+        assert!(
+            table_report
+                .supported
+                .iter()
+                .any(|item| item.name == "Map.Get")
+        );
+        let mut table_harness = Harness::new();
+        table_harness
+            .call("Map", "Lookup", &[Value::Float(0.0), Value::Float(0.0)])
+            .expect("coverage-classified table lookup dispatches");
+        table_harness
+            .call("Map", "Get", &[Value::Int(0)])
+            .expect("coverage-classified table get dispatches");
     }
 
     // ---- Task 7: project-object IO stubs ----
@@ -1417,6 +1892,87 @@ mod tests {
                 BuiltinSupport::Supported,
                 "Calculate.{method} should be Supported"
             );
+        }
+    }
+
+    #[test]
+    fn library_catalog_matches_coverage_and_runtime_dispatch() {
+        let mut cases = SUPPORTED_PURE_METHODS
+            .iter()
+            .map(|&(object, method)| (object, method, BuiltinSupport::Supported))
+            .chain(
+                ASSUMED_PURE_METHODS
+                    .iter()
+                    .chain(ASSUMED_STATEFUL_METHODS.iter())
+                    .chain(ASSUMED_MATH_METHODS.iter())
+                    .map(|&(object, method)| (object, method, BuiltinSupport::Assumed)),
+            )
+            .collect::<Vec<_>>();
+        for &object in STUB_OBJECTS {
+            let library = intrinsics::get()
+                .library_object(object)
+                .expect("stub object is in the intrinsic catalog");
+            cases.extend(
+                library
+                    .functions
+                    .iter()
+                    .map(|overload| (object, overload.name.as_str(), BuiltinSupport::Stubbed)),
+            );
+        }
+        cases.sort_by_key(|(object, method, _)| (*object, *method));
+        cases.dedup_by_key(|(object, method, _)| (*object, *method));
+
+        let mut source = String::new();
+        for (object, method, _) in &cases {
+            let overload = intrinsics::get().library_overloads(object, method)[0];
+            let args = overload
+                .params
+                .iter()
+                .map(|param| match param.ty.as_str() {
+                    "Boolean" => "true",
+                    "String" => "\"x\"",
+                    _ => "1",
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            source.push_str(&format!("{object}.{method}({args});\n"));
+        }
+        let scripts = parse_all(&[("Demo.Update.m1scr".to_string(), source)]);
+        let report = crate::coverage::CoverageReport::analyse(&scripts);
+
+        for (object, method, expected) in cases {
+            let name = format!("{object}.{method}");
+            let bucket = match expected {
+                BuiltinSupport::Supported => &report.supported,
+                BuiltinSupport::Assumed => &report.assumed,
+                BuiltinSupport::Stubbed => &report.stubbed,
+                _ => unreachable!("catalog test covers executable methods"),
+            };
+            assert!(
+                bucket.iter().any(|item| item.name == name),
+                "coverage did not put {name} in {expected:?}: {report:?}"
+            );
+
+            let overload = intrinsics::get().library_overloads(object, method)[0];
+            let args: Vec<Value> = overload
+                .params
+                .iter()
+                .map(|param| match param.ty.as_str() {
+                    "Boolean" => Value::Bool(true),
+                    "Integer" => Value::Int(1),
+                    "UnsignedInteger" => Value::Uint(1),
+                    "String" => Value::Str("x".to_string()),
+                    _ => Value::Float(1.0),
+                })
+                .collect();
+            let mut harness = Harness::new();
+            match harness.call(object, method, &args) {
+                Err(EvalError::UnsupportedBuiltin { .. }) => {
+                    panic!("coverage says {expected:?}, but dispatch rejects {name}")
+                }
+                Err(error) => panic!("dispatch failed for classified {name}: {error}"),
+                Ok(_) => {}
+            }
         }
     }
 

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -7,9 +7,8 @@
 //! driven), and which it cannot handle at all (and would fail loud on). This
 //! module walks every script's CST and answers that, statically:
 //!
-//! - every `Object.Method(...)` builtin call is classified against the dispatch
-//!   table via [`crate::builtins::classify_builtin`] — supported, stubbed, or
-//!   unsupported;
+//! - every call is resolved through the same project-aware capability model as
+//!   runtime dispatch — supported, assumed, stubbed, or unsupported;
 //! - every statement/expression construct `Kind` is classified against the set
 //!   the evaluator implements.
 //!
@@ -17,13 +16,12 @@
 //! data, no `m1-core`/`m1-typecheck` types — that the CLI prints and the `Engine`
 //! facade returns.
 
-use crate::builtins::{BuiltinSupport, classify_builtin};
-use crate::ident::{Target, classify};
+use crate::builtins::{BuiltinSupport, CapabilityScope, classify_bare_call, classify_member_call};
+use crate::loader::Loaded;
 use m1_core::{Field, Kind, Node};
 use m1_typecheck::Project;
 use m1_typecheck::parsed::ParsedScript;
-use m1_typecheck::symbols::SymbolKind;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
 /// One thing a script uses, with where it was found. `name` is a `Object.Method`
 /// for a builtin call or a construct kind for a language construct.
@@ -50,6 +48,9 @@ pub enum ItemKind {
 pub struct CoverageReport {
     /// Items the engine implements under its documented maturity contract.
     pub supported: Vec<CoverageItem>,
+    /// Items the engine evaluates deterministically from a documented assumption
+    /// that still needs M1 conformance evidence.
+    pub assumed: Vec<CoverageItem>,
     /// Items handled as documented/scenario-fed stubs (Tier-3 IO).
     pub stubbed: Vec<CoverageItem>,
     /// Items the engine does not handle (would fail loud at runtime).
@@ -57,11 +58,15 @@ pub struct CoverageReport {
     /// The whole-project execution schedule: one `(function symbol, rate)` entry
     /// per script-backed function. `Some(hz)` is the function's periodic rate (it
     /// runs that many times per second in whole-project mode); `None` flags a
-    /// function with no resolvable periodic trigger (`On Startup`, an untriggered
-    /// or `$(…)`-parameterised trigger) — it is **not** run by the whole-project
-    /// scheduler. Sorted `(rate descending, function symbol)` for a deterministic
-    /// report; empty when the analysis had no [`Project`] to resolve rates from.
+    /// function with no resolvable periodic trigger. Startup functions are
+    /// identified separately in [`CoverageReport::startup`]; other `None` entries
+    /// are not run by the whole-project scheduler. Sorted `(rate descending,
+    /// function symbol)` for a deterministic report; empty when the analysis had
+    /// no [`Project`] to resolve rates from.
     pub schedule: Vec<(String, Option<f64>)>,
+    /// Functions the whole-project runner executes exactly once before the
+    /// periodic loop. These also appear in `schedule` with no periodic rate.
+    pub startup: Vec<String>,
 }
 
 impl CoverageReport {
@@ -69,48 +74,75 @@ impl CoverageReport {
     /// context: a member-expression callee is classified on its `(object, method)`
     /// spelling alone, so a user-function call whose method name collides with an
     /// IO-stub method (e.g. `Update`) cannot be distinguished from the stub. Use
-    /// [`CoverageReport::analyse_in`] for project-accurate user-function coverage.
+    /// [`CoverageReport::analyse_in`] for project-accurate receiver and
+    /// user-function coverage.
     pub fn analyse(scripts: &[ParsedScript]) -> CoverageReport {
-        Self::analyse_in(scripts, None)
+        Self::analyse_with_startup(scripts, None, &[])
     }
 
     /// Analyse every script with optional project context. When a [`Project`] is
     /// given, a `CallExpression` whose member-expression callee resolves to a user
     /// `Function`/`Method` symbol is reported **Supported** (it is evaluated inline
     /// — P15-D), disambiguating it from a same-named IO-stub method (`Service
-    /// Bits.Update` vs `Slip Control.Update`). This mirrors `eval_call`, which
-    /// tries `userfn::call` before library/IO dispatch.
+    /// Bits.Update` vs `Slip Control.Update`). Runtime dispatch and coverage both
+    /// use the same receiver-aware capability classifier.
     pub fn analyse_in(scripts: &[ParsedScript], project: Option<&Project>) -> CoverageReport {
+        Self::analyse_with_startup(scripts, project, &[])
+    }
+
+    /// Analyse a complete loaded project, including the loader's exact startup
+    /// trigger set. This is the path used by [`crate::Engine::coverage`].
+    pub fn analyse_loaded(loaded: &Loaded) -> CoverageReport {
+        Self::analyse_with_startup(
+            &loaded.scripts,
+            Some(&loaded.project),
+            &loaded.startup_fn_symbols,
+        )
+    }
+
+    fn analyse_with_startup(
+        scripts: &[ParsedScript],
+        project: Option<&Project>,
+        startup_fn_symbols: &[String],
+    ) -> CoverageReport {
         let mut supported = BTreeSet::new();
+        let mut assumed = BTreeSet::new();
         let mut stubbed = BTreeSet::new();
         let mut unsupported = BTreeSet::new();
         for script in scripts {
             // The script's enclosing group, for resolving group-relative callees.
             let group = project.and_then(|p| p.group_for_script(&script.name));
+            let fn_symbol = project.and_then(|p| p.function_symbol_for_script(&script.name));
             let cx = WalkCtx {
                 project,
                 group: group.as_deref(),
+                fn_symbol: fn_symbol.as_deref(),
+                scripts,
             };
             walk(
                 &script.cst.root(),
                 &cx,
                 &mut supported,
+                &mut assumed,
                 &mut stubbed,
                 &mut unsupported,
             );
         }
-        // A construct/builtin classified supported by one script must not also be
-        // reported unsupported because a *different* occurrence (e.g. a bad-shape
-        // call) hit the fallback; the sets above are already by (name, kind), so
-        // dedup is automatic. We only ensure the buckets are disjoint by
-        // precedence: supported > stubbed > unsupported.
-        stubbed.retain(|i| !supported.contains(i));
-        unsupported.retain(|i| !supported.contains(i) && !stubbed.contains(i));
+        // The public item identity is its displayed `(name, kind)`, so occurrences
+        // in different scripts collapse into one line. Keep the weakest capability
+        // seen for that identity. A supported occurrence must never hide another
+        // occurrence that will be assumed, stubbed, or rejected at runtime.
+        stubbed.retain(|i| !unsupported.contains(i));
+        assumed.retain(|i| !unsupported.contains(i) && !stubbed.contains(i));
+        supported
+            .retain(|i| !unsupported.contains(i) && !stubbed.contains(i) && !assumed.contains(i));
         CoverageReport {
             supported: supported.into_iter().collect(),
+            assumed: assumed.into_iter().collect(),
             stubbed: stubbed.into_iter().collect(),
             unsupported: unsupported.into_iter().collect(),
             schedule: build_schedule(scripts, project),
+            startup: build_startup(scripts, project, startup_fn_symbols),
         }
     }
 
@@ -120,17 +152,18 @@ impl CoverageReport {
     pub fn render(&self) -> String {
         let mut out = String::new();
         render_section(&mut out, "Supported", &self.supported);
+        render_section(&mut out, "Assumed", &self.assumed);
         render_section(&mut out, "Stubbed", &self.stubbed);
         render_section(&mut out, "Unsupported", &self.unsupported);
-        render_schedule(&mut out, &self.schedule);
+        render_schedule(&mut out, &self.schedule, &self.startup);
         out
     }
 }
 
-/// Append the `Schedule:` section: one line per function with its rate, or a flag
-/// that it is unscheduled (and so never runs in whole-project mode). An empty
-/// schedule still prints the label so the output shape is stable.
-fn render_schedule(out: &mut String, schedule: &[(String, Option<f64>)]) {
+/// Append the `Schedule:` section: one line per function with its periodic rate,
+/// startup execution, or unscheduled status. An empty schedule still prints the
+/// label so the output shape is stable.
+fn render_schedule(out: &mut String, schedule: &[(String, Option<f64>)], startup: &[String]) {
     out.push_str("Schedule:\n");
     if schedule.is_empty() {
         out.push_str("  (none)\n");
@@ -139,6 +172,9 @@ fn render_schedule(out: &mut String, schedule: &[(String, Option<f64>)]) {
     for (function, rate) in schedule {
         match rate {
             Some(hz) => out.push_str(&format!("  {function} @ {hz} Hz\n")),
+            None if startup.binary_search(function).is_ok() => {
+                out.push_str(&format!("  {function} (startup, runs once)\n"));
+            }
             None => out.push_str(&format!("  {function} (unscheduled)\n")),
         }
     }
@@ -179,6 +215,31 @@ fn build_schedule(
             .then_with(|| a.0.cmp(&b.0))
     });
     schedule
+}
+
+/// Keep the loader's exact `On Startup` set, restricted to functions that have
+/// a discovered backing script. Sorted for deterministic rendering and binary
+/// lookup in [`render_schedule`].
+fn build_startup(
+    scripts: &[ParsedScript],
+    project: Option<&Project>,
+    startup_fn_symbols: &[String],
+) -> Vec<String> {
+    let Some(project) = project else {
+        return Vec::new();
+    };
+    let script_functions: BTreeSet<String> = scripts
+        .iter()
+        .filter_map(|script| project.function_symbol_for_script(&script.name))
+        .collect();
+    let mut startup: Vec<String> = startup_fn_symbols
+        .iter()
+        .filter(|function| script_functions.contains(*function))
+        .cloned()
+        .collect();
+    startup.sort();
+    startup.dedup();
+    startup
 }
 
 /// Sort key that places a periodic rate by its Hz (descending when compared
@@ -234,12 +295,13 @@ fn is_reportable_construct(kind: Kind) -> bool {
     )
 }
 
-/// The per-script context the coverage walk carries: the optional project model
-/// and the script's enclosing group, used to resolve a call's callee to a user
-/// function (so an inline user-function call is reported Supported, not stubbed).
+/// The per-script context the coverage walk carries, used to resolve each call's
+/// receiver and any script-backed user function exactly as runtime dispatch does.
 struct WalkCtx<'a> {
     project: Option<&'a Project>,
     group: Option<&'a str>,
+    fn_symbol: Option<&'a str>,
+    scripts: &'a [ParsedScript],
 }
 
 /// Recursively walk a node, bucketing builtin calls and reportable constructs.
@@ -247,26 +309,42 @@ fn walk(
     node: &Node,
     cx: &WalkCtx,
     supported: &mut BTreeSet<CoverageItem>,
+    assumed: &mut BTreeSet<CoverageItem>,
     stubbed: &mut BTreeSet<CoverageItem>,
     unsupported: &mut BTreeSet<CoverageItem>,
 ) {
-    // Calls: an inline user-function/method call (member-expr or bare-identifier
-    // callee resolving to a project `Function`/`Method`) is Supported (P15-D);
-    // otherwise classify the `Object.Method` against the builtin dispatch table.
-    if node.kind() == Kind::CallExpression {
-        if let Some(name) = user_function_callee(node, cx) {
-            // A user function the engine evaluates inline.
-            supported.insert(CoverageItem {
+    // Calls use exactly the same project-aware capability model as runtime.
+    if node.kind() == Kind::CallExpression
+        && let Some(callee) = node.child_by_field(Field::Function)
+    {
+        let scope = CapabilityScope {
+            project: cx.project,
+            group: cx.group,
+            fn_symbol: cx.fn_symbol,
+            locals: None,
+            scripts: cx.scripts,
+        };
+        let classified = match callee.kind() {
+            Kind::MemberExpression => call_object_method(node).map(|(object, method)| {
+                let name = format!("{object}.{method}");
+                let support = classify_member_call(&object, &method, &scope).support;
+                (name, support)
+            }),
+            Kind::Identifier => {
+                let name = callee.text().to_string();
+                let support = classify_bare_call(&name, &scope).support;
+                Some((name, support))
+            }
+            _ => None,
+        };
+        if let Some((name, support)) = classified {
+            let item = CoverageItem {
                 name,
                 kind: ItemKind::Builtin,
-            });
-        } else if let Some((object, method)) = call_object_method(node) {
-            let item = CoverageItem {
-                name: format!("{object}.{method}"),
-                kind: ItemKind::Builtin,
             };
-            match classify_builtin(&object, &method) {
+            match support {
                 BuiltinSupport::Supported => supported.insert(item),
+                BuiltinSupport::Assumed => assumed.insert(item),
                 BuiltinSupport::Stubbed => stubbed.insert(item),
                 BuiltinSupport::Unsupported => unsupported.insert(item),
             };
@@ -287,35 +365,8 @@ fn walk(
     }
 
     for child in node.named_children() {
-        walk(&child, cx, supported, stubbed, unsupported);
+        walk(&child, cx, supported, assumed, stubbed, unsupported);
     }
-}
-
-/// The flattened callee path of a `CallExpression` when it resolves (against the
-/// walk's project + group) to a user `Function`/`Method` symbol — i.e. a call the
-/// engine evaluates inline (P15-D). `None` when there is no project context, the
-/// callee does not resolve to a user function, or the callee shape is unexpected.
-///
-/// Both call forms are recognised, mirroring `eval_call`: a member-expression
-/// callee (`Slip Control.Update`) and a bare-identifier callee (`Update`).
-fn user_function_callee(node: &Node, cx: &WalkCtx) -> Option<String> {
-    let project = cx.project?;
-    let callee = node.child_by_field(Field::Function)?;
-    let path = match callee.kind() {
-        Kind::MemberExpression => crate::expr::flatten_member(&callee).ok()?,
-        Kind::Identifier => callee.text().to_string(),
-        _ => return None,
-    };
-    let no_locals = HashMap::new();
-    let Target::Symbol(canon) = classify(&path, cx.group, None, project, &no_locals) else {
-        return None;
-    };
-    let is_user_fn = project
-        .symbols()
-        .get(&canon)
-        .map(|s| matches!(s.kind, SymbolKind::Function | SymbolKind::Method))
-        .unwrap_or(false);
-    is_user_fn.then_some(path)
 }
 
 /// Extract `(object, method)` from a `CallExpression` whose callee is a member
@@ -347,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    fn integral_and_lookup_are_supported_cancomms_is_stubbed() {
+    fn assumptions_stubs_and_unresolved_receivers_are_distinct() {
         let src = r#"
 local i = Integral.Normal(Speed, 0.0, 100.0, false, 0.0);
 local t = Demo.Map.Lookup(Speed, Load);
@@ -357,12 +408,181 @@ Output = i;
         let scripts = scripts_from(src);
         let report = CoverageReport::analyse(&scripts);
 
-        let names: Vec<&str> = report.supported.iter().map(|i| i.name.as_str()).collect();
-        assert!(names.contains(&"Integral.Normal"), "{names:?}");
-        assert!(names.contains(&"Demo.Map.Lookup"), "{names:?}");
+        let assumed: Vec<&str> = report.assumed.iter().map(|i| i.name.as_str()).collect();
+        assert!(assumed.contains(&"Integral.Normal"), "{assumed:?}");
 
         let stub_names: Vec<&str> = report.stubbed.iter().map(|i| i.name.as_str()).collect();
         assert!(stub_names.contains(&"CanComms.GetFloat"), "{stub_names:?}");
+
+        // Without a project, coverage cannot prove that Demo.Map is a table.
+        let unsupported: Vec<&str> = report.unsupported.iter().map(|i| i.name.as_str()).collect();
+        assert!(unsupported.contains(&"Demo.Map.Lookup"), "{unsupported:?}");
+    }
+
+    #[test]
+    fn table_lookup_and_arbitrary_set_use_the_resolved_receiver_kind() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mini");
+        let loaded = crate::loader::load(
+            &dir.join("Project.m1prj"),
+            Some(&dir.join("parameters.m1cfg")),
+        )
+        .expect("mini fixture loads");
+        let scripts =
+            scripts_from("local x = Map.Lookup(Speed, Speed);\nMap.Set(1);\nOutput = x;\n");
+        let report = CoverageReport::analyse_in(&scripts, Some(&loaded.project));
+
+        let assumed: Vec<&str> = report.assumed.iter().map(|i| i.name.as_str()).collect();
+        assert!(assumed.contains(&"Map.Lookup"), "{assumed:?}");
+        let unsupported: Vec<&str> = report.unsupported.iter().map(|i| i.name.as_str()).collect();
+        assert!(unsupported.contains(&"Map.Set"), "{unsupported:?}");
+    }
+
+    #[test]
+    fn set_is_supported_for_channels_and_stubbed_for_output_objects() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums");
+        let loaded =
+            crate::loader::load(&dir.join("Project.m1prj"), None).expect("enums fixture loads");
+        let scripts = scripts_from("Precharge State.Set(1);\nFan Output.Set(1);\n");
+        let report = CoverageReport::analyse_in(&scripts, Some(&loaded.project));
+
+        assert!(
+            report
+                .supported
+                .iter()
+                .any(|item| item.name == "Precharge State.Set")
+        );
+        assert!(
+            report
+                .stubbed
+                .iter()
+                .any(|item| item.name == "Fan Output.Set")
+        );
+    }
+
+    #[test]
+    fn implemented_debounce_filter_is_reported_as_an_assumption() {
+        let report =
+            CoverageReport::analyse(&scripts_from("Output = Debounce.Filter(true, 0.1);\n"));
+        let assumed: Vec<&str> = report.assumed.iter().map(|i| i.name.as_str()).collect();
+        assert!(assumed.contains(&"Debounce.Filter"), "{assumed:?}");
+        assert!(
+            !report
+                .unsupported
+                .iter()
+                .any(|item| item.name == "Debounce.Filter")
+        );
+    }
+
+    #[test]
+    fn local_named_calculate_does_not_change_builtin_coverage() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mini");
+        let loaded =
+            crate::loader::load(&dir.join("Project.m1prj"), None).expect("mini fixture loads");
+        let scripts = scripts_from("local Calculate = 0;\nOutput = Calculate.Max(1, 2);\n");
+        let report = CoverageReport::analyse_in(&scripts, Some(&loaded.project));
+
+        assert!(
+            report
+                .supported
+                .iter()
+                .any(|item| item.name == "Calculate.Max"),
+            "{report:?}"
+        );
+        assert!(
+            !report
+                .unsupported
+                .iter()
+                .any(|item| item.name == "Calculate.Max"),
+            "{report:?}"
+        );
+    }
+
+    #[test]
+    fn library_qualified_calls_use_the_same_capability_buckets() {
+        let report = CoverageReport::analyse(&scripts_from(
+            "Library.Calculate.Max(1, 2);\n\
+             Library.Debounce.Filter(true, 0.1);\n\
+             Library.Math.fabs(-1.0);\n\
+             Library.CanComms.GetFloat(1, 2);\n",
+        ));
+
+        assert!(
+            report
+                .supported
+                .iter()
+                .any(|item| item.name == "Library.Calculate.Max"),
+            "{report:?}"
+        );
+        for name in ["Library.Debounce.Filter", "Library.Math.fabs"] {
+            assert!(
+                report.assumed.iter().any(|item| item.name == name),
+                "{name}: {report:?}"
+            );
+        }
+        assert!(
+            report
+                .stubbed
+                .iter()
+                .any(|item| item.name == "Library.CanComms.GetFloat"),
+            "{report:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_display_name_keeps_the_weakest_script_capability() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/userfn");
+        let loaded =
+            crate::loader::load(&dir.join("Project.m1prj"), None).expect("userfn fixture loads");
+        let scripts = parse_all(&[
+            (
+                "Caller.Update.m1scr".to_string(),
+                "Output.Set(1);\n".to_string(),
+            ),
+            (
+                "Helper.Compute.m1scr".to_string(),
+                "Output.Set(1);\n".to_string(),
+            ),
+        ]);
+        let report = CoverageReport::analyse_in(&scripts, Some(&loaded.project));
+
+        assert!(
+            report.stubbed.iter().any(|item| item.name == "Output.Set"),
+            "the unresolved Helper occurrence must remain visible: {report:?}"
+        );
+        assert!(
+            !report
+                .supported
+                .iter()
+                .any(|item| item.name == "Output.Set"),
+            "the supported Caller occurrence must not hide the stub: {report:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_display_name_keeps_unsupported_over_supported() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mini");
+        let loaded = crate::loader::load(
+            &dir.join("Project.m1prj"),
+            Some(&dir.join("parameters.m1cfg")),
+        )
+        .expect("mini fixture loads");
+        let scripts = parse_all(&[
+            ("Demo.Update.m1scr".to_string(), "Map.Get(0);\n".to_string()),
+            (
+                "Detached.Update.m1scr".to_string(),
+                "Map.Get(0);\n".to_string(),
+            ),
+        ]);
+        let report = CoverageReport::analyse_in(&scripts, Some(&loaded.project));
+
+        assert!(
+            report.unsupported.iter().any(|item| item.name == "Map.Get"),
+            "the unresolved occurrence must remain visible: {report:?}"
+        );
+        assert!(
+            !report.supported.iter().any(|item| item.name == "Map.Get"),
+            "the resolved table occurrence must not hide the failure: {report:?}"
+        );
     }
 
     #[test]
@@ -467,6 +687,7 @@ Output = i;
         let report = CoverageReport::analyse(&scripts_from(src));
         let text = report.render();
         assert!(text.contains("Supported:"));
+        assert!(text.contains("Assumed:"));
         assert!(text.contains("Stubbed:"));
         assert!(text.contains("Unsupported:"));
         // Stubbed has nothing here.
@@ -474,15 +695,13 @@ Output = i;
     }
 
     #[test]
-    fn schedule_reports_rated_functions_and_flags_unscheduled() {
-        // Task 17: with a project, the report carries a per-function schedule —
-        // each function's `call_rate_hz` (or `None` for an On-Startup function
-        // that never runs in whole-project mode). The multirate fixture has four
-        // periodic functions (two at 100 Hz, two at 50 Hz) and one startup.
+    fn schedule_reports_periodic_and_executed_startup_functions() {
+        // The multirate fixture has four periodic functions and one startup
+        // function that the whole-project runner executes once before tick zero.
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/multirate");
         let loaded =
             crate::loader::load(&dir.join("Project.m1prj"), None).expect("multirate fixture loads");
-        let report = CoverageReport::analyse_in(&loaded.scripts, Some(&loaded.project));
+        let report = CoverageReport::analyse_loaded(&loaded);
 
         // Look the schedule up by function symbol path.
         let by_fn: std::collections::HashMap<&str, Option<f64>> = report
@@ -495,19 +714,17 @@ Output = i;
         assert_eq!(by_fn.get("Root.MR.Fast Reader"), Some(&Some(100.0)));
         assert_eq!(by_fn.get("Root.MR.Slow Writer"), Some(&Some(50.0)));
         assert_eq!(by_fn.get("Root.MR.Slow Integrator"), Some(&Some(50.0)));
-        // The On-Startup function is reported with rate `None` (unscheduled).
+        // Startup has no periodic rate, but its separate set says it executes.
         assert_eq!(by_fn.get("Root.MR.Init"), Some(&None));
+        assert_eq!(report.startup, vec!["Root.MR.Init"]);
     }
 
     #[test]
-    fn render_includes_schedule_section_flagging_unscheduled() {
-        // The `Schedule:` section lists each function with its rate; an
-        // unscheduled (`None`) function is flagged so the user sees it will not
-        // run in whole-project mode.
+    fn render_reports_startup_as_running_once() {
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/multirate");
         let loaded =
             crate::loader::load(&dir.join("Project.m1prj"), None).expect("multirate fixture loads");
-        let report = CoverageReport::analyse_in(&loaded.scripts, Some(&loaded.project));
+        let report = CoverageReport::analyse_loaded(&loaded);
         let text = report.render();
 
         assert!(text.contains("Schedule:"), "no Schedule section: {text}");
@@ -516,8 +733,8 @@ Output = i;
             "rated function not rendered: {text}"
         );
         assert!(
-            text.contains("Root.MR.Init") && text.contains("unscheduled"),
-            "startup function not flagged unscheduled: {text}"
+            text.contains("Root.MR.Init") && text.contains("startup, runs once"),
+            "startup execution not rendered: {text}"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -232,10 +232,11 @@ impl Engine {
     }
 
     /// Report which builtins/constructs every loaded script uses and whether the
-    /// engine supports, stubs, or cannot handle each. Pure static analysis — no
-    /// scenario needed; safe to call before [`Engine::run`].
+    /// engine supports, assumes, stubs, or cannot handle each, along with the
+    /// whole-project execution schedule. Pure static analysis — no scenario
+    /// needed; safe to call before [`Engine::run`].
     pub fn coverage(&self) -> CoverageReport {
-        CoverageReport::analyse_in(&self.loaded.scripts, Some(&self.loaded.project))
+        CoverageReport::analyse_loaded(&self.loaded)
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -923,26 +923,15 @@ fn eval_call(node: &Node, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
                 .ok_or_else(|| op_shape_err(&callee, "call method"))?;
             let method = method_node.text();
 
-            // A member-expression callee may be an inline *user* function/method
-            // call (`Slip Control.Update(...)`): the whole `object.method` path
-            // names a project `Function`/`Method` symbol. Try that first — its
-            // body is executed inline (P15-D) — and only fall through to library
-            // dispatch when the path is not a user function (`Ok(None)`).
-            let full_path = flatten_member(&callee)?;
-            if let Some(v) = crate::builtins::userfn::call(&full_path, &args, ctx)? {
-                v
-            } else {
-                // Not a user function: dispatch the method on its object. A call
-                // whose object is a single builtin-library identifier
-                // (`Calculate`, `Limit`, …) dispatches as a library builtin;
-                // a project-object method (table `.Lookup`, enum `.AsInteger`,
-                // channel `.Set`, an IO stub, a Timer) is routed inside `dispatch`.
-                let object = match object_node.kind() {
-                    Kind::MemberExpression => flatten_member(&object_node)?,
-                    _ => object_node.text().to_string(),
-                };
-                crate::builtins::dispatch(&object, method, &args, site.clone(), ctx)?
-            }
+            // Runtime and coverage share the project-aware capability model in
+            // `builtins::dispatch`. It resolves a script-backed user function
+            // before library and project-object routes, so a user `Update` does
+            // not collapse into the similarly named IO stub.
+            let object = match object_node.kind() {
+                Kind::MemberExpression => flatten_member(&object_node)?,
+                _ => object_node.text().to_string(),
+            };
+            crate::builtins::dispatch(&object, method, &args, site.clone(), ctx)?
         }
         // A bare-identifier callee `Update(...)` is an inline user-function call
         // (the callee names a project `Function`/`Method` symbol directly). Route
@@ -950,15 +939,7 @@ fn eval_call(node: &Node, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
         // rather than guessing (it is neither a library object nor a value).
         Kind::Identifier => {
             let name = callee.text();
-            match crate::builtins::userfn::call(name, &args, ctx)? {
-                Some(v) => v,
-                None => {
-                    return Err(EvalError::UnsupportedConstruct {
-                        kind: format!("call to non-function {name:?}"),
-                        at: node.byte_range().start,
-                    });
-                }
-            }
+            crate::builtins::dispatch_bare(name, &args, site.clone(), ctx)?
         }
         _ => {
             return Err(EvalError::UnsupportedConstruct {

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -49,6 +49,12 @@ fn root_segment(path: &str) -> &str {
     }
 }
 
+/// The intrinsic object segment of a resolved builtin callee. `Library.` is an
+/// explicit scope anchor and is not part of the catalog object name.
+fn builtin_object_segment(path: &str) -> &str {
+    root_segment(path.strip_prefix("Library.").unwrap_or(path))
+}
+
 /// Classify an identifier/path against the project, the enclosing group, the
 /// backing function symbol, and the current function locals.
 ///
@@ -81,10 +87,11 @@ pub fn classify(
         Resolution::BuiltinObject(obj) => Target::Builtin {
             object: obj.to_string(),
         },
-        // A builtin function/method call (`Calculate.Max`). Its object is the
-        // leading segment; the call path validates and dispatches the method.
+        // A builtin function/method call (`Calculate.Max` or the explicitly
+        // anchored `Library.Calculate.Max`). Carry the intrinsic object name;
+        // the call path validates and dispatches the method.
         Resolution::BuiltinFn(_) => Target::Builtin {
-            object: root_segment(name).to_string(),
+            object: builtin_object_segment(name).to_string(),
         },
         // `Opaque` covers `In`/`Out`/`Parent`/`This`/`Library`/`Root` anchors and
         // accessor calls on existing symbols — not a project miss, but also not a
@@ -162,6 +169,39 @@ mod tests {
         let project = mini_project();
         let locals = HashMap::new();
         let t = classify("Calculate.Max", Some("Root.Demo"), None, &project, &locals);
+        assert_eq!(
+            t,
+            Target::Builtin {
+                object: "Calculate".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn local_only_shadows_a_single_segment_not_a_builtin_callee() {
+        let project = mini_project();
+        let mut locals = HashMap::new();
+        locals.insert("Calculate".to_string(), Value::Int(0));
+
+        assert_eq!(
+            classify("Calculate.Max", Some("Root.Demo"), None, &project, &locals,),
+            Target::Builtin {
+                object: "Calculate".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn library_anchored_builtin_function_carries_canonical_object() {
+        let project = mini_project();
+        let locals = HashMap::new();
+        let t = classify(
+            "Library.Calculate.Max",
+            Some("Root.Demo"),
+            None,
+            &project,
+            &locals,
+        );
         assert_eq!(
             t,
             Target::Builtin {

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -794,6 +794,15 @@ mod tests {
             .expect("TickPeriod is a documented stub");
     }
 
+    #[test]
+    fn qualified_builtin_call_is_not_shadowed_by_same_named_local() {
+        let mut h = Harness::new();
+        h.run("local Calculate = 0;\nOutput = Calculate.Max(1, 2);\n")
+            .expect("the complete builtin callee resolves before its receiver");
+
+        assert_eq!(h.env.get("Root.Demo.Output"), Some(&Value::Int(2)));
+    }
+
     // ---- Task 21: if/else ----
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -199,6 +199,7 @@ fn coverage_prints_report() {
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
     // The report labels every bucket deterministically.
     assert!(stdout.contains("Supported:"), "coverage stdout: {stdout}");
+    assert!(stdout.contains("Assumed:"), "coverage stdout: {stdout}");
     assert!(stdout.contains("Stubbed:"), "coverage stdout: {stdout}");
     assert!(stdout.contains("Unsupported:"), "coverage stdout: {stdout}");
 }

--- a/tests/fixtures/enums/Project.m1prj
+++ b/tests/fixtures/enums/Project.m1prj
@@ -13,6 +13,7 @@
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Compound"/>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Compound.Value"><Props Type="::This.Drive State"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Precharge State"><Props Type="u8"/></Component>
+   <Component Classname="BuiltIn.Timer" Name="Root.Demo.Startup Delay"/>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Service Bits"/>
    <Component Classname="BuiltIn.CAN.Message" Name="Root.Demo.DashVals"/>
    <Component Classname="BuiltIn.CAN.Signal" Name="Root.Demo.DashVals.Aux Switch"/>

--- a/tests/fixtures/multirate/Project.m1prj
+++ b/tests/fixtures/multirate/Project.m1prj
@@ -17,7 +17,7 @@
 <!--       (its own period), NOT the 0.01 base dt                          -->
 <!--                                                                       -->
 <!--   Startup (no rate):                                                  -->
-<!--     Root.MR.Init          On Startup -> call_rate_hz = None, excluded -->
+<!--     Root.MR.Init          On Startup -> runs once before tick zero    -->
 <MoTeCM1BuildSession>
  <Project Name="MultiRate" TargetHardware="ecu120">
   <ComponentStream><List>

--- a/tests/fixtures/multirate/Scripts/MR.Init.m1scr
+++ b/tests/fixtures/multirate/Scripts/MR.Init.m1scr
@@ -1,4 +1,4 @@
 // Synthetic m1-eval multirate fixture. No proprietary content.
-// On Startup (call_rate_hz = None): NOT periodically scheduled, so the
-// whole-project schedule excludes it. Writes a marker channel.
+// On Startup (call_rate_hz = None): runs once before the periodic schedule.
+// Writes a marker channel.
 Started = 1.0;

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -129,8 +129,9 @@ fn coverage_render_snapshot() {
 }
 
 /// The multirate fixture's coverage report renders a `Schedule:` section listing
-/// every scheduled function fastest-first with its rate, and flags the On-Startup
-/// function unscheduled — pinned so a regression in the schedule report shows.
+/// every scheduled function fastest-first with its rate, and identifies the
+/// On-Startup function as running once — pinned so a regression in the schedule
+/// report shows.
 #[test]
 fn coverage_schedule_render_snapshot() {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/multirate");

--- a/tests/snapshots/snapshot__coverage_render.snap
+++ b/tests/snapshots/snapshot__coverage_render.snap
@@ -5,6 +5,8 @@ expression: report.render()
 Supported:
   construct assignment_statement
   construct local_declaration
+Assumed:
+  (none)
 Stubbed:
   (none)
 Unsupported:

--- a/tests/snapshots/snapshot__coverage_schedule_render.snap
+++ b/tests/snapshots/snapshot__coverage_schedule_render.snap
@@ -3,8 +3,9 @@ source: tests/snapshot.rs
 expression: report.render()
 ---
 Supported:
-  builtin Integral.Normal
   construct assignment_statement
+Assumed:
+  builtin Integral.Normal
 Stubbed:
   (none)
 Unsupported:
@@ -14,4 +15,4 @@ Schedule:
   Root.MR.Fast Writer @ 100 Hz
   Root.MR.Slow Integrator @ 50 Hz
   Root.MR.Slow Writer @ 50 Hz
-  Root.MR.Init (unscheduled)
+  Root.MR.Init (startup, runs once)


### PR DESCRIPTION
Closes #35

## Summary

- Make runtime dispatch and coverage use one project-aware capability classifier.
- Report supported, assumed, stubbed, and unsupported behavior from the resolved receiver.
- Report startup functions as running once and compare coverage with dispatch across the routed method catalog.

## Validation

- `cargo test`
- `cargo test --features ld`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`