### PR TITLE
Fix capability coverage parity after #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ The multi-rate model:
 ### `--coverage`
 
 Before running, `m1-eval --coverage` reports, per project, which builtins and
-constructs each script uses and whether the engine **implements** them directly,
-evaluates them under a documented **assumption** that still needs M1 conformance
-evidence, **stubs** them (Tier-3 IO, externally driven), or does **not support**
-them (would fail loud at runtime). `Supported` is an implementation label, not a
-**Verified** maturity claim.
+constructs each script uses and whether the engine dispatches them through a
+**direct implementation**, an explicit offline **model**, a hardware **stub**
+(Tier-3 IO, externally driven), or no implementation (would fail loud at
+runtime). The rendered labels are `Supported`, `Assumed`, `Stubbed`, and
+`Unsupported`, respectively. These are execution-route labels, separate from the
+evidence maturity contract above: both `Supported` and `Assumed` coverage entries
+remain **Assumed** maturity until captured M1 output verifies them.
 
 The report also prints a **`Schedule:`** section: every script-backed function
 with its execution rate (`@ 500 Hz`, `@ 50 Hz`, …), `startup, runs once`, or

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,10 +39,12 @@ A run requires `--scenario` (to evaluate), `--log` (to replay a log), or
 declared in the scenario file; at most one may be given (combining two is a usage
 error, exit `2`). `--override` and `--diff` require `--log`.
 
-The `Supported` bucket from `--coverage` means the evaluator has an
-implementation. It does not mean the behavior has been verified against M1.
-See the [README maturity contract](../README.md#maturity-contract) for the
-evidence labels and current status of each evaluator area.
+The `Supported` and `Assumed` buckets from `--coverage` distinguish a direct
+implementation from an explicit offline model. They are execution-route labels,
+not evidence maturity: both remain **Assumed** maturity until compared with
+captured M1 output. See the
+[README maturity contract](../README.md#maturity-contract) for the evidence
+labels and current status of each evaluator area.
 
 ## Scenario file
 

--- a/docs/specs/2026-06-23-m1-eval-design.md
+++ b/docs/specs/2026-06-23-m1-eval-design.md
@@ -191,9 +191,10 @@ silently-wrong number):
   real EV-M1 scripts, using tolerance-based floating-point comparison; divergences
   documented.
 - **`m1-eval --coverage <project>`** reports, before running, which builtins/constructs
-  each script uses and whether the engine implements them directly, evaluates them under
-  a documented assumption, stubs them, or has no implementation. `Supported` does not
-  imply M1 verification.
+  each script uses and whether the engine dispatches them through a direct
+  implementation, an explicit offline model, a hardware stub, or no implementation.
+  Those operational categories are separate from evidence maturity: neither a
+  `Supported` nor an `Assumed` coverage entry implies M1 verification.
 
 ## Interfaces & ecosystem integration
 

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -472,11 +472,15 @@ fn unsupported(object: &str, method: &str) -> EvalError {
 /// actually run for this receiver in this project.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinSupport {
-    /// Implemented by the dispatch table under the documented maturity contract.
-    Supported,
-    /// A deterministic implementation whose exact M1 behavior still needs
-    /// conformance evidence.
-    Assumed,
+    /// Runs through a direct evaluator implementation.
+    ///
+    /// This is an execution-route label, not the README's evidence maturity:
+    /// direct implementations are still `Assumed` maturity until compared with
+    /// captured M1 output.
+    Direct,
+    /// Runs through an explicit offline model, such as a time-domain update law.
+    /// The coverage report renders this operational category as `Assumed`.
+    Modeled,
     /// A Tier-3 IO object handled as a documented/scenario-fed stub.
     Stubbed,
     /// Not implemented — fails loud at runtime.
@@ -560,7 +564,7 @@ const SUPPORTED_PURE_METHODS: &[(&str, &str)] = &[
 ];
 
 /// Pure implementations with a documented outstanding conformance question.
-const ASSUMED_PURE_METHODS: &[(&str, &str)] = &[
+const MODELED_PURE_METHODS: &[(&str, &str)] = &[
     // The current conversion code truncates; exact M1 rounding is awaiting
     // conformance vectors.
     ("Convert", "ToInteger"),
@@ -570,7 +574,7 @@ const ASSUMED_PURE_METHODS: &[(&str, &str)] = &[
 /// Time-domain implementations based on the evaluator's documented Phase-1
 /// model. They run deterministically, but remain assumptions until checked
 /// against M1 Sim. Keep this list aligned with `stateful::call`.
-const ASSUMED_STATEFUL_METHODS: &[(&str, &str)] = &[
+const MODELED_STATEFUL_METHODS: &[(&str, &str)] = &[
     ("Calculate", "Stable"),
     ("Calculate", "Hysteresis"),
     ("Calculate", "Between"),
@@ -606,7 +610,7 @@ const STUB_OBJECTS: &[&str] = &["CanComms", "Serial", "System", "Logging"];
 /// have deterministic standard-library implementations here, but remain explicit
 /// assumptions because their ECU-script validity and exact M1 behavior are not
 /// established.
-const ASSUMED_MATH_METHODS: &[(&str, &str)] = &[("Math", "atan2"), ("Math", "fabs")];
+const MODELED_MATH_METHODS: &[(&str, &str)] = &[("Math", "atan2"), ("Math", "fabs")];
 
 /// Classify a member call with the same receiver resolution runtime dispatch
 /// uses. A user function is checked first because `Service Bits.Update` and a
@@ -619,7 +623,7 @@ pub(crate) fn classify_member_call(
 ) -> CallCapability {
     let full_path = format!("{object}.{method}");
     if let Some(canon) = script_backed_user_function(&full_path, scope) {
-        return capability(BuiltinSupport::Supported, CallRoute::UserFunction(canon));
+        return capability(BuiltinSupport::Direct, CallRoute::UserFunction(canon));
     }
 
     let Some(project) = scope.project else {
@@ -641,7 +645,7 @@ pub(crate) fn classify_member_call(
     }
 
     if method == "AsInteger" && is_enum_literal(object, project) {
-        return capability(BuiltinSupport::Supported, CallRoute::EnumAsInteger);
+        return capability(BuiltinSupport::Direct, CallRoute::EnumAsInteger);
     }
 
     // `Library.` explicitly selects the intrinsic namespace. An unknown object
@@ -662,7 +666,7 @@ pub(crate) fn classify_member_call(
 /// script is executable through this syntax.
 pub(crate) fn classify_bare_call(callee: &str, scope: &CapabilityScope<'_>) -> CallCapability {
     match script_backed_user_function(callee, scope) {
-        Some(canon) => capability(BuiltinSupport::Supported, CallRoute::UserFunction(canon)),
+        Some(canon) => capability(BuiltinSupport::Direct, CallRoute::UserFunction(canon)),
         None => unsupported_capability(),
     }
 }
@@ -692,25 +696,25 @@ fn classify_library(object: &str, method: &str) -> CallCapability {
     let pair = (object, method);
     if SUPPORTED_PURE_METHODS.contains(&pair) {
         return capability(
-            BuiltinSupport::Supported,
+            BuiltinSupport::Direct,
             CallRoute::PureLibrary(object.to_string()),
         );
     }
-    if ASSUMED_PURE_METHODS.contains(&pair) {
+    if MODELED_PURE_METHODS.contains(&pair) {
         return capability(
-            BuiltinSupport::Assumed,
+            BuiltinSupport::Modeled,
             CallRoute::PureLibrary(object.to_string()),
         );
     }
-    if ASSUMED_STATEFUL_METHODS.contains(&pair) {
+    if MODELED_STATEFUL_METHODS.contains(&pair) {
         return capability(
-            BuiltinSupport::Assumed,
+            BuiltinSupport::Modeled,
             CallRoute::StatefulLibrary(object.to_string()),
         );
     }
-    if ASSUMED_MATH_METHODS.contains(&pair) {
+    if MODELED_MATH_METHODS.contains(&pair) {
         return capability(
-            BuiltinSupport::Assumed,
+            BuiltinSupport::Modeled,
             CallRoute::MathAssumption(object.to_string()),
         );
     }
@@ -734,21 +738,21 @@ fn classify_project_method(canon: &str, method: &str, project: &Project) -> Call
 
     if symbol.kind == SymbolKind::Table {
         return match method {
-            "Lookup" => capability(BuiltinSupport::Assumed, CallRoute::TableLookup),
-            "Get" => capability(BuiltinSupport::Supported, CallRoute::TableGet),
+            "Lookup" => capability(BuiltinSupport::Modeled, CallRoute::TableLookup),
+            "Get" => capability(BuiltinSupport::Direct, CallRoute::TableGet),
             _ => unsupported_capability(),
         };
     }
     if method == "AsInteger" && is_enum_source(canon, project) {
-        return capability(BuiltinSupport::Supported, CallRoute::EnumAsInteger);
+        return capability(BuiltinSupport::Direct, CallRoute::EnumAsInteger);
     }
     if method == "Set" && matches!(symbol.kind, SymbolKind::Channel | SymbolKind::Parameter) {
-        return capability(BuiltinSupport::Supported, CallRoute::ChannelSet);
+        return capability(BuiltinSupport::Direct, CallRoute::ChannelSet);
     }
     if symbol.classname.as_deref() == Some("BuiltIn.Timer")
         && matches!(method, "Start" | "Stop" | "Reset" | "Remaining")
     {
-        return capability(BuiltinSupport::Assumed, CallRoute::Timer);
+        return capability(BuiltinSupport::Modeled, CallRoute::Timer);
     }
     if matches!(
         symbol.kind,
@@ -1072,7 +1076,7 @@ mod tests {
         let mut h = Harness::new();
         assert_eq!(
             classify_builtin("Debounce", "Filter"),
-            BuiltinSupport::Assumed
+            BuiltinSupport::Modeled
         );
         assert_eq!(
             h.call(
@@ -1145,13 +1149,13 @@ mod tests {
 
     #[test]
     fn math_atan2_is_classified_assumed() {
-        assert_eq!(classify_builtin("Math", "atan2"), BuiltinSupport::Assumed);
+        assert_eq!(classify_builtin("Math", "atan2"), BuiltinSupport::Modeled);
     }
 
     #[test]
     fn math_fabs_is_classified_assumed() {
         // Same provenance rationale as atan2: routed, but calibration-only.
-        assert_eq!(classify_builtin("Math", "fabs"), BuiltinSupport::Assumed);
+        assert_eq!(classify_builtin("Math", "fabs"), BuiltinSupport::Modeled);
     }
 
     #[test]
@@ -1165,7 +1169,7 @@ mod tests {
                 "Map",
                 "Get"
             ),
-            BuiltinSupport::Supported
+            BuiltinSupport::Direct
         );
     }
 
@@ -1433,7 +1437,7 @@ mod tests {
                 "Drive State.Idle",
                 "AsInteger"
             ),
-            BuiltinSupport::Supported
+            BuiltinSupport::Direct
         );
         assert_eq!(
             support_in(
@@ -1443,7 +1447,7 @@ mod tests {
                 "Mode",
                 "AsInteger"
             ),
-            BuiltinSupport::Supported
+            BuiltinSupport::Direct
         );
         assert_eq!(
             support_in(
@@ -1472,7 +1476,7 @@ mod tests {
                     "Startup Delay",
                     method
                 ),
-                BuiltinSupport::Assumed,
+                BuiltinSupport::Modeled,
                 "Timer.{method} should use the documented timer assumption"
             );
             assert_eq!(
@@ -1616,7 +1620,7 @@ mod tests {
                 "Precharge State",
                 "Set"
             ),
-            BuiltinSupport::Supported
+            BuiltinSupport::Direct
         );
         assert_eq!(
             support_in(
@@ -1889,7 +1893,7 @@ mod tests {
         ] {
             assert_eq!(
                 classify_builtin("Calculate", method),
-                BuiltinSupport::Supported,
+                BuiltinSupport::Direct,
                 "Calculate.{method} should be Supported"
             );
         }
@@ -1899,13 +1903,13 @@ mod tests {
     fn library_catalog_matches_coverage_and_runtime_dispatch() {
         let mut cases = SUPPORTED_PURE_METHODS
             .iter()
-            .map(|&(object, method)| (object, method, BuiltinSupport::Supported))
+            .map(|&(object, method)| (object, method, BuiltinSupport::Direct))
             .chain(
-                ASSUMED_PURE_METHODS
+                MODELED_PURE_METHODS
                     .iter()
-                    .chain(ASSUMED_STATEFUL_METHODS.iter())
-                    .chain(ASSUMED_MATH_METHODS.iter())
-                    .map(|&(object, method)| (object, method, BuiltinSupport::Assumed)),
+                    .chain(MODELED_STATEFUL_METHODS.iter())
+                    .chain(MODELED_MATH_METHODS.iter())
+                    .map(|&(object, method)| (object, method, BuiltinSupport::Modeled)),
             )
             .collect::<Vec<_>>();
         for &object in STUB_OBJECTS {
@@ -1943,8 +1947,8 @@ mod tests {
         for (object, method, expected) in cases {
             let name = format!("{object}.{method}");
             let bucket = match expected {
-                BuiltinSupport::Supported => &report.supported,
-                BuiltinSupport::Assumed => &report.assumed,
+                BuiltinSupport::Direct => &report.supported,
+                BuiltinSupport::Modeled => &report.assumed,
                 BuiltinSupport::Stubbed => &report.stubbed,
                 _ => unreachable!("catalog test covers executable methods"),
             };
@@ -1977,27 +1981,20 @@ mod tests {
     }
 
     #[test]
-    fn io_stub_methods_are_classified_stubbed() {
-        // Each project-object IO method is reported as a documented stub.
-        for method in [
-            "Tx",
-            "TxOpen",
-            "TxInitialise",
-            "Init",
-            "SetBit",
-            "SetUnsignedInteger",
-            "GetScaled",
-            "GetUnsignedInteger",
-            "Receive",
-            "Update",
-            "SetState",
-            "Buzze",
-        ] {
+    fn project_io_stub_catalog_matches_classification_and_dispatch() {
+        let mut harness = ProjectObjHarness::new();
+        // Exercise every entry in the shared project-object catalog through both
+        // coverage's classifier and runtime's dispatcher. This catches drift in
+        // either direction when a new IO method is added.
+        for &method in io_stub::PROJECT_OBJECT_STUB_METHODS {
             assert_eq!(
                 classify_builtin("DashVals", method),
                 BuiltinSupport::Stubbed,
                 "{method} should be a stub"
             );
+            harness
+                .call("DashVals", method, &[])
+                .unwrap_or_else(|error| panic!("stubbed DashVals.{method} failed: {error}"));
         }
     }
 

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -21,7 +21,7 @@ use crate::loader::Loaded;
 use m1_core::{Field, Kind, Node};
 use m1_typecheck::Project;
 use m1_typecheck::parsed::ParsedScript;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 /// One thing a script uses, with where it was found. `name` is a `Object.Method`
 /// for a builtin call or a construct kind for a language construct.
@@ -46,10 +46,9 @@ pub enum ItemKind {
 /// unsupported. Each list is de-duplicated and sorted for a deterministic report.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CoverageReport {
-    /// Items the engine implements under its documented maturity contract.
+    /// Items dispatched through a direct evaluator implementation.
     pub supported: Vec<CoverageItem>,
-    /// Items the engine evaluates deterministically from a documented assumption
-    /// that still needs M1 conformance evidence.
+    /// Items dispatched through an explicit deterministic offline model.
     pub assumed: Vec<CoverageItem>,
     /// Items handled as documented/scenario-fed stubs (Tier-3 IO).
     pub stubbed: Vec<CoverageItem>,
@@ -119,9 +118,11 @@ impl CoverageReport {
                 fn_symbol: fn_symbol.as_deref(),
                 scripts,
             };
+            let mut locals = HashMap::new();
             walk(
                 &script.cst.root(),
                 &cx,
+                &mut locals,
                 &mut supported,
                 &mut assumed,
                 &mut stubbed,
@@ -308,6 +309,7 @@ struct WalkCtx<'a> {
 fn walk(
     node: &Node,
     cx: &WalkCtx,
+    locals: &mut HashMap<String, crate::value::Value>,
     supported: &mut BTreeSet<CoverageItem>,
     assumed: &mut BTreeSet<CoverageItem>,
     stubbed: &mut BTreeSet<CoverageItem>,
@@ -321,7 +323,7 @@ fn walk(
             project: cx.project,
             group: cx.group,
             fn_symbol: cx.fn_symbol,
-            locals: None,
+            locals: Some(locals),
             scripts: cx.scripts,
         };
         let classified = match callee.kind() {
@@ -343,8 +345,8 @@ fn walk(
                 kind: ItemKind::Builtin,
             };
             match support {
-                BuiltinSupport::Supported => supported.insert(item),
-                BuiltinSupport::Assumed => assumed.insert(item),
+                BuiltinSupport::Direct => supported.insert(item),
+                BuiltinSupport::Modeled => assumed.insert(item),
                 BuiltinSupport::Stubbed => stubbed.insert(item),
                 BuiltinSupport::Unsupported => unsupported.insert(item),
             };
@@ -364,8 +366,28 @@ fn walk(
         }
     }
 
+    // Runtime evaluates a local declaration's initializer before adding the
+    // local to the active frame. Mirror that source-order behavior so subsequent
+    // bare and member calls see the same shadowing that dispatch does.
+    if node.kind() == Kind::LocalDeclaration {
+        for child in node.named_children() {
+            walk(&child, cx, locals, supported, assumed, stubbed, unsupported);
+        }
+        let is_static = node
+            .children()
+            .iter()
+            .any(|child| child.kind() == Kind::Static);
+        if !is_static && let Some(name) = node.child_by_field(Field::Name) {
+            locals.insert(
+                name.text().trim().to_string(),
+                crate::value::Value::Bool(false),
+            );
+        }
+        return;
+    }
+
     for child in node.named_children() {
-        walk(&child, cx, supported, assumed, stubbed, unsupported);
+        walk(&child, cx, locals, supported, assumed, stubbed, unsupported);
     }
 }
 
@@ -645,6 +667,62 @@ Output = i;
             "unsupported={unsupported:?}"
         );
         assert!(!stubbed.contains(&"Helper.Compute"), "stubbed={stubbed:?}");
+    }
+
+    #[test]
+    fn local_shadowing_keeps_coverage_aligned_with_runtime_resolution() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/userfn");
+        let loaded =
+            crate::loader::load(&dir.join("Project.m1prj"), None).expect("userfn fixture loads");
+        let mut sources: Vec<(String, String)> = loaded
+            .scripts
+            .iter()
+            .filter(|script| script.name != "Caller.Update.m1scr")
+            .map(|script| (script.name.clone(), script.cst.root().text().to_string()))
+            .collect();
+        sources.push((
+            "Caller.Update.m1scr".to_string(),
+            "local Kick = 0;\nKick();\nlocal Output = 0;\nOutput.Set(1);\n".to_string(),
+        ));
+        let scripts = parse_all(&sources);
+        let report = CoverageReport::analyse_in(&scripts, Some(&loaded.project));
+
+        for name in ["Kick", "Output.Set"] {
+            assert!(
+                report.unsupported.iter().any(|item| item.name == name),
+                "a local-shadowed call must match runtime's fail-loud route: {name}: {report:?}"
+            );
+            assert!(
+                !report.supported.iter().any(|item| item.name == name),
+                "a local-shadowed call cannot remain supported: {name}: {report:?}"
+            );
+        }
+
+        let mut env = crate::env::Env::new();
+        env.set_local("Kick", crate::value::Value::Int(0));
+        let mut state = crate::env::StateStore::new();
+        let mut ctx = crate::expr::EvalCtx {
+            project: &loaded.project,
+            calib: &loaded.calib,
+            env: &mut env,
+            state: &mut state,
+            group: Some("Root.Caller"),
+            fn_symbol: Some("Root.Caller.Update"),
+            script_name: "Caller.Update.m1scr",
+            dt: 0.01,
+            scripts: &scripts,
+            depth: 0,
+            trace: None,
+        };
+        assert!(matches!(
+            crate::builtins::dispatch_bare(
+                "Kick",
+                &[],
+                crate::env::CallSite::new("Caller.Update.m1scr", 0),
+                &mut ctx
+            ),
+            Err(crate::error::EvalError::UnsupportedConstruct { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve lexical local shadowing during static coverage classification so bare and member calls match runtime dispatch
- exercise every project-object IO stub through both classification and runtime dispatch
- separate operational coverage categories from the M1 evidence maturity contract introduced in #56

## Context

#58 was merged at `5606834` while its requested semantic fix was still being completed. This follow-up contains only that fix on top of the merged main branch.

## Validation

- `cargo test --locked --features ld -q` (412 unit tests plus integration suites)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- `git diff --check`

Closes the remaining review findings from #58.