### PR TITLE
Resolve parameterized calculation triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ mode and is mutually exclusive with `--function` / `--target`).
 The multi-rate model:
 
 - **Schedule from the project.** A function's execution rate is its
-  `.m1prj` trigger — a `BuiltIn.EventKernel` clock such as `On 500Hz` /
-  `On 50Hz` — surfaced by `m1-typecheck` as the symbol's `call_rate_hz`. Every
-  function with a resolvable periodic rate (500 / 200 / 50 / 10 / 2 Hz) is
-  scheduled. An `On Startup` function runs **exactly once**, before the first
-  periodic tick (its outputs hold from tick 0). Untriggered and
-  `$(…)`-parameterised-trigger functions are **not** run and are flagged
-  *unscheduled* in `--coverage`.
+  `.m1prj` `SelectedTrigger`, which must resolve to a `BuiltIn.EventKernel`
+  clock such as `On 500Hz` or `On 50Hz`. The resolver handles absolute paths,
+  group-relative `Parent.` paths, and `$(<component>:SelectedTrigger)` attribute
+  references. An `On Startup` function runs **exactly once** before the first
+  periodic tick, and its outputs hold from tick 0. Parameterised user functions
+  and calibration functions remain callable helpers. Functions with no trigger
+  stay unscheduled. Invalid or dangling trigger references are excluded and
+  reported with the failed path or attribute in `--coverage`.
 - **Base tick + exact rate divisors.** The run advances on one base tick grid.
   When `base_rate_hz` is unset it defaults to the **least common multiple** of
   the scheduled rates, so every function has an exact integer tick period —
@@ -144,9 +145,9 @@ remain **Assumed** maturity until captured M1 output verifies them.
 
 The report also prints a **`Schedule:`** section: every script-backed function
 with its execution rate (`@ 500 Hz`, `@ 50 Hz`, …), `startup, runs once`, or
-*unscheduled*. This makes a `whole-project` run transparent — you see exactly
-which functions the scheduler will run, at what rate, and which are excluded —
-before you run it.
+an explicit `helper`, `unscheduled`, or `unresolved trigger` status. The last
+status includes the failed path or attribute, so a project author can repair the
+selection instead of treating every excluded function as the same case.
 
 ## Quickstart
 

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -18,6 +18,7 @@
 
 use crate::builtins::{BuiltinSupport, CapabilityScope, classify_bare_call, classify_member_call};
 use crate::loader::Loaded;
+use crate::triggers::{TriggerMap, TriggerStatus};
 use m1_core::{Field, Kind, Node};
 use m1_typecheck::Project;
 use m1_typecheck::parsed::ParsedScript;
@@ -42,6 +43,17 @@ pub enum ItemKind {
     Construct,
 }
 
+/// A function whose selected project trigger could not be resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnresolvedTrigger {
+    /// Canonical function symbol.
+    pub function: String,
+    /// Original `SelectedTrigger` expression on that function.
+    pub trigger: String,
+    /// Concrete resolution failure suitable for diagnostics.
+    pub reason: String,
+}
+
 /// The coverage analysis result: which used items are supported, stubbed, or
 /// unsupported. Each list is de-duplicated and sorted for a deterministic report.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -57,15 +69,20 @@ pub struct CoverageReport {
     /// The whole-project execution schedule: one `(function symbol, rate)` entry
     /// per script-backed function. `Some(hz)` is the function's periodic rate (it
     /// runs that many times per second in whole-project mode); `None` flags a
-    /// function with no resolvable periodic trigger. Startup functions are
-    /// identified separately in [`CoverageReport::startup`]; other `None` entries
-    /// are not run by the whole-project scheduler. Sorted `(rate descending,
-    /// function symbol)` for a deterministic report; empty when the analysis had
-    /// no [`Project`] to resolve rates from.
+    /// function with no resolved periodic trigger. Companion fields distinguish
+    /// startup, helper, unscheduled, and unresolved cases. Sorted `(rate
+    /// descending, function symbol)` for a deterministic report; empty when the
+    /// analysis had no [`Project`] to resolve rates from.
     pub schedule: Vec<(String, Option<f64>)>,
     /// Functions the whole-project runner executes exactly once before the
     /// periodic loop. These also appear in `schedule` with no periodic rate.
     pub startup: Vec<String>,
+    /// Callable helper or calibration functions that are not scheduler roots.
+    pub helpers: Vec<String>,
+    /// Schedulable functions with no selected trigger.
+    pub unscheduled: Vec<String>,
+    /// Functions whose selected trigger is invalid or cannot be resolved.
+    pub unresolved: Vec<UnresolvedTrigger>,
 }
 
 impl CoverageReport {
@@ -76,7 +93,7 @@ impl CoverageReport {
     /// [`CoverageReport::analyse_in`] for project-accurate receiver and
     /// user-function coverage.
     pub fn analyse(scripts: &[ParsedScript]) -> CoverageReport {
-        Self::analyse_with_startup(scripts, None, &[])
+        Self::analyse_with_triggers(scripts, None, None)
     }
 
     /// Analyse every script with optional project context. When a [`Project`] is
@@ -86,23 +103,23 @@ impl CoverageReport {
     /// Bits.Update` vs `Slip Control.Update`). Runtime dispatch and coverage both
     /// use the same receiver-aware capability classifier.
     pub fn analyse_in(scripts: &[ParsedScript], project: Option<&Project>) -> CoverageReport {
-        Self::analyse_with_startup(scripts, project, &[])
+        Self::analyse_with_triggers(scripts, project, None)
     }
 
     /// Analyse a complete loaded project, including the loader's exact startup
     /// trigger set. This is the path used by [`crate::Engine::coverage`].
     pub fn analyse_loaded(loaded: &Loaded) -> CoverageReport {
-        Self::analyse_with_startup(
+        Self::analyse_with_triggers(
             &loaded.scripts,
             Some(&loaded.project),
-            &loaded.startup_fn_symbols,
+            Some(&loaded.triggers),
         )
     }
 
-    fn analyse_with_startup(
+    fn analyse_with_triggers(
         scripts: &[ParsedScript],
         project: Option<&Project>,
-        startup_fn_symbols: &[String],
+        triggers: Option<&TriggerMap>,
     ) -> CoverageReport {
         let mut supported = BTreeSet::new();
         let mut assumed = BTreeSet::new();
@@ -137,13 +154,17 @@ impl CoverageReport {
         assumed.retain(|i| !unsupported.contains(i) && !stubbed.contains(i));
         supported
             .retain(|i| !unsupported.contains(i) && !stubbed.contains(i) && !assumed.contains(i));
+        let roles = build_trigger_roles(triggers);
         CoverageReport {
             supported: supported.into_iter().collect(),
             assumed: assumed.into_iter().collect(),
             stubbed: stubbed.into_iter().collect(),
             unsupported: unsupported.into_iter().collect(),
-            schedule: build_schedule(scripts, project),
-            startup: build_startup(scripts, project, startup_fn_symbols),
+            schedule: build_schedule(scripts, project, triggers),
+            startup: roles.startup,
+            helpers: roles.helpers,
+            unscheduled: roles.unscheduled,
+            unresolved: roles.unresolved,
         }
     }
 
@@ -156,7 +177,14 @@ impl CoverageReport {
         render_section(&mut out, "Assumed", &self.assumed);
         render_section(&mut out, "Stubbed", &self.stubbed);
         render_section(&mut out, "Unsupported", &self.unsupported);
-        render_schedule(&mut out, &self.schedule, &self.startup);
+        render_schedule(
+            &mut out,
+            &self.schedule,
+            &self.startup,
+            &self.helpers,
+            &self.unscheduled,
+            &self.unresolved,
+        );
         out
     }
 }
@@ -164,7 +192,14 @@ impl CoverageReport {
 /// Append the `Schedule:` section: one line per function with its periodic rate,
 /// startup execution, or unscheduled status. An empty schedule still prints the
 /// label so the output shape is stable.
-fn render_schedule(out: &mut String, schedule: &[(String, Option<f64>)], startup: &[String]) {
+fn render_schedule(
+    out: &mut String,
+    schedule: &[(String, Option<f64>)],
+    startup: &[String],
+    helpers: &[String],
+    unscheduled: &[String],
+    unresolved: &[UnresolvedTrigger],
+) {
     out.push_str("Schedule:\n");
     if schedule.is_empty() {
         out.push_str("  (none)\n");
@@ -173,23 +208,49 @@ fn render_schedule(out: &mut String, schedule: &[(String, Option<f64>)], startup
     for (function, rate) in schedule {
         match rate {
             Some(hz) => out.push_str(&format!("  {function} @ {hz} Hz\n")),
-            None if startup.binary_search(function).is_ok() => {
-                out.push_str(&format!("  {function} (startup, runs once)\n"));
+            None => {
+                if startup.binary_search(function).is_ok() {
+                    out.push_str(&format!("  {function} (startup, runs once)\n"));
+                } else if helpers.binary_search(function).is_ok() {
+                    out.push_str(&format!("  {function} (helper, not scheduled directly)\n"));
+                } else if let Ok(index) = unresolved
+                    .binary_search_by(|entry| entry.function.as_str().cmp(function.as_str()))
+                {
+                    let entry = &unresolved[index];
+                    if entry.trigger.is_empty() {
+                        out.push_str(&format!(
+                            "  {function} (unresolved trigger: {})\n",
+                            entry.reason
+                        ));
+                    } else {
+                        out.push_str(&format!(
+                            "  {function} (unresolved trigger `{}`: {})\n",
+                            entry.trigger, entry.reason
+                        ));
+                    }
+                } else if unscheduled.binary_search(function).is_ok() {
+                    out.push_str(&format!(
+                        "  {function} (unscheduled, no trigger selected)\n"
+                    ));
+                } else {
+                    out.push_str(&format!("  {function} (unscheduled)\n"));
+                }
             }
-            None => out.push_str(&format!("  {function} (unscheduled)\n")),
         }
     }
 }
 
 /// Derive the whole-project execution schedule: one `(function symbol, rate)`
-/// entry per script-backed function. Mirrors `runner::enumerate_scheduled`'s rate
-/// derivation (`function_symbol_for_script` → `symbols().get(..).call_rate_hz`)
-/// but keeps the **unscheduled** (`None`) functions too, so the report can flag
-/// them. Sorted `(rate descending, function symbol)` for determinism; empty when
-/// no [`Project`] is available to resolve rates.
+/// entry per script-backed function. Loaded-project analysis reads the same
+/// effective trigger map as `runner::enumerate_scheduled` and keeps every
+/// nonperiodic function as `None`, so companion status fields can explain why
+/// it is excluded. Project-only analysis falls back to `call_rate_hz` because it
+/// has no raw `SelectedTrigger` attributes. Sorted `(rate descending, function
+/// symbol)` for determinism; empty when no [`Project`] is available.
 fn build_schedule(
     scripts: &[ParsedScript],
     project: Option<&Project>,
+    triggers: Option<&TriggerMap>,
 ) -> Vec<(String, Option<f64>)> {
     let Some(project) = project else {
         return Vec::new();
@@ -200,10 +261,13 @@ fn build_schedule(
             // A script without a backing function symbol is not a scheduled
             // function (e.g. a non-function script) — skip it entirely.
             let fn_symbol = project.function_symbol_for_script(&script.name)?;
-            let rate_hz = project
-                .symbols()
-                .get(&fn_symbol)
-                .and_then(|s| s.call_rate_hz);
+            let rate_hz = match triggers {
+                Some(map) => map.periodic_rate(&fn_symbol),
+                None => project
+                    .symbols()
+                    .get(&fn_symbol)
+                    .and_then(|symbol| symbol.call_rate_hz),
+            };
             Some((fn_symbol, rate_hz))
         })
         .collect();
@@ -218,29 +282,35 @@ fn build_schedule(
     schedule
 }
 
-/// Keep the loader's exact `On Startup` set, restricted to functions that have
-/// a discovered backing script. Sorted for deterministic rendering and binary
-/// lookup in [`render_schedule`].
-fn build_startup(
-    scripts: &[ParsedScript],
-    project: Option<&Project>,
-    startup_fn_symbols: &[String],
-) -> Vec<String> {
-    let Some(project) = project else {
-        return Vec::new();
+#[derive(Default)]
+struct TriggerRoles {
+    startup: Vec<String>,
+    helpers: Vec<String>,
+    unscheduled: Vec<String>,
+    unresolved: Vec<UnresolvedTrigger>,
+}
+
+fn build_trigger_roles(triggers: Option<&TriggerMap>) -> TriggerRoles {
+    let mut roles = TriggerRoles::default();
+    let Some(triggers) = triggers else {
+        return roles;
     };
-    let script_functions: BTreeSet<String> = scripts
-        .iter()
-        .filter_map(|script| project.function_symbol_for_script(&script.name))
-        .collect();
-    let mut startup: Vec<String> = startup_fn_symbols
-        .iter()
-        .filter(|function| script_functions.contains(*function))
-        .cloned()
-        .collect();
-    startup.sort();
-    startup.dedup();
-    startup
+    for (function, status) in triggers.iter() {
+        match status {
+            TriggerStatus::Periodic(_) => {}
+            TriggerStatus::Startup => roles.startup.push(function.to_string()),
+            TriggerStatus::Helper => roles.helpers.push(function.to_string()),
+            TriggerStatus::Unscheduled => roles.unscheduled.push(function.to_string()),
+            TriggerStatus::Unresolved { trigger, reason } => {
+                roles.unresolved.push(UnresolvedTrigger {
+                    function: function.to_string(),
+                    trigger: trigger.clone(),
+                    reason: reason.clone(),
+                });
+            }
+        }
+    }
+    roles
 }
 
 /// Sort key that places a periodic rate by its Hz (descending when compared
@@ -815,6 +885,37 @@ Output = i;
             text.contains("Root.MR.Init") && text.contains("startup, runs once"),
             "startup execution not rendered: {text}"
         );
+    }
+
+    #[test]
+    fn coverage_distinguishes_every_trigger_status() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/triggers");
+        let loaded =
+            crate::loader::load(&dir.join("Project.m1prj"), None).expect("trigger fixture loads");
+        let report = CoverageReport::analyse_loaded(&loaded);
+        let by_fn: std::collections::HashMap<&str, Option<f64>> = report
+            .schedule
+            .iter()
+            .map(|(function, rate)| (function.as_str(), *rate))
+            .collect();
+
+        assert_eq!(by_fn.get("Root.T.Direct"), Some(&Some(100.0)));
+        assert_eq!(by_fn.get("Root.T.Grouped"), Some(&Some(50.0)));
+        assert_eq!(by_fn.get("Root.T.Parameterized"), Some(&Some(200.0)));
+        assert_eq!(report.startup, vec!["Root.T.Startup"]);
+        assert_eq!(report.helpers, vec!["Root.T.Helper"]);
+        assert_eq!(report.unscheduled, vec!["Root.T.Unscheduled"]);
+        assert_eq!(report.unresolved.len(), 1);
+        assert_eq!(report.unresolved[0].function, "Root.T.Invalid");
+        assert!(report.unresolved[0].reason.contains("missing component"));
+
+        let rendered = report.render();
+        assert!(rendered.contains("Root.T.Parameterized @ 200 Hz"));
+        assert!(rendered.contains("Root.T.Startup (startup, runs once)"));
+        assert!(rendered.contains("Root.T.Helper (helper, not scheduled directly)"));
+        assert!(rendered.contains("Root.T.Unscheduled (unscheduled, no trigger selected)"));
+        assert!(rendered.contains("Root.T.Invalid (unresolved trigger"));
+        assert!(rendered.contains("missing component `Root.Events.On 999Hz`"));
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -214,11 +214,7 @@ impl Engine {
                 .loaded
                 .project
                 .function_symbol_for_script(&script.name)?;
-            self.loaded
-                .project
-                .symbols()
-                .get(&fn_symbol)
-                .and_then(|s| s.call_rate_hz)
+            self.loaded.triggers.periodic_rate(&fn_symbol)
         }))
         .unwrap_or(100.0)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub mod table;
 pub mod loader;
 pub use loader::{Loaded, load};
 
+pub mod triggers;
+pub use triggers::{TriggerMap, TriggerStatus};
+
 pub mod env;
 pub use env::{CallSite, Env, OpState, StateStore};
 
@@ -50,7 +53,7 @@ pub mod runner;
 pub use runner::{CounterfactualCfg, run_counterfactual};
 
 pub mod coverage;
-pub use coverage::{CoverageItem, CoverageReport, ItemKind};
+pub use coverage::{CoverageItem, CoverageReport, ItemKind, UnresolvedTrigger};
 
 pub mod engine;
 pub use engine::Engine;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -16,6 +16,7 @@
 
 use crate::calib::Calibration;
 use crate::error::EvalError;
+use crate::triggers::{TriggerMap, TriggerStatus};
 use crate::value::M1ScalarKind;
 use m1_typecheck::Project;
 use m1_typecheck::parsed::{ParsedScript, parse_all};
@@ -63,11 +64,13 @@ pub struct Loaded {
     /// the typechecker's coarser `ValueType` model at evaluator boundaries.
     pub signature_m1_types: SignatureM1Types,
     /// Function symbols whose `.m1prj` `SelectedTrigger` resolves to the
-    /// `On Startup` event kernel (trigger leaf `"On Startup"`, the convention
-    /// both real corpora follow). The whole-project runner executes these
-    /// exactly once before the periodic loop. `$(…)`-parameterised and
-    /// untriggered functions are NOT here — they stay unscheduled.
+    /// `On Startup` event kernel, including any resolved attribute reference.
+    /// The whole-project runner executes these exactly once before the periodic
+    /// loop.
     pub startup_fn_symbols: Vec<String>,
+    /// Effective trigger state for every script-backed function. Runtime and
+    /// coverage both use this map instead of the lossy `call_rate_hz` field.
+    pub triggers: TriggerMap,
 }
 
 /// Load a project, its scripts, and (optionally) its calibration values.
@@ -114,8 +117,14 @@ pub fn load(project_path: &Path, cfg_path: Option<&Path>) -> Result<Loaded, Eval
     };
 
     let project_xml = read_xml(project_path)?;
-    let startup_fn_symbols = startup_functions(&project_xml)?;
     let signature_m1_types = signature_m1_types(&project_xml)?;
+    let triggers = TriggerMap::from_project_xml(&project_xml, &project, &scripts)?;
+    let startup_fn_symbols = triggers
+        .iter()
+        .filter_map(|(function, status)| {
+            matches!(status, TriggerStatus::Startup).then_some(function.to_string())
+        })
+        .collect();
 
     Ok(Loaded {
         project,
@@ -123,6 +132,7 @@ pub fn load(project_path: &Path, cfg_path: Option<&Path>) -> Result<Loaded, Eval
         calib,
         signature_m1_types,
         startup_fn_symbols,
+        triggers,
     })
 }
 
@@ -180,39 +190,6 @@ fn signature_scalar_kind(raw: &str) -> Option<M1ScalarKind> {
         _ => None,
     }
 }
-
-/// The full component names (function symbols) whose `SelectedTrigger` points at
-/// the `On Startup` event kernel — trigger path leaf `"On Startup"`, matching
-/// both synthetic fixtures and the real corpora (`…Events.On Startup`, possibly
-/// `Parent.`-prefixed). Parsed from the raw `.m1prj` because the typed symbol
-/// model deliberately collapses non-periodic triggers to `call_rate_hz = None`
-/// without recording which are startup. Fails loud on unparseable XML — the
-/// project just loaded through `m1-typecheck`, so a parse failure here is a
-/// genuine inconsistency, not a condition to guess through.
-fn startup_functions(xml: &str) -> Result<Vec<String>, EvalError> {
-    let doc = roxmltree::Document::parse(xml).map_err(|e| EvalError::UnsupportedConstruct {
-        kind: format!("project XML re-parse for startup triggers failed: {e}"),
-        at: 0,
-    })?;
-    let mut out = Vec::new();
-    for node in doc.descendants().filter(|n| n.has_tag_name("Component")) {
-        let Some(name) = node.attribute("Name") else {
-            continue;
-        };
-        let trigger = node
-            .children()
-            .find(|c| c.has_tag_name("Props"))
-            .and_then(|p| p.attribute("SelectedTrigger"));
-        if let Some(t) = trigger
-            && t.rsplit('.').next() == Some("On Startup")
-        {
-            out.push(name.to_string());
-        }
-    }
-    out.sort();
-    Ok(out)
-}
-
 /// Read a MoTeC XML file as text, decoding lossily so Windows-1252 exports do not
 /// abort the load. Maps IO failure onto a fail-loud [`EvalError`].
 fn read_xml(path: &Path) -> Result<String, EvalError> {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1794,11 +1794,11 @@ duration_s = 0.01
         assert_eq!(trace.time.len(), 2, "auto base is 200 Hz");
         assert_eq!(
             trace.channels.get("Root.T.Parameterized Out"),
-            Some(&vec![Value::Float(3.0), Value::Float(3.0)])
+            Some(&vec![Value::m1_float(3.0), Value::m1_float(3.0)])
         );
         assert_eq!(
             trace.channels.get("Root.T.Started"),
-            Some(&vec![Value::Float(4.0), Value::Float(4.0)])
+            Some(&vec![Value::m1_float(4.0), Value::m1_float(4.0)])
         );
         assert!(!trace.channels.contains_key("Root.T.Unscheduled Out"));
         assert!(!trace.channels.contains_key("Root.T.Invalid Out"));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -247,10 +247,8 @@ fn exact_divisor(
     Ok((base_mhz / rate_mhz) as usize)
 }
 
-/// One scheduled function together with its periodic execution rate in Hz, as
-/// derived from the function symbol's `call_rate_hz`. Only functions with a
-/// resolvable periodic trigger (a `BuiltIn.EventKernel` clock like `On 100Hz`)
-/// appear here; `On Startup` / untriggered functions (rate `None`) are excluded.
+/// One scheduled function together with its resolved periodic execution rate.
+/// Startup, helper, unscheduled, and unresolved functions never appear here.
 struct ScheduledRated<'a> {
     /// The scheduled function (script + resolved scope).
     sched: Scheduled<'a>,
@@ -261,12 +259,10 @@ struct ScheduledRated<'a> {
 /// Build the whole-project schedule: every periodically-scheduled function, in
 /// dependency-then-rate order.
 ///
-/// 1. **Enumerate + rate** (Task 11): for each script, the backing function
-///    symbol's `call_rate_hz` gives its periodic rate. Keep only the functions
-///    with `Some(rate)` — exactly the pattern `m1-typecheck`'s `schedule.rs`
-///    uses (`symbols().get(&fn_path).and_then(|s| s.call_rate_hz)`). Startup /
-///    untriggered functions (`None`) are not periodically scheduled, so they are
-///    excluded.
+/// 1. **Enumerate + rate** (Task 11): for each script, read the effective rate
+///    from [`Loaded::triggers`]. This includes direct, group-relative, and
+///    `$(…:SelectedTrigger)` attribute-reference forms. Keep only periodic
+///    functions.
 /// 2. **Dependency-then-rate order** (Task 12): within a single rate group,
 ///    writer-before-reader topological order (from [`io_sets`], reusing
 ///    [`topo_order`]); groups concatenated fastest-rate-first. There are no
@@ -281,21 +277,17 @@ fn build_whole_project_schedule(loaded: &Loaded) -> Vec<ScheduledRated<'_>> {
 
 /// Enumerate every periodically-scheduled function with its rate (Task 11).
 ///
-/// For each parsed script, resolve its backing function symbol and read that
-/// symbol's `call_rate_hz`; keep only functions with a periodic rate. The result
-/// is sorted by `(rate descending, fn_symbol)` as a deterministic baseline; the
-/// dependency layer (Task 12) refines order *within* each rate group.
+/// For each parsed script, resolve its backing function symbol and effective
+/// trigger; keep only periodic functions. The result is sorted by `(rate
+/// descending, fn_symbol)` as a deterministic baseline; the dependency layer
+/// refines order within each rate group.
 fn enumerate_scheduled(loaded: &Loaded) -> Vec<ScheduledRated<'_>> {
     let mut rated: Vec<ScheduledRated> = loaded
         .scripts
         .iter()
         .filter_map(|script| {
             let fn_symbol = loaded.project.function_symbol_for_script(&script.name)?;
-            let rate_hz = loaded
-                .project
-                .symbols()
-                .get(&fn_symbol)
-                .and_then(|s| s.call_rate_hz)?;
+            let rate_hz = loaded.triggers.periodic_rate(&fn_symbol)?;
             Some(ScheduledRated {
                 sched: scheduled_for(loaded, script),
                 rate_hz,
@@ -612,12 +604,12 @@ struct RunPlan {
 
 /// The On-Startup functions to run once before the periodic loop, in
 /// writer-before-reader order — whole-project mode only (function/cone modes
-/// pin a single explicit target and model no initialisation pass). Each
-/// `startup_fn_symbols` entry (from the loader's trigger scan) is matched back
-/// to its parsed script; ordering reuses the same single-group topological
-/// machinery as the periodic schedule (nominal rate, stripped after ordering).
+/// pin a single explicit target and model no initialisation pass). Each resolved
+/// startup entry is matched back to its parsed script; ordering
+/// reuses the same single-group topological machinery as the periodic schedule
+/// with a nominal rate that is stripped after ordering.
 fn startup_schedule<'a>(loaded: &'a Loaded, scenario: &Scenario) -> Vec<Scheduled<'a>> {
-    if !matches!(scenario.mode, RunMode::WholeProject) || loaded.startup_fn_symbols.is_empty() {
+    if !matches!(scenario.mode, RunMode::WholeProject) {
         return Vec::new();
     }
     let mut rated: Vec<ScheduledRated> = loaded
@@ -625,7 +617,10 @@ fn startup_schedule<'a>(loaded: &'a Loaded, scenario: &Scenario) -> Vec<Schedule
         .iter()
         .filter_map(|script| {
             let fn_symbol = loaded.project.function_symbol_for_script(&script.name)?;
-            if !loaded.startup_fn_symbols.contains(&fn_symbol) {
+            if !matches!(
+                loaded.triggers.get(&fn_symbol),
+                Some(crate::triggers::TriggerStatus::Startup)
+            ) {
                 return None;
             }
             Some(ScheduledRated {
@@ -1054,8 +1049,8 @@ pub fn run_counterfactual(
     // on a tick holds its last value (zero-order hold) — reusing the schedule-write
     // hold machinery the tick loop already relies on.
     //
-    // Each cone function keeps its **declared** project rate (its trigger's
-    // `call_rate_hz`): a 10 Hz state machine in the cone runs every 10th tick of
+    // Each cone function keeps its resolved project rate: a 10 Hz state machine
+    // in the cone runs every 10th tick of
     // a 100 Hz replay with dt = 0.1 s, exactly as scheduled on the ECU — not
     // once per base tick, which over-ran slow filters/integrators/debounce
     // logic 10x. A function without a resolvable periodic rate (no trigger)
@@ -1067,8 +1062,7 @@ pub fn run_counterfactual(
             let rate_hz = sched
                 .fn_symbol
                 .as_deref()
-                .and_then(|f| loaded.project.symbols().get(f))
-                .and_then(|s| s.call_rate_hz)
+                .and_then(|function| loaded.triggers.periodic_rate(function))
                 .unwrap_or(base_rate_hz);
             ScheduledRated { sched, rate_hz }
         })
@@ -1515,6 +1509,11 @@ const = "oops"
         load(&dir.join("Project.m1prj"), None).expect("ratemix fixture loads")
     }
 
+    fn trigger_fixture() -> Loaded {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/triggers");
+        load(&dir.join("Project.m1prj"), None).expect("trigger fixture loads")
+    }
+
     #[test]
     fn auto_base_is_lcm_of_scheduled_rates() {
         // 500 Hz and 200 Hz do not divide each other: neither rate can serve as
@@ -1750,6 +1749,59 @@ const = 3.0
             vec![100.0, 100.0, 50.0, 50.0],
             "fastest-first baseline"
         );
+    }
+
+    #[test]
+    fn parameterized_trigger_runs_at_its_effective_rate() {
+        let loaded = trigger_fixture();
+        let rated = enumerate_scheduled(&loaded);
+        let by_fn: std::collections::HashMap<String, f64> = rated
+            .iter()
+            .map(|entry| {
+                (
+                    entry
+                        .sched
+                        .fn_symbol
+                        .clone()
+                        .expect("scheduled function has a symbol"),
+                    entry.rate_hz,
+                )
+            })
+            .collect();
+        assert_eq!(by_fn.get("Root.T.Direct"), Some(&100.0));
+        assert_eq!(by_fn.get("Root.T.Grouped"), Some(&50.0));
+        assert_eq!(by_fn.get("Root.T.Parameterized"), Some(&200.0));
+        for excluded in [
+            "Root.T.Startup",
+            "Root.T.Helper",
+            "Root.T.Unscheduled",
+            "Root.T.Invalid",
+        ] {
+            assert!(
+                !by_fn.contains_key(excluded),
+                "{excluded} must not be periodic"
+            );
+        }
+
+        let scenario = Scenario::from_toml_str(
+            r#"
+mode = "whole-project"
+duration_s = 0.01
+"#,
+        )
+        .expect("scenario parses");
+        let trace = run(&loaded, &scenario).expect("resolved schedule executes");
+        assert_eq!(trace.time.len(), 2, "auto base is 200 Hz");
+        assert_eq!(
+            trace.channels.get("Root.T.Parameterized Out"),
+            Some(&vec![Value::Float(3.0), Value::Float(3.0)])
+        );
+        assert_eq!(
+            trace.channels.get("Root.T.Started"),
+            Some(&vec![Value::Float(4.0), Value::Float(4.0)])
+        );
+        assert!(!trace.channels.contains_key("Root.T.Unscheduled Out"));
+        assert!(!trace.channels.contains_key("Root.T.Invalid Out"));
     }
 
     #[test]

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -67,10 +67,10 @@ pub enum RunMode {
     /// Run a target channel plus its upstream dependency cone. The string is the
     /// canonical channel path the user wants computed.
     Cone(String),
-    /// Run *every* periodically-scheduled function (those whose trigger resolves
-    /// to a `call_rate_hz`) each base tick at its own rate, in dependency-then-rate
-    /// order. The offline schedule model has no single target: the runner schedules the
-    /// whole project.
+    /// Run *every* periodically-scheduled function whose effective project
+    /// trigger resolves to a rate. Each runs at its own rate in
+    /// dependency-then-rate order. The offline schedule model has no single
+    /// target: the runner schedules the whole project.
     WholeProject,
 }
 

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Resolve each script-backed function's effective project trigger.
+//!
+//! M1 projects may copy `SelectedTrigger` from another component with an
+//! attribute expression such as
+//! `$(Parent.Absolute Travel.Calculation:SelectedTrigger)`. The copied value can
+//! itself be relative to that component. `m1-typecheck` deliberately leaves
+//! these expressions without a `call_rate_hz`, so the evaluator resolves the
+//! small project-attribute chain here before it builds any execution schedule.
+
+use crate::error::EvalError;
+use m1_typecheck::Project;
+use m1_typecheck::parsed::ParsedScript;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// The effective scheduling role of one script-backed project function.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TriggerStatus {
+    /// Run periodically at the resolved rate in Hz.
+    Periodic(f64),
+    /// Run once before the periodic loop.
+    Startup,
+    /// Callable function that is never an independent scheduler entry point.
+    Helper,
+    /// A schedulable function whose project component has no selected trigger.
+    Unscheduled,
+    /// A selected trigger exists, but cannot be resolved safely.
+    Unresolved {
+        /// The trigger expression declared on the script-backed function.
+        trigger: String,
+        /// A concrete explanation suitable for coverage output.
+        reason: String,
+    },
+}
+
+/// Resolved trigger state, keyed by canonical function symbol.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TriggerMap {
+    by_function: BTreeMap<String, TriggerStatus>,
+}
+
+impl TriggerMap {
+    /// Resolve trigger state for every discovered script with a project symbol.
+    pub(crate) fn from_project_xml(
+        xml: &str,
+        project: &Project,
+        scripts: &[ParsedScript],
+    ) -> Result<Self, EvalError> {
+        let doc = roxmltree::Document::parse(xml).map_err(|e| EvalError::UnsupportedConstruct {
+            kind: format!("project XML re-parse for calculation triggers failed: {e}"),
+            at: 0,
+        })?;
+        let components: BTreeMap<String, Component> = doc
+            .descendants()
+            .filter(|node| node.has_tag_name("Component"))
+            .filter_map(|node| {
+                let name = node.attribute("Name")?;
+                let classname = node.attribute("Classname")?;
+                let selected_trigger = node
+                    .children()
+                    .find(|child| child.has_tag_name("Props"))
+                    .and_then(|props| props.attribute("SelectedTrigger"))
+                    .map(str::to_string);
+                Some((
+                    name.to_string(),
+                    Component {
+                        classname: classname.to_string(),
+                        selected_trigger,
+                    },
+                ))
+            })
+            .collect();
+
+        let mut by_function = BTreeMap::new();
+        for script in scripts {
+            let Some(function) = project.function_symbol_for_script(&script.name) else {
+                continue;
+            };
+            let status = match components.get(&function) {
+                Some(component) if is_helper_class(&component.classname) => TriggerStatus::Helper,
+                Some(component) => match component
+                    .selected_trigger
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|trigger| !trigger.is_empty())
+                {
+                    Some(trigger) => resolve_selected_trigger(
+                        &function,
+                        trigger,
+                        trigger,
+                        &components,
+                        &mut BTreeSet::new(),
+                    ),
+                    None => TriggerStatus::Unscheduled,
+                },
+                None => TriggerStatus::Unresolved {
+                    trigger: String::new(),
+                    reason: "the script's function component is missing from Project.m1prj"
+                        .to_string(),
+                },
+            };
+            by_function.insert(function, status);
+        }
+        Ok(Self { by_function })
+    }
+
+    /// Trigger state for a canonical function symbol.
+    pub fn get(&self, function: &str) -> Option<&TriggerStatus> {
+        self.by_function.get(function)
+    }
+
+    /// Resolved periodic rate for a canonical function symbol.
+    pub fn periodic_rate(&self, function: &str) -> Option<f64> {
+        match self.get(function) {
+            Some(TriggerStatus::Periodic(rate)) => Some(*rate),
+            _ => None,
+        }
+    }
+
+    /// Iterate over canonical function symbols and their trigger states.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &TriggerStatus)> {
+        self.by_function
+            .iter()
+            .map(|(function, status)| (function.as_str(), status))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Component {
+    classname: String,
+    selected_trigger: Option<String>,
+}
+
+/// Parameterised user functions and calibration functions are invoked by other
+/// code or tooling. M1 does not schedule them as independent event functions.
+fn is_helper_class(classname: &str) -> bool {
+    classname.starts_with("BuiltIn.FuncUserParam") || classname.starts_with("BuiltIn.CalFuncUser")
+}
+
+fn resolve_selected_trigger(
+    owner: &str,
+    selected: &str,
+    original: &str,
+    components: &BTreeMap<String, Component>,
+    resolving: &mut BTreeSet<String>,
+) -> TriggerStatus {
+    let selected = selected.trim();
+    if is_startup_trigger(selected) {
+        return TriggerStatus::Startup;
+    }
+
+    if selected.starts_with("$(") {
+        let Some((reference, attribute)) = parse_attribute_reference(selected) else {
+            return unresolved(
+                original,
+                format!(
+                    "invalid attribute expression `{selected}`; expected `$(<component>:SelectedTrigger)`"
+                ),
+            );
+        };
+        if attribute != "SelectedTrigger" {
+            return unresolved(
+                original,
+                format!(
+                    "attribute expression reads `{attribute}`; only `SelectedTrigger` can define a calculation rate"
+                ),
+            );
+        }
+        let Some(target) = resolve_component_path(owner, reference) else {
+            return unresolved(
+                original,
+                format!("attribute reference `{reference}` climbs above the project root"),
+            );
+        };
+        let Some(component) = components.get(&target) else {
+            return unresolved(
+                original,
+                format!("attribute reference resolves to missing component `{target}`"),
+            );
+        };
+        let Some(next) = component
+            .selected_trigger
+            .as_deref()
+            .map(str::trim)
+            .filter(|trigger| !trigger.is_empty())
+        else {
+            return unresolved(
+                original,
+                format!("referenced component `{target}` has no SelectedTrigger"),
+            );
+        };
+        if !resolving.insert(target.clone()) {
+            return unresolved(
+                original,
+                format!("SelectedTrigger attribute references form a cycle at `{target}`"),
+            );
+        }
+        let status = resolve_selected_trigger(&target, next, original, components, resolving);
+        resolving.remove(&target);
+        return status;
+    }
+
+    if selected.contains("$(") {
+        return unresolved(
+            original,
+            format!(
+                "unsupported mixed trigger expression `{selected}`; use one event path or one SelectedTrigger reference"
+            ),
+        );
+    }
+
+    let Some(target) = resolve_component_path(owner, selected) else {
+        return unresolved(
+            original,
+            format!("trigger path `{selected}` climbs above the project root"),
+        );
+    };
+    let Some(component) = components.get(&target) else {
+        return unresolved(
+            original,
+            format!("trigger resolves to missing component `{target}`"),
+        );
+    };
+    if component.classname != "BuiltIn.EventKernel" {
+        return unresolved(
+            original,
+            format!(
+                "trigger resolves to `{target}` ({}) instead of a BuiltIn.EventKernel",
+                component.classname
+            ),
+        );
+    }
+    let leaf = target.rsplit('.').next().unwrap_or(target.as_str());
+    let Some(number) = leaf
+        .strip_prefix("On ")
+        .and_then(|value| value.strip_suffix("Hz"))
+    else {
+        return unresolved(
+            original,
+            format!("event kernel `{target}` does not name an `On <rate>Hz` event"),
+        );
+    };
+    let Ok(rate) = number.trim().parse::<f64>() else {
+        return unresolved(
+            original,
+            format!("event kernel `{target}` has an invalid numeric rate"),
+        );
+    };
+    if !rate.is_finite() || rate <= 0.0 {
+        return unresolved(
+            original,
+            format!("event kernel `{target}` must have a positive finite rate"),
+        );
+    }
+    TriggerStatus::Periodic(rate)
+}
+
+fn unresolved(trigger: &str, reason: String) -> TriggerStatus {
+    TriggerStatus::Unresolved {
+        trigger: trigger.to_string(),
+        reason,
+    }
+}
+
+fn is_startup_trigger(trigger: &str) -> bool {
+    trigger.eq_ignore_ascii_case("startup")
+        || trigger.eq_ignore_ascii_case("On Startup")
+        || trigger
+            .rsplit('.')
+            .next()
+            .is_some_and(|leaf| leaf.eq_ignore_ascii_case("On Startup"))
+}
+
+fn parse_attribute_reference(expression: &str) -> Option<(&str, &str)> {
+    let body = expression.strip_prefix("$(")?.strip_suffix(')')?;
+    let (component, attribute) = body.rsplit_once(':')?;
+    let component = component.trim();
+    let attribute = attribute.trim();
+    (!component.is_empty() && !attribute.is_empty()).then_some((component, attribute))
+}
+
+/// Resolve M1's component-relative path form. `Parent.` starts at the owner
+/// component itself, so one `Parent` reaches its enclosing group. Absolute
+/// `Root` paths pass through unchanged.
+fn resolve_component_path(owner: &str, value: &str) -> Option<String> {
+    let value = value.trim();
+    if value == "Root" || value.starts_with("Root.") {
+        return Some(value.to_string());
+    }
+    let owner_segments: Vec<&str> = owner.split('.').collect();
+    let mut climb = 0usize;
+    let mut rest = value;
+    while let Some(tail) = rest.strip_prefix("Parent.") {
+        climb += 1;
+        rest = tail;
+    }
+    if climb > owner_segments.len() || rest.is_empty() {
+        return None;
+    }
+    let ancestor = &owner_segments[..owner_segments.len() - climb];
+    if ancestor.is_empty() {
+        Some(rest.to_string())
+    } else {
+        Some(format!("{}.{rest}", ancestor.join(".")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use m1_typecheck::parsed::parse_all;
+
+    fn statuses(xml: &str, files: &[&str]) -> TriggerMap {
+        let project = Project::from_xml(xml).expect("project parses");
+        let sources: Vec<(String, String)> = files
+            .iter()
+            .map(|file| ((*file).to_string(), String::new()))
+            .collect();
+        let scripts = parse_all(&sources);
+        TriggerMap::from_project_xml(xml, &project, &scripts).expect("triggers resolve")
+    }
+
+    #[test]
+    fn resolves_direct_grouped_parameterized_and_nonperiodic_statuses() {
+        let xml = r#"<Project>
+  <Component Classname="BuiltIn.GroupCompound" Name="Root"/>
+  <Component Classname="BuiltIn.GroupCompound" Name="Root.Events"/>
+  <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On 100Hz"/>
+  <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On 200Hz"/>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.Direct" Filename="Direct.m1scr"><Props SelectedTrigger="Root.Events.On 100Hz"/></Component>
+  <Component Classname="BuiltIn.GroupCompound" Name="Root.Control"/>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.Control.Grouped" Filename="Grouped.m1scr"><Props SelectedTrigger="Parent.Parent.Events.On 100Hz"/></Component>
+  <Component Classname="BuiltIn.MethodUser" Name="Root.Control.Calculation"><Props SelectedTrigger="Parent.Parent.Events.On 200Hz"/></Component>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.Control.Parameterized" Filename="Parameterized.m1scr"><Props SelectedTrigger="$(Parent.Calculation:SelectedTrigger)"/></Component>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.Startup" Filename="Startup.m1scr"><Props SelectedTrigger="Parent.Events.On Startup"/></Component>
+  <Component Classname="BuiltIn.FuncUserParam" Name="Root.Helper" Filename="Helper.m1scr"/>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.Unscheduled" Filename="Unscheduled.m1scr"/>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.Invalid" Filename="Invalid.m1scr"><Props SelectedTrigger="Root.Events.On 999Hz"/></Component>
+</Project>"#;
+        let map = statuses(
+            xml,
+            &[
+                "Direct.m1scr",
+                "Grouped.m1scr",
+                "Parameterized.m1scr",
+                "Startup.m1scr",
+                "Helper.m1scr",
+                "Unscheduled.m1scr",
+                "Invalid.m1scr",
+            ],
+        );
+
+        assert_eq!(
+            map.get("Root.Direct"),
+            Some(&TriggerStatus::Periodic(100.0))
+        );
+        assert_eq!(
+            map.get("Root.Control.Grouped"),
+            Some(&TriggerStatus::Periodic(100.0))
+        );
+        assert_eq!(
+            map.get("Root.Control.Parameterized"),
+            Some(&TriggerStatus::Periodic(200.0))
+        );
+        assert_eq!(map.get("Root.Startup"), Some(&TriggerStatus::Startup));
+        assert_eq!(map.get("Root.Helper"), Some(&TriggerStatus::Helper));
+        assert_eq!(
+            map.get("Root.Unscheduled"),
+            Some(&TriggerStatus::Unscheduled)
+        );
+        assert!(matches!(
+            map.get("Root.Invalid"),
+            Some(TriggerStatus::Unresolved { reason, .. })
+                if reason.contains("missing component `Root.Events.On 999Hz`")
+        ));
+    }
+
+    #[test]
+    fn reports_missing_selected_trigger_reference_and_cycles() {
+        let xml = r#"<Project>
+  <Component Classname="BuiltIn.GroupCompound" Name="Root"/>
+  <Component Classname="BuiltIn.MethodUser" Name="Root.A"><Props SelectedTrigger="$(Root.B:SelectedTrigger)"/></Component>
+  <Component Classname="BuiltIn.MethodUser" Name="Root.B"><Props SelectedTrigger="$(Root.A:SelectedTrigger)"/></Component>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.Cycle" Filename="Cycle.m1scr"><Props SelectedTrigger="$(Root.A:SelectedTrigger)"/></Component>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.Missing" Filename="Missing.m1scr"><Props SelectedTrigger="$(Root.Nope:SelectedTrigger)"/></Component>
+</Project>"#;
+        let map = statuses(xml, &["Cycle.m1scr", "Missing.m1scr"]);
+        assert!(matches!(
+            map.get("Root.Cycle"),
+            Some(TriggerStatus::Unresolved { reason, .. }) if reason.contains("form a cycle")
+        ));
+        assert!(matches!(
+            map.get("Root.Missing"),
+            Some(TriggerStatus::Unresolved { reason, .. }) if reason.contains("missing component")
+        ));
+    }
+}

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -145,10 +145,6 @@ fn resolve_selected_trigger(
     resolving: &mut BTreeSet<String>,
 ) -> TriggerStatus {
     let selected = selected.trim();
-    if is_startup_trigger(selected) {
-        return TriggerStatus::Startup;
-    }
-
     if selected.starts_with("$(") {
         let Some((reference, attribute)) = parse_attribute_reference(selected) else {
             return unresolved(
@@ -231,6 +227,9 @@ fn resolve_selected_trigger(
         );
     }
     let leaf = target.rsplit('.').next().unwrap_or(target.as_str());
+    if leaf.eq_ignore_ascii_case("On Startup") {
+        return TriggerStatus::Startup;
+    }
     let Some(number) = leaf
         .strip_prefix("On ")
         .and_then(|value| value.strip_suffix("Hz"))
@@ -262,15 +261,6 @@ fn unresolved(trigger: &str, reason: String) -> TriggerStatus {
     }
 }
 
-fn is_startup_trigger(trigger: &str) -> bool {
-    trigger.eq_ignore_ascii_case("startup")
-        || trigger.eq_ignore_ascii_case("On Startup")
-        || trigger
-            .rsplit('.')
-            .next()
-            .is_some_and(|leaf| leaf.eq_ignore_ascii_case("On Startup"))
-}
-
 fn parse_attribute_reference(expression: &str) -> Option<(&str, &str)> {
     let body = expression.strip_prefix("$(")?.strip_suffix(')')?;
     let (component, attribute) = body.rsplit_once(':')?;
@@ -294,7 +284,10 @@ fn resolve_component_path(owner: &str, value: &str) -> Option<String> {
         climb += 1;
         rest = tail;
     }
-    if climb > owner_segments.len() || rest.is_empty() {
+    // `Root` is the highest valid component. Consuming every owner segment
+    // would step above it and produce a non-canonical path without the Root
+    // prefix, so treat that as an invalid climb rather than a missing target.
+    if rest.is_empty() || (climb > 0 && climb >= owner_segments.len()) {
         return None;
     }
     let ancestor = &owner_segments[..owner_segments.len() - climb];
@@ -327,12 +320,16 @@ mod tests {
   <Component Classname="BuiltIn.GroupCompound" Name="Root.Events"/>
   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On 100Hz"/>
   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On 200Hz"/>
+  <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On Startup"/>
   <Component Classname="BuiltIn.FuncUser" Name="Root.Direct" Filename="Direct.m1scr"><Props SelectedTrigger="Root.Events.On 100Hz"/></Component>
   <Component Classname="BuiltIn.GroupCompound" Name="Root.Control"/>
   <Component Classname="BuiltIn.FuncUser" Name="Root.Control.Grouped" Filename="Grouped.m1scr"><Props SelectedTrigger="Parent.Parent.Events.On 100Hz"/></Component>
   <Component Classname="BuiltIn.MethodUser" Name="Root.Control.Calculation"><Props SelectedTrigger="Parent.Parent.Events.On 200Hz"/></Component>
   <Component Classname="BuiltIn.FuncUser" Name="Root.Control.Parameterized" Filename="Parameterized.m1scr"><Props SelectedTrigger="$(Parent.Calculation:SelectedTrigger)"/></Component>
   <Component Classname="BuiltIn.FuncUser" Name="Root.Startup" Filename="Startup.m1scr"><Props SelectedTrigger="Parent.Events.On Startup"/></Component>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.DanglingStartup" Filename="DanglingStartup.m1scr"><Props SelectedTrigger="Root.Nope.On Startup"/></Component>
+  <Component Classname="BuiltIn.GroupCompound" Name="Root.NotAnEvent.On Startup"/>
+  <Component Classname="BuiltIn.FuncUser" Name="Root.WrongStartupClass" Filename="WrongStartupClass.m1scr"><Props SelectedTrigger="Root.NotAnEvent.On Startup"/></Component>
   <Component Classname="BuiltIn.FuncUserParam" Name="Root.Helper" Filename="Helper.m1scr"/>
   <Component Classname="BuiltIn.FuncUser" Name="Root.Unscheduled" Filename="Unscheduled.m1scr"/>
   <Component Classname="BuiltIn.FuncUser" Name="Root.Invalid" Filename="Invalid.m1scr"><Props SelectedTrigger="Root.Events.On 999Hz"/></Component>
@@ -344,6 +341,8 @@ mod tests {
                 "Grouped.m1scr",
                 "Parameterized.m1scr",
                 "Startup.m1scr",
+                "DanglingStartup.m1scr",
+                "WrongStartupClass.m1scr",
                 "Helper.m1scr",
                 "Unscheduled.m1scr",
                 "Invalid.m1scr",
@@ -363,6 +362,16 @@ mod tests {
             Some(&TriggerStatus::Periodic(200.0))
         );
         assert_eq!(map.get("Root.Startup"), Some(&TriggerStatus::Startup));
+        assert!(matches!(
+            map.get("Root.DanglingStartup"),
+            Some(TriggerStatus::Unresolved { reason, .. })
+                if reason.contains("missing component `Root.Nope.On Startup`")
+        ));
+        assert!(matches!(
+            map.get("Root.WrongStartupClass"),
+            Some(TriggerStatus::Unresolved { reason, .. })
+                if reason.contains("instead of a BuiltIn.EventKernel")
+        ));
         assert_eq!(map.get("Root.Helper"), Some(&TriggerStatus::Helper));
         assert_eq!(
             map.get("Root.Unscheduled"),
@@ -393,5 +402,17 @@ mod tests {
             map.get("Root.Missing"),
             Some(TriggerStatus::Unresolved { reason, .. }) if reason.contains("missing component")
         ));
+    }
+
+    #[test]
+    fn relative_paths_cannot_climb_above_root() {
+        assert_eq!(
+            resolve_component_path("Root.Group.Function", "Parent.Parent.Events.On 100Hz"),
+            Some("Root.Events.On 100Hz".to_string())
+        );
+        assert_eq!(
+            resolve_component_path("Root.Group", "Parent.Parent.Events.On 100Hz"),
+            None
+        );
     }
 }

--- a/tests/evm1_smoke.rs
+++ b/tests/evm1_smoke.rs
@@ -161,15 +161,16 @@ fn evm1_whole_project_runs_end_to_end() {
     };
     let engine = load_evm1(&dir);
 
-    // A short whole-project run. No `target` is needed in whole-project mode; the
-    // base tick is pinned at 500 Hz (the fastest EV-M1 control rate) so every
-    // scheduled rate (500/200/50/10/2 Hz) divides it cleanly. 0.02 s = 10 base
-    // ticks — enough for the slower loops to fire at least once.
+    // A short whole-project run needs no `target`. The base tick is pinned at
+    // 1000 Hz, the least common multiple of the scheduled 500/200/50/10/2 Hz
+    // rates, giving every function an exact integer tick period. 0.02 s = 20
+    // base ticks — enough for the slower loops to fire
+    // at least once.
     let scenario = Scenario::from_toml_str(
         r#"
 mode = "whole-project"
 duration_s = 0.02
-base_rate_hz = 500.0
+base_rate_hz = 1000.0
 "#,
     )
     .expect("whole-project scenario parses");
@@ -178,8 +179,8 @@ base_rate_hz = 500.0
         .run(&scenario)
         .expect("EV-M1 whole-project run completes without an EvalError");
 
-    // 0.02 s at 500 Hz = 10 base ticks; the trace has a dense time axis.
-    assert_eq!(trace.time.len(), 10, "expected 10 base ticks");
+    // 0.02 s at 1000 Hz = 20 base ticks; the trace has a dense time axis.
+    assert_eq!(trace.time.len(), 20, "expected 20 base ticks");
     assert!(
         !trace.channels.is_empty(),
         "whole-project run produced no channel columns"

--- a/tests/evm1_smoke.rs
+++ b/tests/evm1_smoke.rs
@@ -99,6 +99,44 @@ fn evm1_phase15_categories_are_closed() {
     }
 }
 
+/// Issue #41 corpus gate: the four suspension update functions inherit their
+/// trigger from each sensor's `Absolute Travel.Calculation` component. All four
+/// must resolve to the effective 200 Hz rate instead of appearing unresolved or
+/// unscheduled.
+#[test]
+#[ignore = "requires M1_EVAL_EVM1_DIR pointing at the proprietary EV-M1 project"]
+fn evm1_parameterized_suspension_triggers_resolve_to_200_hz() {
+    let Some(dir) = evm1_dir() else {
+        eprintln!("M1_EVAL_EVM1_DIR unset; skipping EV-M1 trigger-resolution gate");
+        return;
+    };
+    let report = load_evm1(&dir).coverage();
+    let by_function: std::collections::HashMap<&str, Option<f64>> = report
+        .schedule
+        .iter()
+        .map(|(function, rate)| (function.as_str(), *rate))
+        .collect();
+    for function in [
+        "Root.Vehicle.Suspension.Front.Left.Linpot.Update",
+        "Root.Vehicle.Suspension.Front.Right.Linpot.Update",
+        "Root.Vehicle.Suspension.Rear.Left.Linpot.Update",
+        "Root.Vehicle.Suspension.Rear.Right.Linpot.Update",
+    ] {
+        assert_eq!(
+            by_function.get(function),
+            Some(&Some(200.0)),
+            "{function} must inherit its 200 Hz Calculation trigger"
+        );
+        assert!(
+            report
+                .unresolved
+                .iter()
+                .all(|entry| entry.function != function),
+            "{function} must not remain unresolved"
+        );
+    }
+}
+
 /// Phase-2 acceptance gate ([`evm1_whole_project_runs_end_to_end`]).
 ///
 /// Loads the real EV-M1 project and runs the **whole-project multi-rate

--- a/tests/fixtures/triggers/Project.m1prj
+++ b/tests/fixtures/triggers/Project.m1prj
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!-- Synthetic trigger-resolution fixture. No proprietary MoTeC content. -->
+<MoTeCM1BuildSession>
+ <Project Name="Triggers" TargetHardware="ecu120">
+  <ComponentStream><List>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.T"/>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Events"/>
+   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On 50Hz"/>
+   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On 100Hz"/>
+   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On 200Hz"/>
+   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On Startup"/>
+
+   <Component Classname="BuiltIn.Channel" Name="Root.T.Direct Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.T.Grouped Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.T.Parameterized Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.T.Started"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.T.Unscheduled Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.T.Invalid Out"><Props Type="f32"/></Component>
+
+   <Component Classname="BuiltIn.FuncUser" Filename="T.Direct.m1scr" Name="Root.T.Direct">
+    <Props SelectedTrigger="Root.Events.On 100Hz"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="T.Grouped.m1scr" Name="Root.T.Grouped">
+    <Props SelectedTrigger="Parent.Parent.Events.On 50Hz"/>
+   </Component>
+   <Component Classname="BuiltIn.MethodUser" Name="Root.T.Calculation">
+    <Props SelectedTrigger="Parent.Parent.Events.On 200Hz"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="T.Parameterized.m1scr" Name="Root.T.Parameterized">
+    <Props SelectedTrigger="$(Parent.Calculation:SelectedTrigger)"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="T.Startup.m1scr" Name="Root.T.Startup">
+    <Props SelectedTrigger="Parent.Parent.Events.On Startup"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUserParam" Filename="T.Helper.m1scr" Name="Root.T.Helper"/>
+   <Component Classname="BuiltIn.FuncUser" Filename="T.Unscheduled.m1scr" Name="Root.T.Unscheduled"/>
+   <Component Classname="BuiltIn.FuncUser" Filename="T.Invalid.m1scr" Name="Root.T.Invalid">
+    <Props SelectedTrigger="Root.Events.On 999Hz"/>
+   </Component>
+  </List></ComponentStream>
+ </Project>
+</MoTeCM1BuildSession>

--- a/tests/fixtures/triggers/Scripts/T.Direct.m1scr
+++ b/tests/fixtures/triggers/Scripts/T.Direct.m1scr
@@ -1,0 +1,2 @@
+// Synthetic trigger-resolution fixture. No proprietary content.
+Direct Out = 1.0;

--- a/tests/fixtures/triggers/Scripts/T.Grouped.m1scr
+++ b/tests/fixtures/triggers/Scripts/T.Grouped.m1scr
@@ -1,0 +1,2 @@
+// Synthetic trigger-resolution fixture. No proprietary content.
+Grouped Out = 2.0;

--- a/tests/fixtures/triggers/Scripts/T.Helper.m1scr
+++ b/tests/fixtures/triggers/Scripts/T.Helper.m1scr
@@ -1,0 +1,2 @@
+// Synthetic trigger-resolution fixture. No proprietary content.
+Out = 5.0;

--- a/tests/fixtures/triggers/Scripts/T.Invalid.m1scr
+++ b/tests/fixtures/triggers/Scripts/T.Invalid.m1scr
@@ -1,0 +1,2 @@
+// Synthetic trigger-resolution fixture. No proprietary content.
+Invalid Out = 7.0;

--- a/tests/fixtures/triggers/Scripts/T.Parameterized.m1scr
+++ b/tests/fixtures/triggers/Scripts/T.Parameterized.m1scr
@@ -1,0 +1,2 @@
+// Synthetic trigger-resolution fixture. No proprietary content.
+Parameterized Out = 3.0;

--- a/tests/fixtures/triggers/Scripts/T.Startup.m1scr
+++ b/tests/fixtures/triggers/Scripts/T.Startup.m1scr
@@ -1,0 +1,2 @@
+// Synthetic trigger-resolution fixture. No proprietary content.
+Started = 4.0;

--- a/tests/fixtures/triggers/Scripts/T.Unscheduled.m1scr
+++ b/tests/fixtures/triggers/Scripts/T.Unscheduled.m1scr
@@ -1,0 +1,2 @@
+// Synthetic trigger-resolution fixture. No proprietary content.
+Unscheduled Out = 6.0;

--- a/tests/snapshots/snapshot__coverage_render.snap
+++ b/tests/snapshots/snapshot__coverage_render.snap
@@ -12,4 +12,4 @@ Stubbed:
 Unsupported:
   (none)
 Schedule:
-  Root.Demo.Update (unscheduled)
+  Root.Demo.Update (unscheduled, no trigger selected)


### PR DESCRIPTION
## Summary

- resolve direct, group-relative, and `$(<component>:SelectedTrigger)` project triggers through one shared trigger map
- use effective trigger status in runtime scheduling and coverage, with separate periodic, startup, helper, unscheduled, and actionable unresolved states
- add synthetic end-to-end coverage plus an opt-in EV corpus gate for the four suspension update functions

## Validation

- `cargo test --verbose`
- `cargo test --verbose --features ld`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `cargo +1.88 check --all-targets`
- opt-in EV corpus test confirms all four known suspension update functions resolve to 200 Hz
- AV and EV project schedules were inspected locally; proprietary project data is not committed

Closes #41