### PR TITLE
Complete core object-method and Library-qualified dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ do not compare computed channel values with captured M1 results.
 | --- | --- | --- |
 | Expressions, statements, enums, and inline user functions | **Assumed** | Covered by unit and synthetic-project tests. M1 evaluation results have not been captured for comparison. |
 | `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | Parsing, interpolation, and edge clamping use synthetic fixtures. Use the matching calibration file for actual values. Without it, parameters use typed external defaults. Table `.Lookup()` and `.Get()` fail in strict modes; whole-project mode may opt in to an external `0.0` fallback. |
-| `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, and table methods | **Assumed** | Implemented methods have hand-derived tests. `--coverage` remains authoritative for the methods a project uses. |
+| `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, core value-object methods, and table methods | **Assumed** | Implemented methods have hand-derived tests. `AsString`, `Validate`, `Constrain`, `GetUnscheduled`, and `Set` resolve against the receiver; `Set` applies its project validation range before writing. `--coverage` remains authoritative for the methods a project uses. |
 | Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. |
 | `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Stubbed** | Scenario `[[io]]` values take precedence. Otherwise calls use documented or generic typed stubs; writes are offline no-ops. |
 | Scenario parsing, tick grids, trace output, and `--coverage` | **Assumed** | These are deterministic m1-eval contracts tested with synthetic data. A `Supported` coverage entry means implemented, not M1-verified. |
@@ -168,6 +168,16 @@ with its execution rate (`@ 500 Hz`, `@ 50 Hz`, …), `startup, runs once`, or
 an explicit `helper`, `unscheduled`, or `unresolved trigger` status. The last
 status includes the failed path or attribute, so a project author can repair the
 selection instead of treating every excluded function as the same case.
+
+Core value-object calls are receiver-aware. Enum values provide `AsInteger()`
+and `AsString()`. Numeric channels, parameters, tables, and value compounds
+provide `Validate(v)`, `Constrain(v)`, and `GetUnscheduled()`. `MinMax` project
+validation is inclusive; the legacy `Positive` rule is treated as a lower bound
+of zero. `Constrain` retains its argument's M1 scalar family. `Set(v)` first
+converts to the writable target's family, then applies the same range before it
+writes. `GetUnscheduled()` performs an ordinary runtime read but deliberately
+adds no scheduler dependency. Unknown validation kinds fail if execution reaches
+one, and unsupported receiver/method pairs name the exact call.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ do not compare computed channel values with captured M1 results.
 | --- | --- | --- |
 | Expressions, statements, enums, and inline user functions | **Assumed** | Covered by unit and synthetic-project tests. M1 evaluation results have not been captured for comparison. |
 | `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | Parsing, interpolation, and edge clamping use synthetic fixtures. Use the matching calibration file for actual values. Without it, parameters use typed external defaults. Table `.Lookup()` and `.Get()` fail in strict modes; whole-project mode may opt in to an external `0.0` fallback. |
-| `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, core value-object methods, and table methods | **Assumed** | Implemented methods have hand-derived tests. `AsString`, `Validate`, `Constrain`, `GetUnscheduled`, and `Set` resolve against the receiver; `Set` applies its project validation range before writing. `--coverage` remains authoritative for the methods a project uses. |
+| `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, core value-object methods, and table methods | **Assumed** | Implemented methods have hand-derived tests. `AsString`, `Validate`, `Constrain`, `GetUnscheduled`, and `Set` resolve against eligible receiver classes; channel `Set` applies its project validation range before writing. `--coverage` remains authoritative for the methods a project uses. |
 | Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. |
 | `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Stubbed** | Scenario `[[io]]` values take precedence. Otherwise calls use documented or generic typed stubs; writes are offline no-ops. |
 | Scenario parsing, tick grids, trace output, and `--coverage` | **Assumed** | These are deterministic m1-eval contracts tested with synthetic data. A `Supported` coverage entry means implemented, not M1-verified. |
@@ -171,13 +171,16 @@ selection instead of treating every excluded function as the same case.
 
 Core value-object calls are receiver-aware. Enum values provide `AsInteger()`
 and `AsString()`. Numeric channels, parameters, tables, and value compounds
-provide `Validate(v)`, `Constrain(v)`, and `GetUnscheduled()`. `MinMax` project
-validation is inclusive; the legacy `Positive` rule is treated as a lower bound
-of zero. `Constrain` retains its argument's M1 scalar family. `Set(v)` first
-converts to the writable target's family, then applies the same range before it
-writes. `GetUnscheduled()` performs an ordinary runtime read but deliberately
-adds no scheduler dependency. Unknown validation kinds fail if execution reaches
-one, and unsupported receiver/method pairs name the exact call.
+provide `Validate(v)` and `Constrain(v)`. `MinMax` project validation is
+inclusive; each endpoint is converted to the argument's M1 scalar family, and
+the legacy `Positive` rule is treated as a lower bound of zero. `Constrain`
+retains that family. `Set(v)` is available to channels and channel-backed value
+compounds; it converts to the writable channel's family, then applies the same
+range before it writes. Parameters remain calibration-owned. Channels and
+tuning tables provide `GetUnscheduled()`, which performs an ordinary runtime
+read but deliberately adds no scheduler dependency. Unknown validation kinds
+fail if execution reaches one, and unsupported receiver/method pairs name the
+exact call.
 
 ## Quickstart
 

--- a/src/builtins/enum_conv.rs
+++ b/src/builtins/enum_conv.rs
@@ -58,6 +58,10 @@ pub fn as_string(object: &str, ctx: &mut EvalCtx) -> Result<Option<Value>, EvalE
     let Some(value) = enum_value(object, ctx)? else {
         return Ok(None);
     };
+    // Match AsInteger's fail-loud membership contract. `Value::Enum` is public,
+    // so a caller can seed a structurally valid value whose member does not
+    // belong to its declared enum; never echo that corrupt member as a string.
+    value.as_enum_int(ctx.project)?;
     let Value::Enum { member, .. } = value else {
         unreachable!("enum_value only returns Value::Enum");
     };

--- a/src/builtins/enum_conv.rs
+++ b/src/builtins/enum_conv.rs
@@ -27,7 +27,9 @@ use crate::error::EvalError;
 use crate::expr::EvalCtx;
 use crate::ident::{Target, classify};
 use crate::value::Value;
+use m1_typecheck::Project;
 use m1_typecheck::symbols::SymbolKind;
+use std::collections::{HashMap, HashSet};
 
 /// Convert `<object>.AsInteger()` to its declared enum integer.
 ///
@@ -41,6 +43,29 @@ use m1_typecheck::symbols::SymbolKind;
 ///   conversion cannot proceed (an unknown member, an unset enum channel, or a
 ///   non-enum runtime value) — never a guessed integer.
 pub fn as_integer(object: &str, ctx: &mut EvalCtx) -> Result<Option<Value>, EvalError> {
+    let Some(value) = enum_value(object, ctx)? else {
+        return Ok(None);
+    };
+    let integer =
+        i32::try_from(value.as_enum_int(ctx.project)?).map_err(|_| EvalError::TypeError {
+            detail: format!("enum value from {object:?} is outside the M1 Integer range"),
+        })?;
+    Ok(Some(Value::m1_integer(integer)))
+}
+
+/// Convert `<object>.AsString()` to the enum member's exact display name.
+pub fn as_string(object: &str, ctx: &mut EvalCtx) -> Result<Option<Value>, EvalError> {
+    let Some(value) = enum_value(object, ctx)? else {
+        return Ok(None);
+    };
+    let Value::Enum { member, .. } = value else {
+        unreachable!("enum_value only returns Value::Enum");
+    };
+    Ok(Some(Value::Str(member)))
+}
+
+/// Resolve either supported enum source form to its current enum value.
+fn enum_value(object: &str, ctx: &mut EvalCtx) -> Result<Option<Value>, EvalError> {
     // Form 1: an enum-type-qualified member literal `<EnumTypeName>.<Member>`.
     // Split on the rightmost `.` only — both the type name and the member may
     // contain spaces.
@@ -48,15 +73,10 @@ pub fn as_integer(object: &str, ctx: &mut EvalCtx) -> Result<Option<Value>, Eval
         && let Some(id) = ctx.project.symbols().enum_by_name(prefix)
     {
         if ctx.project.symbols().enum_has_member(id, leaf) {
-            let v = Value::Enum {
+            return Ok(Some(Value::Enum {
                 id,
                 member: leaf.to_string(),
-            };
-            let integer =
-                i32::try_from(v.as_enum_int(ctx.project)?).map_err(|_| EvalError::TypeError {
-                    detail: format!("enum member {leaf:?} is outside the M1 Integer range"),
-                })?;
-            return Ok(Some(Value::m1_integer(integer)));
+            }));
         }
         // The prefix *is* an enum type but the leaf is not one of its members:
         // a fail-loud error rather than a silent miss — the author wrote an
@@ -79,25 +99,64 @@ pub fn as_integer(object: &str, ctx: &mut EvalCtx) -> Result<Option<Value>, Eval
         // fall through to other dispatch.
         return Ok(None);
     };
-    let Some(kind) = ctx.project.symbols().get(&canon).map(|s| s.kind) else {
+    let Some(value_path) = enum_value_path(&canon, ctx.project) else {
         return Ok(None);
     };
+    read_enum_at(&value_path, ctx).map(Some)
+}
 
-    match kind {
-        // An enum-typed channel (or parameter): read its current enum value.
-        SymbolKind::Channel | SymbolKind::Parameter => convert_value_at(&canon, ctx).map(Some),
-        // A value-compound: the enum value lives on its `.Value` child.
-        SymbolKind::Group => {
-            let value_path = format!("{canon}.Value");
-            // Only treat it as a value-compound when the `.Value` child exists.
-            if ctx.project.symbols().get(&value_path).is_none() {
-                return Ok(None);
-            }
-            convert_value_at(&value_path, ctx).map(Some)
-        }
-        // Any other symbol kind is not an enum source — fall through.
-        _ => Ok(None),
+/// Resolve an enum-valued project object to the symbol `read_symbol` consumes.
+/// Constants and direct typed objects keep their own path. A value compound
+/// follows its declared default, then its generated `.Value` child.
+pub(crate) fn enum_value_path(canon: &str, project: &Project) -> Option<String> {
+    enum_value_path_inner(canon, project, &mut HashSet::new())
+}
+
+fn enum_value_path_inner(
+    canon: &str,
+    project: &Project,
+    seen: &mut HashSet<String>,
+) -> Option<String> {
+    if !seen.insert(canon.to_string()) {
+        return None;
     }
+    let symbol = project.symbols().get(canon)?;
+    if symbol.value_type.is_enum()
+        && matches!(
+            symbol.kind,
+            SymbolKind::Channel
+                | SymbolKind::Parameter
+                | SymbolKind::Constant
+                | SymbolKind::Object
+                | SymbolKind::Reference
+                | SymbolKind::Other
+        )
+    {
+        return Some(canon.to_string());
+    }
+
+    if symbol.kind == SymbolKind::Group
+        && let Some(default) = symbol.default_value.as_deref()
+    {
+        let locals = HashMap::new();
+        if let Target::Symbol(path) = classify(default, Some(canon), None, project, &locals)
+            && let Some(value_path) = enum_value_path_inner(&path, project, seen)
+        {
+            return Some(value_path);
+        }
+    }
+
+    if matches!(
+        symbol.kind,
+        SymbolKind::Group | SymbolKind::Table | SymbolKind::Object
+    ) {
+        let value_path = format!("{canon}.Value");
+        return project
+            .symbols()
+            .get(&value_path)
+            .and_then(|_| enum_value_path_inner(&value_path, project, seen));
+    }
+    None
 }
 
 /// Read the current value at a canonical channel path and convert it to its enum
@@ -106,13 +165,15 @@ pub fn as_integer(object: &str, ctx: &mut EvalCtx) -> Result<Option<Value>, Eval
 /// whole-project mode) the channel's externally-driven enum startup default, else
 /// — in single-function/cone mode — a fail-loud [`EvalError::MissingInput`]. A
 /// non-enum value is a `TypeError` (never a guessed integer).
-fn convert_value_at(canon: &str, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
+fn read_enum_at(canon: &str, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
     let value = crate::expr::read_symbol(canon, ctx)?;
-    let integer =
-        i32::try_from(value.as_enum_int(ctx.project)?).map_err(|_| EvalError::TypeError {
-            detail: format!("enum value at {canon:?} is outside the M1 Integer range"),
-        })?;
-    Ok(Value::m1_integer(integer))
+    if matches!(value, Value::Enum { .. }) {
+        Ok(value)
+    } else {
+        Err(EvalError::TypeError {
+            detail: format!("value at {canon:?} is not an enum value"),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -165,6 +226,7 @@ mod tests {
                 dt: 0.01,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: None,
             }

--- a/src/builtins/io_stub.rs
+++ b/src/builtins/io_stub.rs
@@ -353,6 +353,7 @@ mod tests {
                 dt: 0.02,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: Some(&mut self.trace),
             };

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -24,6 +24,7 @@ pub mod convert;
 pub mod enum_conv;
 pub mod io_stub;
 pub mod limit;
+pub mod object;
 pub mod stateful;
 pub mod userfn;
 
@@ -139,10 +140,29 @@ pub fn dispatch(
                 None => Err(unsupported(object, method)),
             }
         }
-        CallRoute::ChannelSet => match try_channel_set(object, args, ctx)? {
-            Some(value) => Ok(value),
-            None => Err(unsupported(object, method)),
-        },
+        CallRoute::EnumAsString => {
+            validate_object_arity(object, method, args.len())?;
+            match enum_conv::as_string(object, ctx)? {
+                Some(value) => Ok(value),
+                None => Err(unsupported(object, method)),
+            }
+        }
+        CallRoute::ObjectValidate => {
+            validate_object_arity(object, method, args.len())?;
+            object::validate(object, args, ctx)
+        }
+        CallRoute::ObjectConstrain => {
+            validate_object_arity(object, method, args.len())?;
+            object::constrain(object, args, ctx)
+        }
+        CallRoute::ObjectGetUnscheduled => {
+            validate_object_arity(object, method, args.len())?;
+            object::get_unscheduled(object, ctx)
+        }
+        CallRoute::ChannelSet => {
+            validate_object_arity(object, method, args.len())?;
+            object::set(object, args, ctx)
+        }
         CallRoute::Timer => {
             validate_object_arity(object, method, args.len())?;
             let object_key = timer_object_key(object, ctx);
@@ -199,57 +219,6 @@ pub(crate) fn dispatch_bare(
         kind: format!("call to non-function {callee:?}"),
         at: site.offset(),
     })
-}
-
-/// Attempt a channel `.Set(value)` imperative setter. Returns `Ok(Some(unit))`
-/// when `object` resolves to a `Channel`/`Parameter` symbol — writing the single
-/// evaluated argument to its canonical path and recording the write to the trace
-/// — and `Ok(None)` when `object` is not a channel (so dispatch falls through to
-/// IO/Timer routing). A wrong argument count is a fail-loud [`EvalError::BadCall`]
-/// (the setter takes exactly one value).
-fn try_channel_set(
-    object: &str,
-    args: &[Value],
-    ctx: &mut EvalCtx,
-) -> Result<Option<Value>, EvalError> {
-    // Only a project channel/parameter has an imperative `.Set`.
-    let Target::Symbol(canon) = classify(
-        object,
-        ctx.group,
-        ctx.fn_symbol,
-        ctx.project,
-        &ctx.env.locals,
-    ) else {
-        return Ok(None);
-    };
-    let is_writable = ctx
-        .project
-        .symbols()
-        .get(&canon)
-        .map(|s| matches!(s.kind, SymbolKind::Channel | SymbolKind::Parameter))
-        .unwrap_or(false);
-    if !is_writable {
-        return Ok(None);
-    }
-
-    // The setter takes exactly one value — fail loud on any other arity rather
-    // than guessing which argument to write.
-    if args.len() != 1 {
-        return Err(EvalError::BadCall {
-            detail: format!("{object}.Set expects 1 argument, got {}", args.len()),
-        });
-    }
-    // Apply the target channel's declared M1 family. Integer/unsigned writes use
-    // their shared 32-bit pattern, float promotion rounds to binary32, and an
-    // enum target resolves the exact member value.
-    let value = crate::expr::coerce_for_channel(&canon, args[0].clone(), ctx.project)?;
-    ctx.env.set(canon.clone(), value.clone());
-    if let Some(trace) = ctx.trace.as_deref_mut() {
-        trace.record_channel(canon, value.clone());
-    }
-    // The setter is a statement-level write; reuse the unit value the IO void
-    // writers return so an expression-statement call succeeds.
-    Ok(Some(Value::Bool(true)))
 }
 
 /// The state key for a Timer object: a [`CallSite`] whose script slot is the
@@ -541,6 +510,10 @@ enum CallRoute {
     TableLookup,
     TableGet,
     EnumAsInteger,
+    EnumAsString,
+    ObjectValidate,
+    ObjectConstrain,
+    ObjectGetUnscheduled,
     ChannelSet,
     Timer,
     ProjectIo,
@@ -684,8 +657,16 @@ pub(crate) fn classify_member_call(
         return classify_library(&library_object, method);
     }
 
-    if method == "AsInteger" && is_enum_literal(object, project) {
-        return capability(BuiltinSupport::Direct, CallRoute::EnumAsInteger);
+    // A resolved enum member is never a project IO object. Handle both
+    // supported conversions here and reject every other method before the
+    // unresolved-project fallback can mistake spellings such as `.Set()` for
+    // a hardware stub.
+    if is_enum_literal(object, project) {
+        return match method {
+            "AsInteger" => capability(BuiltinSupport::Direct, CallRoute::EnumAsInteger),
+            "AsString" => capability(BuiltinSupport::Direct, CallRoute::EnumAsString),
+            _ => unsupported_capability(),
+        };
     }
 
     // `Library.` explicitly selects the intrinsic namespace. An unknown object
@@ -771,17 +752,31 @@ fn classify_project_method(canon: &str, method: &str, project: &Project) -> Call
     };
 
     if symbol.kind == SymbolKind::Table {
-        return match method {
-            "Lookup" => capability(BuiltinSupport::Modeled, CallRoute::TableLookup),
-            "Get" => capability(BuiltinSupport::Direct, CallRoute::TableGet),
-            _ => unsupported_capability(),
-        };
+        match method {
+            "Lookup" => return capability(BuiltinSupport::Modeled, CallRoute::TableLookup),
+            "Get" => return capability(BuiltinSupport::Direct, CallRoute::TableGet),
+            // A table may also expose generic numeric accessors through its
+            // generated `.Value` channel. Continue to receiver-aware object
+            // method classification for every other method.
+            _ => {}
+        }
     }
     if method == "AsInteger" && is_enum_source(canon, project) {
         return capability(BuiltinSupport::Direct, CallRoute::EnumAsInteger);
     }
-    if method == "Set" && matches!(symbol.kind, SymbolKind::Channel | SymbolKind::Parameter) {
+    if method == "AsString" && is_enum_source(canon, project) {
+        return capability(BuiltinSupport::Direct, CallRoute::EnumAsString);
+    }
+    if method == "Set" && object::writable_value_path(canon, project).is_some() {
         return capability(BuiltinSupport::Direct, CallRoute::ChannelSet);
+    }
+    if object::is_numeric_source(canon, project) {
+        return match method {
+            "Validate" => capability(BuiltinSupport::Direct, CallRoute::ObjectValidate),
+            "Constrain" => capability(BuiltinSupport::Direct, CallRoute::ObjectConstrain),
+            "GetUnscheduled" => capability(BuiltinSupport::Direct, CallRoute::ObjectGetUnscheduled),
+            _ => unsupported_capability(),
+        };
     }
     if symbol.classname.as_deref() == Some("BuiltIn.Timer")
         && matches!(method, "Start" | "Stop" | "Reset" | "Remaining")
@@ -816,17 +811,7 @@ fn is_enum_literal(object: &str, project: &Project) -> bool {
 }
 
 fn is_enum_source(canon: &str, project: &Project) -> bool {
-    let Some(symbol) = project.symbols().get(canon) else {
-        return false;
-    };
-    match symbol.kind {
-        SymbolKind::Channel | SymbolKind::Parameter => symbol.value_type.is_enum(),
-        SymbolKind::Group => project
-            .symbols()
-            .get(&format!("{canon}.Value"))
-            .is_some_and(|value| value.value_type.is_enum()),
-        _ => false,
-    }
+    enum_conv::enum_value_path(canon, project).is_some()
 }
 
 fn script_backed_user_function(callee: &str, scope: &CapabilityScope<'_>) -> Option<String> {
@@ -938,6 +923,7 @@ mod tests {
                 dt: 0.01,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: None,
             }
@@ -1468,6 +1454,7 @@ mod tests {
                 dt: 0.01,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: None,
             }
@@ -1514,6 +1501,40 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_as_string_preserves_enum_member_names() {
+        let mut h = EnumHarness::new();
+        assert_eq!(
+            h.call("Drive State.Precharging", "AsString", &[]).unwrap(),
+            Value::Str("Precharging".to_string())
+        );
+
+        let id = h.enum_id();
+        h.env.set(
+            "Root.Demo.Mode",
+            Value::Enum {
+                id,
+                member: "Idle".to_string(),
+            },
+        );
+        assert_eq!(
+            h.call("Mode", "AsString", &[]).unwrap(),
+            Value::Str("Idle".to_string())
+        );
+
+        h.env.set(
+            "Root.Demo.Compound.Value",
+            Value::Enum {
+                id,
+                member: "Precharging".to_string(),
+            },
+        );
+        assert_eq!(
+            h.call("Compound", "AsString", &[]).unwrap(),
+            Value::Str("Precharging".to_string())
+        );
+    }
+
+    #[test]
     fn dispatch_as_integer_on_non_enum_fails_loud() {
         let mut h = EnumHarness::new();
         // A name that is neither an enum literal nor an enum-typed project symbol:
@@ -1528,7 +1549,7 @@ mod tests {
     }
 
     #[test]
-    fn as_integer_is_classified_supported() {
+    fn enum_conversions_are_classified_by_receiver() {
         let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums");
         let loaded =
             crate::loader::load(&dir.join("Project.m1prj"), None).expect("enums fixture loads");
@@ -1539,6 +1560,26 @@ mod tests {
                 Some("Root.Demo.Update"),
                 "Drive State.Idle",
                 "AsInteger"
+            ),
+            BuiltinSupport::Direct
+        );
+        assert_eq!(
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Drive State.Idle",
+                "AsString"
+            ),
+            BuiltinSupport::Direct
+        );
+        assert_eq!(
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Mode",
+                "AsString"
             ),
             BuiltinSupport::Direct
         );
@@ -1562,6 +1603,17 @@ mod tests {
             ),
             BuiltinSupport::Unsupported,
             "a non-enum channel is not an AsInteger receiver"
+        );
+        assert_eq!(
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Precharge State",
+                "AsString"
+            ),
+            BuiltinSupport::Unsupported,
+            "a non-enum channel is not an AsString receiver"
         );
     }
 
@@ -1607,6 +1659,7 @@ mod tests {
     struct ProjectObjHarness {
         project: Project,
         calib: Calibration,
+        object_rules: object::ObjectRules,
         env: Env,
         state: StateStore,
         trace: crate::trace::Trace,
@@ -1620,6 +1673,7 @@ mod tests {
             ProjectObjHarness {
                 project: loaded.project,
                 calib: Calibration::default(),
+                object_rules: loaded.object_rules,
                 env: Env::new(),
                 state: StateStore::new(),
                 trace: crate::trace::Trace::new(),
@@ -1639,6 +1693,7 @@ mod tests {
                 dt: 0.01,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: Some(&self.object_rules),
                 depth: 0,
                 trace: Some(&mut self.trace),
             };
@@ -1708,6 +1763,211 @@ mod tests {
     }
 
     #[test]
+    fn validate_uses_inclusive_project_ranges_and_positive_rules() {
+        let mut h = ProjectObjHarness::new();
+        for (value, expected) in [(-3, false), (-2, true), (3, true), (4, false)] {
+            assert_eq!(
+                h.call("Limited Signed", "Validate", &[Value::m1_integer(value)])
+                    .unwrap(),
+                Value::Bool(expected),
+                "value {value}"
+            );
+        }
+        assert_eq!(
+            h.call("Positive Float", "Validate", &[Value::m1_float(-0.5)])
+                .unwrap(),
+            Value::Bool(false)
+        );
+        assert_eq!(
+            h.call("Positive Float", "Validate", &[Value::m1_float(0.0)])
+                .unwrap(),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            h.call("Free Unsigned", "Validate", &[Value::m1_unsigned(u32::MAX)])
+                .unwrap(),
+            Value::Bool(true),
+            "an object without validation accepts its numeric domain"
+        );
+    }
+
+    #[test]
+    fn constrain_clamps_and_preserves_each_m1_scalar_family() {
+        let mut h = ProjectObjHarness::new();
+        assert_eq!(
+            h.call("Limited Signed", "Constrain", &[Value::m1_integer(-10)])
+                .unwrap(),
+            Value::m1_integer(-2)
+        );
+        assert_eq!(
+            h.call("Limited Float", "Constrain", &[Value::m1_float(8.0)])
+                .unwrap(),
+            Value::m1_float(2.25)
+        );
+        assert_eq!(
+            h.call(
+                "Limited Fixed",
+                "Constrain",
+                &[Value::M1(M1Scalar::FixedPoint7dps(
+                    crate::value::FixedPoint7dps::from_raw(-20_000_000)
+                ))]
+            )
+            .unwrap(),
+            Value::M1(M1Scalar::FixedPoint7dps(
+                crate::value::FixedPoint7dps::from_raw(-12_345_678)
+            ))
+        );
+        assert_eq!(
+            h.call(
+                "Limited Unsigned",
+                "Constrain",
+                &[Value::m1_unsigned(u32::MAX)]
+            )
+            .unwrap(),
+            Value::m1_unsigned(10)
+        );
+    }
+
+    #[test]
+    fn set_coerces_then_clamps_to_the_target_rule() {
+        let mut h = ProjectObjHarness::new();
+        h.call("Limited Signed", "Set", &[Value::m1_unsigned(20)])
+            .unwrap();
+        assert_eq!(
+            h.env.get("Root.Demo.Limited Signed"),
+            Some(&Value::m1_integer(3))
+        );
+
+        h.call("Limited Float", "Set", &[Value::m1_integer(-10)])
+            .unwrap();
+        assert_eq!(
+            h.env.get("Root.Demo.Limited Float"),
+            Some(&Value::m1_float(-1.5))
+        );
+
+        h.call("Positive Float", "Set", &[Value::m1_float(-2.0)])
+            .unwrap();
+        assert_eq!(
+            h.env.get("Root.Demo.Positive Float"),
+            Some(&Value::m1_float(0.0))
+        );
+    }
+
+    #[test]
+    fn get_unscheduled_reads_the_exact_stored_scalar() {
+        let mut h = ProjectObjHarness::new();
+        h.env.set("Root.Demo.Limited Signed", Value::m1_integer(-1));
+        assert_eq!(
+            h.call("Limited Signed", "GetUnscheduled", &[]).unwrap(),
+            Value::m1_integer(-1)
+        );
+    }
+
+    #[test]
+    fn numeric_value_compounds_follow_their_declared_default() {
+        let mut h = ProjectObjHarness::new();
+        assert_eq!(
+            h.call("Limited Compound", "Validate", &[Value::m1_unsigned(5)])
+                .unwrap(),
+            Value::Bool(false)
+        );
+        assert_eq!(
+            h.call("Limited Compound", "Constrain", &[Value::m1_unsigned(5)])
+                .unwrap(),
+            Value::m1_unsigned(4)
+        );
+        h.env
+            .set("Root.Demo.Limited Compound.Value", Value::m1_unsigned(3));
+        assert_eq!(
+            h.call("Limited Compound", "GetUnscheduled", &[]).unwrap(),
+            Value::m1_unsigned(3)
+        );
+        h.call("Limited Compound", "Set", &[Value::m1_unsigned(9)])
+            .unwrap();
+        assert_eq!(
+            h.env.get("Root.Demo.Limited Compound.Value"),
+            Some(&Value::m1_unsigned(4)),
+            "Set writes the concrete value child after applying the compound's range"
+        );
+    }
+
+    #[test]
+    fn get_unscheduled_reads_a_tables_generated_value_channel() {
+        let mut h = Harness::new();
+        h.env.set("Root.Demo.Map.Value", Value::m1_float(12.5));
+        assert_eq!(
+            h.call("Map", "GetUnscheduled", &[]).unwrap(),
+            Value::m1_float(12.5)
+        );
+    }
+
+    #[test]
+    fn unsupported_object_method_pairs_name_the_exact_call() {
+        let mut h = ProjectObjHarness::new();
+        for (object, method, args) in [
+            ("Mode", "Validate", vec![Value::m1_integer(1)]),
+            ("Limited Signed", "AsString", vec![]),
+            ("Startup Delay", "GetUnscheduled", vec![]),
+            ("Drive State.Idle", "Set", vec![Value::m1_integer(1)]),
+        ] {
+            assert_eq!(
+                h.call(object, method, &args),
+                Err(EvalError::UnsupportedBuiltin {
+                    object: object.to_string(),
+                    method: method.to_string(),
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn core_object_methods_have_capability_parity() {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums");
+        let loaded =
+            crate::loader::load(&dir.join("Project.m1prj"), None).expect("enums fixture loads");
+        for (object, method) in [
+            ("Mode", "AsString"),
+            ("Limited Signed", "Validate"),
+            ("Limited Signed", "Constrain"),
+            ("Limited Signed", "GetUnscheduled"),
+            ("Limited Compound", "Validate"),
+            ("Limited Compound", "Constrain"),
+            ("Limited Compound", "GetUnscheduled"),
+            ("Limited Compound", "Set"),
+            ("Limited Signed", "Set"),
+        ] {
+            assert_eq!(
+                support_in(
+                    &loaded,
+                    Some("Root.Demo"),
+                    Some("Root.Demo.Update"),
+                    object,
+                    method,
+                ),
+                BuiltinSupport::Direct,
+                "{object}.{method}"
+            );
+        }
+        for (object, method) in [
+            ("Mode", "Constrain"),
+            ("Limited Signed", "AsString"),
+            ("Startup Delay", "GetUnscheduled"),
+        ] {
+            assert_eq!(
+                support_in(
+                    &loaded,
+                    Some("Root.Demo"),
+                    Some("Root.Demo.Update"),
+                    object,
+                    method,
+                ),
+                BuiltinSupport::Unsupported,
+                "{object}.{method}"
+            );
+        }
+    }
+
+    #[test]
     fn timer_dispatch_requires_a_timer_receiver() {
         let mut h = ProjectObjHarness::new();
         assert_eq!(
@@ -1760,7 +2020,11 @@ mod tests {
         let scripts = parse_all(&[(
             "Demo.Update.m1scr".to_string(),
             "Mode.AsInteger();\n\
+             Mode.AsString();\n\
              Precharge State.Set(1);\n\
+             Limited Signed.Validate(1);\n\
+             Limited Signed.Constrain(1);\n\
+             Limited Signed.GetUnscheduled();\n\
              Startup Delay.Start(1.0);\n\
              Startup Delay.Stop();\n\
              Startup Delay.Reset();\n\
@@ -1774,7 +2038,14 @@ mod tests {
         )]);
         let report = crate::coverage::CoverageReport::analyse_in(&scripts, Some(&harness.project));
 
-        for name in ["Mode.AsInteger", "Precharge State.Set"] {
+        for name in [
+            "Mode.AsInteger",
+            "Mode.AsString",
+            "Precharge State.Set",
+            "Limited Signed.Validate",
+            "Limited Signed.Constrain",
+            "Limited Signed.GetUnscheduled",
+        ] {
             assert!(
                 report.supported.iter().any(|item| item.name == name),
                 "{name} should be supported: {report:?}"
@@ -1816,9 +2087,16 @@ mod tests {
                 member: "Idle".to_string(),
             },
         );
+        harness
+            .env
+            .set("Root.Demo.Limited Signed", Value::m1_integer(1));
         let calls = [
             ("Mode", "AsInteger", vec![]),
+            ("Mode", "AsString", vec![]),
             ("Precharge State", "Set", vec![Value::m1_integer(1)]),
+            ("Limited Signed", "Validate", vec![Value::m1_integer(1)]),
+            ("Limited Signed", "Constrain", vec![Value::m1_integer(1)]),
+            ("Limited Signed", "GetUnscheduled", vec![]),
             ("Startup Delay", "Start", vec![Value::m1_float(1.0)]),
             ("Startup Delay", "Stop", vec![]),
             ("Startup Delay", "Reset", vec![]),

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -773,6 +773,24 @@ fn classify_project_method(canon: &str, method: &str, project: &Project) -> Call
     if method == "GetUnscheduled" && object::unscheduled_value_path(canon, project).is_some() {
         return capability(BuiltinSupport::Direct, CallRoute::ObjectGetUnscheduled);
     }
+    // GetUnscheduled never falls through to a similarly named hardware stub.
+    if method == "GetUnscheduled" {
+        return unsupported_capability();
+    }
+    // A project value that cannot resolve to a writable Channel must not be
+    // reinterpreted as a generic hardware `Set` call. Non-value package
+    // objects and references retain their separately catalogued IO stubs.
+    let generated_value = format!("{canon}.Value");
+    let is_value_group = symbol.kind == SymbolKind::Group
+        && (symbol.default_value.is_some() || project.symbols().get(&generated_value).is_some());
+    if method == "Set"
+        && (matches!(
+            symbol.kind,
+            SymbolKind::Channel | SymbolKind::Parameter | SymbolKind::Constant | SymbolKind::Table
+        ) || is_value_group)
+    {
+        return unsupported_capability();
+    }
     if object::is_numeric_source(canon, project) {
         match method {
             "Validate" => {
@@ -1883,6 +1901,33 @@ mod tests {
     }
 
     #[test]
+    fn set_does_not_bypass_a_compounds_parameter_default() {
+        let mut h = ProjectObjHarness::new();
+        h.env.set(
+            "Root.Demo.Calibration Compound.Calibration",
+            Value::m1_float(1.0),
+        );
+        h.env
+            .set("Root.Demo.Calibration Compound.Value", Value::m1_float(2.0));
+
+        assert_eq!(
+            h.call("Calibration Compound", "Set", &[Value::m1_float(3.0)]),
+            Err(EvalError::UnsupportedBuiltin {
+                object: "Calibration Compound".to_string(),
+                method: "Set".to_string(),
+            })
+        );
+        assert_eq!(
+            h.env.get("Root.Demo.Calibration Compound.Calibration"),
+            Some(&Value::m1_float(1.0))
+        );
+        assert_eq!(
+            h.env.get("Root.Demo.Calibration Compound.Value"),
+            Some(&Value::m1_float(2.0))
+        );
+    }
+
+    #[test]
     fn get_unscheduled_reads_the_exact_stored_scalar() {
         let mut h = ProjectObjHarness::new();
         h.env.set("Root.Demo.Limited Signed", Value::m1_integer(-1));
@@ -2023,6 +2068,7 @@ mod tests {
             ("Limited Compound", "GetUnscheduled"),
             ("Positive Float", "GetUnscheduled"),
             ("Positive Float", "Set"),
+            ("Calibration Compound", "Set"),
             ("Numeric Constant", "GetUnscheduled"),
             ("Typed IO", "GetUnscheduled"),
             ("Startup Delay", "GetUnscheduled"),

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -771,12 +771,21 @@ fn classify_project_method(canon: &str, method: &str, project: &Project) -> Call
         return capability(BuiltinSupport::Direct, CallRoute::ChannelSet);
     }
     if object::is_numeric_source(canon, project) {
-        return match method {
-            "Validate" => capability(BuiltinSupport::Direct, CallRoute::ObjectValidate),
-            "Constrain" => capability(BuiltinSupport::Direct, CallRoute::ObjectConstrain),
-            "GetUnscheduled" => capability(BuiltinSupport::Direct, CallRoute::ObjectGetUnscheduled),
-            _ => unsupported_capability(),
-        };
+        match method {
+            "Validate" => {
+                return capability(BuiltinSupport::Direct, CallRoute::ObjectValidate);
+            }
+            "Constrain" => {
+                return capability(BuiltinSupport::Direct, CallRoute::ObjectConstrain);
+            }
+            "GetUnscheduled" => {
+                return capability(BuiltinSupport::Direct, CallRoute::ObjectGetUnscheduled);
+            }
+            // A typed hardware object also carries a numeric value. Core value
+            // methods claim only their exact names; every other method must
+            // continue to the receiver-specific timer/IO routes below.
+            _ => {}
+        }
     }
     if symbol.classname.as_deref() == Some("BuiltIn.Timer")
         && matches!(method, "Start" | "Stop" | "Reset" | "Remaining")
@@ -1918,6 +1927,41 @@ mod tests {
                 })
             );
         }
+    }
+
+    #[test]
+    fn typed_numeric_project_io_keeps_its_hardware_stub_route() {
+        let loaded = crate::loader::load(
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums/Project.m1prj"),
+            None,
+        )
+        .unwrap();
+        let mut h = ProjectObjHarness::new();
+        assert_eq!(
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Typed IO",
+                "GetScaled",
+            ),
+            BuiltinSupport::Stubbed
+        );
+        assert_eq!(
+            h.call("Typed IO", "GetScaled", &[]).unwrap(),
+            Value::m1_float(0.0)
+        );
+        assert_eq!(
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
+                "Limited Float",
+                "GetScaled",
+            ),
+            BuiltinSupport::Unsupported,
+            "ordinary numeric channels must not inherit hardware stubs"
+        );
     }
 
     #[test]

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -770,6 +770,9 @@ fn classify_project_method(canon: &str, method: &str, project: &Project) -> Call
     if method == "Set" && object::writable_value_path(canon, project).is_some() {
         return capability(BuiltinSupport::Direct, CallRoute::ChannelSet);
     }
+    if method == "GetUnscheduled" && object::unscheduled_value_path(canon, project).is_some() {
+        return capability(BuiltinSupport::Direct, CallRoute::ObjectGetUnscheduled);
+    }
     if object::is_numeric_source(canon, project) {
         match method {
             "Validate" => {
@@ -777,9 +780,6 @@ fn classify_project_method(canon: &str, method: &str, project: &Project) -> Call
             }
             "Constrain" => {
                 return capability(BuiltinSupport::Direct, CallRoute::ObjectConstrain);
-            }
-            "GetUnscheduled" => {
-                return capability(BuiltinSupport::Direct, CallRoute::ObjectGetUnscheduled);
             }
             // A typed hardware object also carries a numeric value. Core value
             // methods claim only their exact names; every other method must
@@ -1544,6 +1544,24 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_as_string_rejects_an_invalid_seeded_member() {
+        let mut h = EnumHarness::new();
+        let id = h.enum_id();
+        h.env.set(
+            "Root.Demo.Mode",
+            Value::Enum {
+                id,
+                member: "Bogus".to_string(),
+            },
+        );
+
+        let error = h.call("Mode", "AsString", &[]).unwrap_err();
+        assert!(matches!(error, EvalError::TypeError { .. }));
+        assert!(error.to_string().contains("Bogus"), "{error}");
+        assert!(error.to_string().contains("Drive State"), "{error}");
+    }
+
+    #[test]
     fn dispatch_as_integer_on_non_enum_fails_loud() {
         let mut h = EnumHarness::new();
         // A name that is neither an enum literal nor an enum-typed project symbol:
@@ -1854,11 +1872,13 @@ mod tests {
             Some(&Value::m1_float(-1.5))
         );
 
-        h.call("Positive Float", "Set", &[Value::m1_float(-2.0)])
-            .unwrap();
         assert_eq!(
-            h.env.get("Root.Demo.Positive Float"),
-            Some(&Value::m1_float(0.0))
+            h.call("Positive Float", "Set", &[Value::m1_float(-2.0)]),
+            Err(EvalError::UnsupportedBuiltin {
+                object: "Positive Float".to_string(),
+                method: "Set".to_string(),
+            }),
+            "parameters are calibration-owned and not firmware-writable"
         );
     }
 
@@ -1885,11 +1905,13 @@ mod tests {
                 .unwrap(),
             Value::m1_unsigned(4)
         );
-        h.env
-            .set("Root.Demo.Limited Compound.Value", Value::m1_unsigned(3));
         assert_eq!(
-            h.call("Limited Compound", "GetUnscheduled", &[]).unwrap(),
-            Value::m1_unsigned(3)
+            h.call("Limited Compound", "GetUnscheduled", &[]),
+            Err(EvalError::UnsupportedBuiltin {
+                object: "Limited Compound".to_string(),
+                method: "GetUnscheduled".to_string(),
+            }),
+            "GetUnscheduled belongs to channels and generated table values"
         );
         h.call("Limited Compound", "Set", &[Value::m1_unsigned(9)])
             .unwrap();
@@ -1916,6 +1938,10 @@ mod tests {
         for (object, method, args) in [
             ("Mode", "Validate", vec![Value::m1_integer(1)]),
             ("Limited Signed", "AsString", vec![]),
+            ("Limited Compound", "GetUnscheduled", vec![]),
+            ("Positive Float", "GetUnscheduled", vec![]),
+            ("Numeric Constant", "GetUnscheduled", vec![]),
+            ("Typed IO", "GetUnscheduled", vec![]),
             ("Startup Delay", "GetUnscheduled", vec![]),
             ("Drive State.Idle", "Set", vec![Value::m1_integer(1)]),
         ] {
@@ -1976,7 +2002,6 @@ mod tests {
             ("Limited Signed", "GetUnscheduled"),
             ("Limited Compound", "Validate"),
             ("Limited Compound", "Constrain"),
-            ("Limited Compound", "GetUnscheduled"),
             ("Limited Compound", "Set"),
             ("Limited Signed", "Set"),
         ] {
@@ -1995,6 +2020,11 @@ mod tests {
         for (object, method) in [
             ("Mode", "Constrain"),
             ("Limited Signed", "AsString"),
+            ("Limited Compound", "GetUnscheduled"),
+            ("Positive Float", "GetUnscheduled"),
+            ("Positive Float", "Set"),
+            ("Numeric Constant", "GetUnscheduled"),
+            ("Typed IO", "GetUnscheduled"),
             ("Startup Delay", "GetUnscheduled"),
         ] {
             assert_eq!(

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -160,11 +160,13 @@ fn writable_value_path_inner(
 
     if let Some(default) = symbol.default_value.as_deref() {
         let locals = HashMap::new();
-        if let Target::Symbol(path) = classify(default, Some(canon), None, project, &locals)
-            && let Some(value_path) = writable_value_path_inner(&path, project, seen)
-        {
-            return Some(value_path);
-        }
+        // A declared default is the compound's authoritative value provider.
+        // Do not silently switch to a generated `.Value` sibling when that
+        // provider is a calibration-owned Parameter (or otherwise unwritable).
+        return match classify(default, Some(canon), None, project, &locals) {
+            Target::Symbol(path) => writable_value_path_inner(&path, project, seen),
+            _ => None,
+        };
     }
 
     let value_path = format!("{canon}.Value");
@@ -438,10 +440,15 @@ fn bound_scalar(
     };
     let scalar = match kind {
         M1ScalarKind::FloatingPoint => {
-            let value = bound as f32;
-            if !value.is_finite() {
-                return Err(invalid());
-            }
+            let family_min = -f64::from(f32::MAX);
+            let family_max = f64::from(f32::MAX);
+            let value = match side {
+                BoundSide::Lower if bound <= family_min => -f32::MAX,
+                BoundSide::Lower if bound > family_max => return Err(invalid()),
+                BoundSide::Upper if bound < family_min => return Err(invalid()),
+                BoundSide::Upper if bound >= family_max => f32::MAX,
+                _ => bound as f32,
+            };
             M1Scalar::FloatingPoint(value)
         }
         M1ScalarKind::Integer => {
@@ -449,20 +456,31 @@ fn bound_scalar(
                 BoundSide::Lower => bound.ceil(),
                 BoundSide::Upper => bound.floor(),
             };
-            if rounded < f64::from(i32::MIN) || rounded > f64::from(i32::MAX) {
-                return Err(invalid());
-            }
-            M1Scalar::Integer(rounded as i32)
+            let family_min = f64::from(i32::MIN);
+            let family_max = f64::from(i32::MAX);
+            let value = match side {
+                BoundSide::Lower if rounded <= family_min => i32::MIN,
+                BoundSide::Lower if rounded > family_max => return Err(invalid()),
+                BoundSide::Upper if rounded < family_min => return Err(invalid()),
+                BoundSide::Upper if rounded >= family_max => i32::MAX,
+                _ => rounded as i32,
+            };
+            M1Scalar::Integer(value)
         }
         M1ScalarKind::UnsignedInteger => {
             let rounded = match side {
                 BoundSide::Lower => bound.ceil(),
                 BoundSide::Upper => bound.floor(),
             };
-            if rounded < 0.0 || rounded > f64::from(u32::MAX) {
-                return Err(invalid());
-            }
-            M1Scalar::UnsignedInteger(rounded as u32)
+            let family_max = f64::from(u32::MAX);
+            let value = match side {
+                BoundSide::Lower if rounded <= 0.0 => 0,
+                BoundSide::Lower if rounded > family_max => return Err(invalid()),
+                BoundSide::Upper if rounded < 0.0 => return Err(invalid()),
+                BoundSide::Upper if rounded >= family_max => u32::MAX,
+                _ => rounded as u32,
+            };
+            M1Scalar::UnsignedInteger(value)
         }
         M1ScalarKind::FixedPoint7dps => {
             let scaled = bound * FixedPoint7dps::SCALE as f64;
@@ -616,6 +634,75 @@ mod tests {
             constrain_value("float", "float", Value::m1_float(5.0), Some(&rules),).unwrap(),
             Value::m1_float(4.4)
         );
+    }
+
+    #[test]
+    fn permissive_out_of_family_bounds_saturate_to_family_endpoints() {
+        let cases = [
+            (
+                "unsigned-lower",
+                ValidationRule::MinMax {
+                    min: -1.0,
+                    max: 2.0,
+                },
+                M1Scalar::UnsignedInteger(1),
+            ),
+            (
+                "unsigned-upper",
+                ValidationRule::MinMax {
+                    min: 0.0,
+                    max: f64::from(u32::MAX) + 1.0,
+                },
+                M1Scalar::UnsignedInteger(u32::MAX),
+            ),
+            (
+                "integer-lower",
+                ValidationRule::MinMax {
+                    min: f64::from(i32::MIN) - 1.0,
+                    max: 0.0,
+                },
+                M1Scalar::Integer(-1),
+            ),
+            (
+                "integer-upper",
+                ValidationRule::MinMax {
+                    min: 0.0,
+                    max: f64::from(i32::MAX) + 1.0,
+                },
+                M1Scalar::Integer(i32::MAX),
+            ),
+            (
+                "fixed",
+                ValidationRule::MinMax {
+                    min: -1_000.0,
+                    max: 1_000.0,
+                },
+                M1Scalar::FixedPoint7dps(FixedPoint7dps::ZERO),
+            ),
+            (
+                "float",
+                ValidationRule::MinMax {
+                    min: -1.0e300,
+                    max: 1.0e300,
+                },
+                M1Scalar::FloatingPoint(0.0),
+            ),
+        ];
+
+        for (name, rule, scalar) in cases {
+            assert!(
+                rule_accepts(&rule, scalar, name).unwrap(),
+                "{name}: an in-family value must remain valid"
+            );
+            let rules = ObjectRules {
+                validation: HashMap::from([(name.to_string(), rule)]),
+            };
+            assert_eq!(
+                constrain_value(name, name, Value::M1(scalar), Some(&rules)).unwrap(),
+                Value::M1(scalar),
+                "{name}: an in-range value must remain unchanged"
+            );
+        }
     }
 
     #[test]

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -329,22 +329,49 @@ fn constrain_value(
         return Ok(value);
     }
     if min.is_some_and(|bound| x < bound) {
-        return bound_value(
+        let constrained = bound_value(
             min.expect("checked above"),
             scalar.kind(),
             BoundSide::Lower,
             canon,
-        );
+        )?;
+        return ensure_in_range(constrained, rule, canon, min, max);
     }
     if max.is_some_and(|bound| x > bound) {
-        return bound_value(
+        let constrained = bound_value(
             max.expect("checked above"),
             scalar.kind(),
             BoundSide::Upper,
             canon,
-        );
+        )?;
+        return ensure_in_range(constrained, rule, canon, min, max);
     }
     Ok(value)
+}
+
+fn ensure_in_range(
+    value: Value,
+    rule: &ValidationRule,
+    canon: &str,
+    min: Option<f64>,
+    max: Option<f64>,
+) -> Result<Value, EvalError> {
+    let scalar = value.m1_scalar()?;
+    if rule_accepts(rule, scalar, canon)? {
+        return Ok(value);
+    }
+    let range = match (min, max) {
+        (Some(min), Some(max)) => format!("[{min}, {max}]"),
+        (Some(min), None) => format!("[{min}, +infinity)"),
+        (None, Some(max)) => format!("(-infinity, {max}]"),
+        (None, None) => "unbounded".to_string(),
+    };
+    Err(EvalError::TypeError {
+        detail: format!(
+            "validation range {range} on {canon:?} has no value in M1 {:?}",
+            scalar.kind()
+        ),
+    })
 }
 
 fn rule_accepts(rule: &ValidationRule, scalar: M1Scalar, canon: &str) -> Result<bool, EvalError> {
@@ -419,14 +446,36 @@ fn bound_value(
         }
         M1ScalarKind::FixedPoint7dps => {
             let scaled = bound * FixedPoint7dps::SCALE as f64;
-            let rounded = match side {
-                BoundSide::Lower => scaled.ceil(),
-                BoundSide::Upper => scaled.floor(),
-            };
-            if rounded < f64::from(i32::MIN) || rounded > f64::from(i32::MAX) {
+            if !scaled.is_finite() {
                 return Err(invalid());
             }
-            M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(rounded as i32))
+            let min_raw = i64::from(i32::MIN);
+            let max_raw = i64::from(i32::MAX);
+            let mut raw = scaled.round().clamp(min_raw as f64, max_raw as f64) as i64;
+            let fixed_at = |raw: i64| {
+                FixedPoint7dps::from_raw(i32::try_from(raw).expect("raw is range-checked"))
+            };
+
+            match side {
+                BoundSide::Lower => {
+                    while raw <= max_raw && fixed_at(raw).as_f64() < bound {
+                        raw += 1;
+                    }
+                    while raw > min_raw && fixed_at(raw - 1).as_f64() >= bound {
+                        raw -= 1;
+                    }
+                }
+                BoundSide::Upper => {
+                    while raw >= min_raw && fixed_at(raw).as_f64() > bound {
+                        raw -= 1;
+                    }
+                    while raw < max_raw && fixed_at(raw + 1).as_f64() <= bound {
+                        raw += 1;
+                    }
+                }
+            }
+            let raw = i32::try_from(raw).map_err(|_| invalid())?;
+            M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(raw))
         }
     };
     Ok(Value::M1(scalar))
@@ -480,5 +529,104 @@ mod tests {
         .unwrap_err();
         assert!(error.to_string().contains("Root.Bad"), "{error}");
         assert!(error.to_string().contains("exceeds"), "{error}");
+    }
+
+    #[test]
+    fn constrain_rejects_ranges_with_no_value_in_the_argument_family() {
+        let cases = [
+            (
+                "signed",
+                0.2,
+                0.8,
+                Value::m1_integer(-1),
+                Value::m1_integer(2),
+            ),
+            (
+                "unsigned",
+                0.2,
+                0.8,
+                Value::m1_unsigned(0),
+                Value::m1_unsigned(1),
+            ),
+            (
+                "float",
+                1.000_000_01,
+                1.000_000_02,
+                Value::m1_float(1.0),
+                Value::m1_float(f32::from_bits(1.0f32.to_bits() + 1)),
+            ),
+            (
+                "fixed",
+                0.000_000_01,
+                0.000_000_02,
+                Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::ZERO)),
+                Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(1))),
+            ),
+        ];
+
+        for (name, min, max, below, above) in cases {
+            let rules = ObjectRules {
+                validation: HashMap::from([(
+                    name.to_string(),
+                    ValidationRule::MinMax { min, max },
+                )]),
+            };
+            for input in [below, above] {
+                let error = constrain_value(name, name, input, Some(&rules)).unwrap_err();
+                assert!(
+                    error.to_string().contains("has no value in M1"),
+                    "{name}: {error}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fixed_bounds_preserve_exact_seven_decimal_places() {
+        let lower_rules = ObjectRules {
+            validation: HashMap::from([(
+                "lower".to_string(),
+                ValidationRule::MinMax {
+                    min: 79.020_497_0,
+                    max: 100.0,
+                },
+            )]),
+        };
+        assert_eq!(
+            constrain_value(
+                "lower",
+                "lower",
+                Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::ZERO)),
+                Some(&lower_rules),
+            )
+            .unwrap(),
+            Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(
+                790_204_970,
+            )))
+        );
+
+        let upper_rules = ObjectRules {
+            validation: HashMap::from([(
+                "upper".to_string(),
+                ValidationRule::MinMax {
+                    min: 0.0,
+                    max: 88.717_452_5,
+                },
+            )]),
+        };
+        assert_eq!(
+            constrain_value(
+                "upper",
+                "upper",
+                Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(
+                    1_000_000_000,
+                ))),
+                Some(&upper_rules),
+            )
+            .unwrap(),
+            Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(
+                887_174_525,
+            )))
+        );
     }
 }

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -1,0 +1,484 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Core methods on resolved project value objects.
+//!
+//! The project file owns each value object's validation rule. Runtime dispatch
+//! resolves the source spelling to a canonical project path, then uses this
+//! index for `Validate`, `Constrain`, and `Set`. `GetUnscheduled` reads through
+//! the normal value path; only dependency analysis treats that accessor
+//! specially.
+
+use crate::error::EvalError;
+use crate::expr::EvalCtx;
+use crate::ident::{Target, classify};
+use crate::value::{FixedPoint7dps, M1Scalar, M1ScalarKind, Value};
+use m1_typecheck::Project;
+use m1_typecheck::symbols::SymbolKind;
+use m1_typecheck::types::ValueType;
+use std::collections::{HashMap, HashSet};
+
+/// Validation rules parsed from `.m1prj` component properties.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ObjectRules {
+    validation: HashMap<String, ValidationRule>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum ValidationRule {
+    MinMax {
+        min: f64,
+        max: f64,
+    },
+    /// M1 project exports use `Positive` for a lower bound of zero.
+    NonNegative,
+    /// Preserve unknown project data and fail only if execution reaches it.
+    Unsupported(String),
+}
+
+impl ObjectRules {
+    /// Parse validation metadata without retaining the project XML.
+    pub(crate) fn from_project_xml(xml: &str) -> Result<Self, EvalError> {
+        let doc =
+            roxmltree::Document::parse(xml).map_err(|error| EvalError::UnsupportedConstruct {
+                kind: format!("project XML re-parse for object rules failed: {error}"),
+                at: 0,
+            })?;
+        let mut rules = Self::default();
+
+        for component in doc
+            .descendants()
+            .filter(|node| node.has_tag_name("Component"))
+        {
+            let Some(path) = component.attribute("Name") else {
+                continue;
+            };
+            let Some(props) = component.children().find(|node| node.has_tag_name("Props")) else {
+                continue;
+            };
+            let Some(raw_kind) = props.attribute("Validation").map(str::trim) else {
+                continue;
+            };
+            if raw_kind.is_empty() || raw_kind.eq_ignore_ascii_case("None") {
+                continue;
+            }
+
+            let rule = match raw_kind {
+                "MinMax" => {
+                    let min = parse_bound(path, "ValMin", props.attribute("ValMin"))?;
+                    let max = parse_bound(path, "ValMax", props.attribute("ValMax"))?;
+                    if min > max {
+                        return Err(invalid_rule(
+                            path,
+                            format!("ValMin {min} exceeds ValMax {max}"),
+                        ));
+                    }
+                    ValidationRule::MinMax { min, max }
+                }
+                "Positive" => ValidationRule::NonNegative,
+                other => ValidationRule::Unsupported(other.to_string()),
+            };
+            rules.validation.insert(path.to_string(), rule);
+        }
+
+        Ok(rules)
+    }
+
+    fn rule_for<'a>(&'a self, object: &str, value_path: &str) -> Option<&'a ValidationRule> {
+        self.validation
+            .get(object)
+            .or_else(|| self.validation.get(value_path))
+    }
+}
+
+fn parse_bound(path: &str, name: &str, raw: Option<&str>) -> Result<f64, EvalError> {
+    let value = raw
+        .ok_or_else(|| invalid_rule(path, format!("MinMax is missing {name}")))?
+        .parse::<f64>()
+        .map_err(|_| invalid_rule(path, format!("{name} is not a number")))?;
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(invalid_rule(path, format!("{name} must be finite")))
+    }
+}
+
+fn invalid_rule(path: &str, detail: String) -> EvalError {
+    EvalError::UnsupportedConstruct {
+        kind: format!("invalid validation rule on {path:?}: {detail}"),
+        at: 0,
+    }
+}
+
+/// Whether a resolved project symbol provides a numeric scalar value.
+pub(crate) fn is_numeric_source(canon: &str, project: &Project) -> bool {
+    numeric_value_path(canon, project).is_some()
+}
+
+/// Resolve a value-bearing object to the concrete numeric symbol it reads.
+/// Direct channels, parameters, and constants return themselves. A value
+/// compound follows its declared default or generated `.Value` child.
+pub(crate) fn numeric_value_path(canon: &str, project: &Project) -> Option<String> {
+    numeric_value_path_inner(canon, project, &mut HashSet::new())
+}
+
+/// Resolve a writable value object to the channel or parameter that stores it.
+/// A direct channel/parameter stores itself. A value compound follows its
+/// declared default, then its generated `.Value` child. Tables and package IO
+/// objects retain their dedicated dispatch rather than becoming arbitrary
+/// writable channels through this helper.
+pub(crate) fn writable_value_path(canon: &str, project: &Project) -> Option<String> {
+    writable_value_path_inner(canon, project, &mut HashSet::new())
+}
+
+fn writable_value_path_inner(
+    canon: &str,
+    project: &Project,
+    seen: &mut HashSet<String>,
+) -> Option<String> {
+    if !seen.insert(canon.to_string()) {
+        return None;
+    }
+    let symbol = project.symbols().get(canon)?;
+    if matches!(symbol.kind, SymbolKind::Channel | SymbolKind::Parameter) {
+        return Some(canon.to_string());
+    }
+    if symbol.kind != SymbolKind::Group {
+        return None;
+    }
+
+    if let Some(default) = symbol.default_value.as_deref() {
+        let locals = HashMap::new();
+        if let Target::Symbol(path) = classify(default, Some(canon), None, project, &locals)
+            && let Some(value_path) = writable_value_path_inner(&path, project, seen)
+        {
+            return Some(value_path);
+        }
+    }
+
+    let value_path = format!("{canon}.Value");
+    project
+        .symbols()
+        .get(&value_path)
+        .and_then(|_| writable_value_path_inner(&value_path, project, seen))
+}
+
+fn numeric_value_path_inner(
+    canon: &str,
+    project: &Project,
+    seen: &mut HashSet<String>,
+) -> Option<String> {
+    if !seen.insert(canon.to_string()) {
+        return None;
+    }
+    let symbol = project.symbols().get(canon)?;
+    let numeric = symbol_is_numeric(symbol.value_type, symbol.declared_type.as_deref());
+    match symbol.kind {
+        SymbolKind::Channel | SymbolKind::Parameter | SymbolKind::Constant if numeric => {
+            return Some(canon.to_string());
+        }
+        SymbolKind::Object | SymbolKind::Reference | SymbolKind::Other if numeric => {
+            // These are the typed external-value objects that `read_symbol`
+            // reads directly. In particular, do not apply this shortcut to a
+            // Table: its type describes the generated `.Value` output, not a
+            // scalar stored on the table symbol itself.
+            return Some(canon.to_string());
+        }
+        _ => {}
+    }
+
+    if symbol.kind == SymbolKind::Group
+        && let Some(default) = symbol.default_value.as_deref()
+    {
+        let locals = HashMap::new();
+        if let Target::Symbol(path) = classify(default, Some(canon), None, project, &locals)
+            && let Some(value_path) = numeric_value_path_inner(&path, project, seen)
+        {
+            return Some(value_path);
+        }
+    }
+
+    if matches!(
+        symbol.kind,
+        SymbolKind::Group | SymbolKind::Table | SymbolKind::Object
+    ) {
+        let value_path = format!("{canon}.Value");
+        return project
+            .symbols()
+            .get(&value_path)
+            .and_then(|_| numeric_value_path_inner(&value_path, project, seen));
+    }
+    None
+}
+
+fn symbol_is_numeric(value_type: ValueType, declared_type: Option<&str>) -> bool {
+    matches!(
+        value_type,
+        ValueType::Integer | ValueType::Unsigned | ValueType::Float
+    ) || declared_type.is_some_and(|raw| {
+        raw.eq_ignore_ascii_case("FixedPoint7dps") || raw.eq_ignore_ascii_case("fixed7dps")
+    })
+}
+
+/// Return whether `value` satisfies the receiver's validation range.
+pub(crate) fn validate(
+    object: &str,
+    args: &[Value],
+    ctx: &mut EvalCtx,
+) -> Result<Value, EvalError> {
+    let (canon, value_path) = resolve_numeric_source(object, "Validate", ctx)?;
+    let value = args
+        .first()
+        .ok_or_else(|| bad_arity(object, "Validate", args.len(), 1))?;
+    let scalar = value.m1_scalar()?;
+    let Some(rule) = ctx
+        .object_rules
+        .and_then(|rules| rules.rule_for(&canon, &value_path))
+    else {
+        return Ok(Value::Bool(true));
+    };
+    Ok(Value::Bool(rule_accepts(rule, scalar, &canon)?))
+}
+
+/// Clamp a numeric argument to the receiver's validation range while retaining
+/// the argument's M1 scalar family.
+pub(crate) fn constrain(
+    object: &str,
+    args: &[Value],
+    ctx: &mut EvalCtx,
+) -> Result<Value, EvalError> {
+    let (canon, value_path) = resolve_numeric_source(object, "Constrain", ctx)?;
+    let value = args
+        .first()
+        .cloned()
+        .ok_or_else(|| bad_arity(object, "Constrain", args.len(), 1))?;
+    constrain_value(&canon, &value_path, value, ctx.object_rules)
+}
+
+/// Read a numeric value without adding a scheduler dependency. The scheduler
+/// distinction lives in `summary`; runtime uses the same read semantics as the
+/// source object itself.
+pub(crate) fn get_unscheduled(object: &str, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
+    let (_, value_path) = resolve_numeric_source(object, "GetUnscheduled", ctx)?;
+    crate::expr::read_symbol(&value_path, ctx)
+}
+
+/// Set a writable channel, parameter, or value compound after target-type
+/// conversion and range clamping.
+pub(crate) fn set(object: &str, args: &[Value], ctx: &mut EvalCtx) -> Result<Value, EvalError> {
+    let Target::Symbol(canon) = classify(
+        object,
+        ctx.group,
+        ctx.fn_symbol,
+        ctx.project,
+        &ctx.env.locals,
+    ) else {
+        return Err(unsupported(object, "Set"));
+    };
+    let value_path =
+        writable_value_path(&canon, ctx.project).ok_or_else(|| unsupported(object, "Set"))?;
+    let value = args
+        .first()
+        .cloned()
+        .ok_or_else(|| bad_arity(object, "Set", args.len(), 1))?;
+    let value = crate::expr::coerce_for_channel(&value_path, value, ctx.project)?;
+    let value = if value.is_numeric() {
+        constrain_value(&canon, &value_path, value, ctx.object_rules)?
+    } else {
+        value
+    };
+
+    ctx.env.set(value_path.clone(), value.clone());
+    if let Some(trace) = ctx.trace.as_deref_mut() {
+        trace.record_channel(value_path, value);
+    }
+    Ok(Value::Bool(true))
+}
+
+fn resolve_numeric_source(
+    object: &str,
+    method: &str,
+    ctx: &EvalCtx,
+) -> Result<(String, String), EvalError> {
+    let Target::Symbol(canon) = classify(
+        object,
+        ctx.group,
+        ctx.fn_symbol,
+        ctx.project,
+        &ctx.env.locals,
+    ) else {
+        return Err(unsupported(object, method));
+    };
+    let value_path =
+        numeric_value_path(&canon, ctx.project).ok_or_else(|| unsupported(object, method))?;
+    Ok((canon, value_path))
+}
+
+fn constrain_value(
+    canon: &str,
+    value_path: &str,
+    value: Value,
+    rules: Option<&ObjectRules>,
+) -> Result<Value, EvalError> {
+    let Some(rule) = rules.and_then(|rules| rules.rule_for(canon, value_path)) else {
+        return Ok(value);
+    };
+    let scalar = value.m1_scalar()?;
+    let x = scalar.as_f64();
+    let (min, max) = rule_bounds(rule, canon)?;
+
+    if x.is_nan() {
+        return Ok(value);
+    }
+    if min.is_some_and(|bound| x < bound) {
+        return bound_value(
+            min.expect("checked above"),
+            scalar.kind(),
+            BoundSide::Lower,
+            canon,
+        );
+    }
+    if max.is_some_and(|bound| x > bound) {
+        return bound_value(
+            max.expect("checked above"),
+            scalar.kind(),
+            BoundSide::Upper,
+            canon,
+        );
+    }
+    Ok(value)
+}
+
+fn rule_accepts(rule: &ValidationRule, scalar: M1Scalar, canon: &str) -> Result<bool, EvalError> {
+    let x = scalar.as_f64();
+    if x.is_nan() {
+        return Ok(false);
+    }
+    let (min, max) = rule_bounds(rule, canon)?;
+    Ok(min.is_none_or(|bound| x >= bound) && max.is_none_or(|bound| x <= bound))
+}
+
+fn rule_bounds(
+    rule: &ValidationRule,
+    canon: &str,
+) -> Result<(Option<f64>, Option<f64>), EvalError> {
+    match rule {
+        ValidationRule::MinMax { min, max } => Ok((Some(*min), Some(*max))),
+        ValidationRule::NonNegative => Ok((Some(0.0), None)),
+        ValidationRule::Unsupported(kind) => Err(EvalError::TypeError {
+            detail: format!("object {canon:?} uses unsupported validation rule {kind:?}"),
+        }),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum BoundSide {
+    Lower,
+    Upper,
+}
+
+fn bound_value(
+    bound: f64,
+    kind: M1ScalarKind,
+    side: BoundSide,
+    canon: &str,
+) -> Result<Value, EvalError> {
+    let invalid = || EvalError::TypeError {
+        detail: format!("validation bound {bound} on {canon:?} has no value in M1 {kind:?}"),
+    };
+    let scalar = match kind {
+        M1ScalarKind::FloatingPoint => {
+            let mut value = bound as f32;
+            if !value.is_finite() {
+                return Err(invalid());
+            }
+            match side {
+                BoundSide::Lower if f64::from(value) < bound => value = value.next_up(),
+                BoundSide::Upper if f64::from(value) > bound => value = value.next_down(),
+                _ => {}
+            }
+            M1Scalar::FloatingPoint(value)
+        }
+        M1ScalarKind::Integer => {
+            let rounded = match side {
+                BoundSide::Lower => bound.ceil(),
+                BoundSide::Upper => bound.floor(),
+            };
+            if rounded < f64::from(i32::MIN) || rounded > f64::from(i32::MAX) {
+                return Err(invalid());
+            }
+            M1Scalar::Integer(rounded as i32)
+        }
+        M1ScalarKind::UnsignedInteger => {
+            let rounded = match side {
+                BoundSide::Lower => bound.ceil(),
+                BoundSide::Upper => bound.floor(),
+            };
+            if rounded < 0.0 || rounded > f64::from(u32::MAX) {
+                return Err(invalid());
+            }
+            M1Scalar::UnsignedInteger(rounded as u32)
+        }
+        M1ScalarKind::FixedPoint7dps => {
+            let scaled = bound * FixedPoint7dps::SCALE as f64;
+            let rounded = match side {
+                BoundSide::Lower => scaled.ceil(),
+                BoundSide::Upper => scaled.floor(),
+            };
+            if rounded < f64::from(i32::MIN) || rounded > f64::from(i32::MAX) {
+                return Err(invalid());
+            }
+            M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(rounded as i32))
+        }
+    };
+    Ok(Value::M1(scalar))
+}
+
+fn bad_arity(object: &str, method: &str, got: usize, expected: usize) -> EvalError {
+    EvalError::BadCall {
+        detail: format!("{object}.{method} expects {expected} argument(s), got {got}"),
+    }
+}
+
+fn unsupported(object: &str, method: &str) -> EvalError {
+    EvalError::UnsupportedBuiltin {
+        object: object.to_string(),
+        method: method.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_min_max_positive_and_unknown_rules() {
+        let rules = ObjectRules::from_project_xml(
+            r#"<Project><Component Name="Root.Min"><Props Validation="MinMax" ValMin="-2" ValMax="3"/></Component><Component Name="Root.Positive"><Props Validation="Positive"/></Component><Component Name="Root.Future"><Props Validation="FutureRule"/></Component></Project>"#,
+        )
+        .unwrap();
+        assert_eq!(
+            rules.validation.get("Root.Min"),
+            Some(&ValidationRule::MinMax {
+                min: -2.0,
+                max: 3.0
+            })
+        );
+        assert_eq!(
+            rules.validation.get("Root.Positive"),
+            Some(&ValidationRule::NonNegative)
+        );
+        assert_eq!(
+            rules.validation.get("Root.Future"),
+            Some(&ValidationRule::Unsupported("FutureRule".to_string()))
+        );
+    }
+
+    #[test]
+    fn malformed_min_max_rule_fails_with_the_object_path() {
+        let error = ObjectRules::from_project_xml(
+            r#"<Project><Component Name="Root.Bad"><Props Validation="MinMax" ValMin="4" ValMax="3"/></Component></Project>"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("Root.Bad"), "{error}");
+        assert!(error.to_string().contains("exceeds"), "{error}");
+    }
+}

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -120,11 +120,24 @@ pub(crate) fn numeric_value_path(canon: &str, project: &Project) -> Option<Strin
     numeric_value_path_inner(canon, project, &mut HashSet::new())
 }
 
-/// Resolve a writable value object to the channel or parameter that stores it.
-/// A direct channel/parameter stores itself. A value compound follows its
-/// declared default, then its generated `.Value` child. Tables and package IO
-/// objects retain their dedicated dispatch rather than becoming arbitrary
-/// writable channels through this helper.
+/// Resolve the receiver classes whose read is explicitly excluded from M1's
+/// scheduling dependency analysis. The method belongs to channels and to a
+/// tuning table's generated numeric value, not to parameters, constants, or
+/// arbitrary typed package objects.
+pub(crate) fn unscheduled_value_path(canon: &str, project: &Project) -> Option<String> {
+    let symbol = project.symbols().get(canon)?;
+    match symbol.kind {
+        SymbolKind::Channel if is_numeric_source(canon, project) => Some(canon.to_string()),
+        SymbolKind::Table => numeric_value_path(canon, project),
+        _ => None,
+    }
+}
+
+/// Resolve a firmware-writable value object to the channel that stores it. A
+/// direct channel stores itself. A value compound follows its declared default,
+/// then its generated `.Value` child. Parameters remain calibration-owned, and
+/// tables and package IO objects retain their dedicated dispatch rather than
+/// becoming arbitrary writable channels through this helper.
 pub(crate) fn writable_value_path(canon: &str, project: &Project) -> Option<String> {
     writable_value_path_inner(canon, project, &mut HashSet::new())
 }
@@ -138,7 +151,7 @@ fn writable_value_path_inner(
         return None;
     }
     let symbol = project.symbols().get(canon)?;
-    if matches!(symbol.kind, SymbolKind::Channel | SymbolKind::Parameter) {
+    if symbol.kind == SymbolKind::Channel {
         return Some(canon.to_string());
     }
     if symbol.kind != SymbolKind::Group {
@@ -257,12 +270,23 @@ pub(crate) fn constrain(
 /// distinction lives in `summary`; runtime uses the same read semantics as the
 /// source object itself.
 pub(crate) fn get_unscheduled(object: &str, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let (_, value_path) = resolve_numeric_source(object, "GetUnscheduled", ctx)?;
+    let Target::Symbol(canon) = classify(
+        object,
+        ctx.group,
+        ctx.fn_symbol,
+        ctx.project,
+        &ctx.env.locals,
+    ) else {
+        return Err(unsupported(object, "GetUnscheduled"));
+    };
+    let value_path = unscheduled_value_path(&canon, ctx.project)
+        .ok_or_else(|| unsupported(object, "GetUnscheduled"))?;
     crate::expr::read_symbol(&value_path, ctx)
 }
 
-/// Set a writable channel, parameter, or value compound after target-type
-/// conversion and range clamping.
+/// Set a writable channel or channel-backed value compound after target-type
+/// conversion and range clamping. Parameters are calibration-owned and cannot
+/// be mutated by ECU firmware.
 pub(crate) fn set(object: &str, args: &[Value], ctx: &mut EvalCtx) -> Result<Value, EvalError> {
     let Target::Symbol(canon) = classify(
         object,
@@ -323,64 +347,65 @@ fn constrain_value(
     };
     let scalar = value.m1_scalar()?;
     let x = scalar.as_f64();
-    let (min, max) = rule_bounds(rule, canon)?;
+    let (min, max) = converted_rule_bounds(rule, scalar.kind(), canon)?;
 
     if x.is_nan() {
         return Ok(value);
     }
-    if min.is_some_and(|bound| x < bound) {
-        let constrained = bound_value(
-            min.expect("checked above"),
-            scalar.kind(),
-            BoundSide::Lower,
-            canon,
-        )?;
-        return ensure_in_range(constrained, rule, canon, min, max);
+    if min.is_some_and(|bound| x < bound.as_f64()) {
+        return Ok(Value::M1(min.expect("checked above")));
     }
-    if max.is_some_and(|bound| x > bound) {
-        let constrained = bound_value(
-            max.expect("checked above"),
-            scalar.kind(),
-            BoundSide::Upper,
-            canon,
-        )?;
-        return ensure_in_range(constrained, rule, canon, min, max);
+    if max.is_some_and(|bound| x > bound.as_f64()) {
+        return Ok(Value::M1(max.expect("checked above")));
     }
     Ok(value)
 }
 
-fn ensure_in_range(
-    value: Value,
+fn rule_accepts(rule: &ValidationRule, scalar: M1Scalar, canon: &str) -> Result<bool, EvalError> {
+    let x = scalar.as_f64();
+    let (min, max) = converted_rule_bounds(rule, scalar.kind(), canon)?;
+    if x.is_nan() {
+        return Ok(false);
+    }
+    Ok(min.is_none_or(|bound| x >= bound.as_f64()) && max.is_none_or(|bound| x <= bound.as_f64()))
+}
+
+fn converted_rule_bounds(
     rule: &ValidationRule,
+    kind: M1ScalarKind,
     canon: &str,
+) -> Result<(Option<M1Scalar>, Option<M1Scalar>), EvalError> {
+    let (raw_min, raw_max) = rule_bounds(rule, canon)?;
+    let min = raw_min
+        .map(|bound| bound_scalar(bound, kind, BoundSide::Lower, canon))
+        .transpose()?;
+    let max = raw_max
+        .map(|bound| bound_scalar(bound, kind, BoundSide::Upper, canon))
+        .transpose()?;
+    if min
+        .zip(max)
+        .is_some_and(|(min, max)| min.as_f64() > max.as_f64())
+    {
+        return Err(no_value_in_range(canon, kind, raw_min, raw_max));
+    }
+    Ok((min, max))
+}
+
+fn no_value_in_range(
+    canon: &str,
+    kind: M1ScalarKind,
     min: Option<f64>,
     max: Option<f64>,
-) -> Result<Value, EvalError> {
-    let scalar = value.m1_scalar()?;
-    if rule_accepts(rule, scalar, canon)? {
-        return Ok(value);
-    }
+) -> EvalError {
     let range = match (min, max) {
         (Some(min), Some(max)) => format!("[{min}, {max}]"),
         (Some(min), None) => format!("[{min}, +infinity)"),
         (None, Some(max)) => format!("(-infinity, {max}]"),
         (None, None) => "unbounded".to_string(),
     };
-    Err(EvalError::TypeError {
-        detail: format!(
-            "validation range {range} on {canon:?} has no value in M1 {:?}",
-            scalar.kind()
-        ),
-    })
-}
-
-fn rule_accepts(rule: &ValidationRule, scalar: M1Scalar, canon: &str) -> Result<bool, EvalError> {
-    let x = scalar.as_f64();
-    if x.is_nan() {
-        return Ok(false);
+    EvalError::TypeError {
+        detail: format!("validation range {range} on {canon:?} has no value in M1 {kind:?}"),
     }
-    let (min, max) = rule_bounds(rule, canon)?;
-    Ok(min.is_none_or(|bound| x >= bound) && max.is_none_or(|bound| x <= bound))
 }
 
 fn rule_bounds(
@@ -402,25 +427,20 @@ enum BoundSide {
     Upper,
 }
 
-fn bound_value(
+fn bound_scalar(
     bound: f64,
     kind: M1ScalarKind,
     side: BoundSide,
     canon: &str,
-) -> Result<Value, EvalError> {
+) -> Result<M1Scalar, EvalError> {
     let invalid = || EvalError::TypeError {
         detail: format!("validation bound {bound} on {canon:?} has no value in M1 {kind:?}"),
     };
     let scalar = match kind {
         M1ScalarKind::FloatingPoint => {
-            let mut value = bound as f32;
+            let value = bound as f32;
             if !value.is_finite() {
                 return Err(invalid());
-            }
-            match side {
-                BoundSide::Lower if f64::from(value) < bound => value = value.next_up(),
-                BoundSide::Upper if f64::from(value) > bound => value = value.next_down(),
-                _ => {}
             }
             M1Scalar::FloatingPoint(value)
         }
@@ -478,7 +498,7 @@ fn bound_value(
             M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(raw))
         }
     };
-    Ok(Value::M1(scalar))
+    Ok(scalar)
 }
 
 fn bad_arity(object: &str, method: &str, got: usize, expected: usize) -> EvalError {
@@ -549,13 +569,6 @@ mod tests {
                 Value::m1_unsigned(1),
             ),
             (
-                "float",
-                1.000_000_01,
-                1.000_000_02,
-                Value::m1_float(1.0),
-                Value::m1_float(f32::from_bits(1.0f32.to_bits() + 1)),
-            ),
-            (
                 "fixed",
                 0.000_000_01,
                 0.000_000_02,
@@ -579,6 +592,30 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn float_validation_uses_binary32_endpoints() {
+        let min = "0.0100000000000000002".parse::<f64>().unwrap();
+        let max = "4.40000000000000036".parse::<f64>().unwrap();
+        let rules = ObjectRules {
+            validation: HashMap::from([("float".to_string(), ValidationRule::MinMax { min, max })]),
+        };
+        let rule = rules.validation.get("float").unwrap();
+        for endpoint in [0.01f32, 4.4f32] {
+            assert!(
+                rule_accepts(rule, M1Scalar::FloatingPoint(endpoint), "float").unwrap(),
+                "binary32 endpoint {endpoint:?} must validate"
+            );
+        }
+        assert_eq!(
+            constrain_value("float", "float", Value::m1_float(0.0), Some(&rules),).unwrap(),
+            Value::m1_float(0.01)
+        );
+        assert_eq!(
+            constrain_value("float", "float", Value::m1_float(5.0), Some(&rules),).unwrap(),
+            Value::m1_float(4.4)
+        );
     }
 
     #[test]

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -483,10 +483,21 @@ fn bound_scalar(
             M1Scalar::UnsignedInteger(value)
         }
         M1ScalarKind::FixedPoint7dps => {
-            let scaled = bound * FixedPoint7dps::SCALE as f64;
-            if !scaled.is_finite() {
-                return Err(invalid());
+            let family_min = FixedPoint7dps::from_raw(i32::MIN).as_f64();
+            let family_max = FixedPoint7dps::from_raw(i32::MAX).as_f64();
+            match side {
+                BoundSide::Lower if bound <= family_min => {
+                    return Ok(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(i32::MIN)));
+                }
+                BoundSide::Lower if bound > family_max => return Err(invalid()),
+                BoundSide::Upper if bound < family_min => return Err(invalid()),
+                BoundSide::Upper if bound >= family_max => {
+                    return Ok(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(i32::MAX)));
+                }
+                _ => {}
             }
+            let scaled = bound * FixedPoint7dps::SCALE as f64;
+            debug_assert!(scaled.is_finite(), "in-domain Fixed7 bound must scale");
             let min_raw = i64::from(i32::MIN);
             let max_raw = i64::from(i32::MAX);
             let mut raw = scaled.round().clamp(min_raw as f64, max_raw as f64) as i64;
@@ -674,8 +685,8 @@ mod tests {
             (
                 "fixed",
                 ValidationRule::MinMax {
-                    min: -1_000.0,
-                    max: 1_000.0,
+                    min: -1.0e308,
+                    max: 1.0e308,
                 },
                 M1Scalar::FixedPoint7dps(FixedPoint7dps::ZERO),
             ),

--- a/src/builtins/stateful.rs
+++ b/src/builtins/stateful.rs
@@ -1013,6 +1013,7 @@ mod tests {
                 dt: self.dt,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: None,
             };
@@ -1171,6 +1172,7 @@ mod tests {
                 dt: h.dt,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: None,
             };
@@ -1204,6 +1206,7 @@ mod tests {
             dt: h.dt,
             scripts: &[],
             signature_m1_types: None,
+            object_rules: None,
             depth: 0,
             trace: None,
         };
@@ -1512,6 +1515,7 @@ mod tests {
                 dt: h.dt,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: None,
             };
@@ -1541,6 +1545,7 @@ mod tests {
                 dt: h.dt,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: None,
             };

--- a/src/builtins/userfn.rs
+++ b/src/builtins/userfn.rs
@@ -206,6 +206,7 @@ pub fn call(
             dt: ctx.dt,
             scripts: ctx.scripts,
             signature_m1_types: ctx.signature_m1_types,
+            object_rules: ctx.object_rules,
             depth: ctx.depth + 1,
             trace: ctx.trace.as_deref_mut(),
         };
@@ -291,6 +292,7 @@ mod tests {
                 dt: 0.01,
                 scripts,
                 signature_m1_types: Some(&self.loaded.signature_m1_types),
+                object_rules: Some(&self.loaded.object_rules),
                 depth: 0,
                 trace: None,
             };

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -782,6 +782,7 @@ Output = i;
             dt: 0.01,
             scripts: &scripts,
             signature_m1_types: Some(&loaded.signature_m1_types),
+            object_rules: Some(&loaded.object_rules),
             depth: 0,
             trace: None,
         };

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -69,6 +69,10 @@ pub struct EvalCtx<'a> {
     /// `None` is supported for direct expression users that did not load a
     /// project through [`crate::loader::load`].
     pub signature_m1_types: Option<&'a crate::loader::SignatureM1Types>,
+    /// Project-owned validation rules for core object methods. Loader-backed
+    /// evaluation always supplies them; small expression unit tests may omit
+    /// them when they do not call those methods.
+    pub object_rules: Option<&'a crate::builtins::object::ObjectRules>,
     /// Current inline-call nesting depth. `0` at the top of a tick; incremented
     /// each time [`crate::builtins::userfn::call`] enters a callee body, so a
     /// runtime call cycle fails loud past a fixed bound rather than overflowing
@@ -1313,6 +1317,7 @@ mod tests {
                 dt: 0.01,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: None,
             }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -14,6 +14,7 @@
 //! `Engine` facade (a later task) re-wraps it so no toolchain types leak past the
 //! library boundary.
 
+use crate::builtins::object::ObjectRules;
 use crate::calib::Calibration;
 use crate::error::EvalError;
 use crate::triggers::{TriggerMap, TriggerStatus};
@@ -63,6 +64,9 @@ pub struct Loaded {
     /// Exact numeric families from raw function signatures. This complements
     /// the typechecker's coarser `ValueType` model at evaluator boundaries.
     pub signature_m1_types: SignatureM1Types,
+    /// Validation ranges declared on project value objects. Core object methods
+    /// use this index for `Validate`, `Constrain`, and `Set`.
+    pub object_rules: ObjectRules,
     /// Function symbols whose `.m1prj` `SelectedTrigger` resolves to the
     /// `On Startup` event kernel, including any resolved attribute reference.
     /// The whole-project runner executes these exactly once before the periodic
@@ -118,6 +122,7 @@ pub fn load(project_path: &Path, cfg_path: Option<&Path>) -> Result<Loaded, Eval
 
     let project_xml = read_xml(project_path)?;
     let signature_m1_types = signature_m1_types(&project_xml)?;
+    let object_rules = ObjectRules::from_project_xml(&project_xml)?;
     let triggers = TriggerMap::from_project_xml(&project_xml, &project, &scripts)?;
     let startup_fn_symbols = triggers
         .iter()
@@ -131,6 +136,7 @@ pub fn load(project_path: &Path, cfg_path: Option<&Path>) -> Result<Loaded, Eval
         scripts,
         calib,
         signature_m1_types,
+        object_rules,
         startup_fn_symbols,
         triggers,
     })

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -498,6 +498,7 @@ fn tick_loop(
                 dt: 1.0 / base_rate_hz,
                 scripts: &loaded.scripts,
                 signature_m1_types: Some(&loaded.signature_m1_types),
+                object_rules: Some(&loaded.object_rules),
                 depth: 0,
                 // No trace: no tick is open yet, and record_channel appends
                 // blindly — a startup record would desync columns from the time
@@ -555,6 +556,7 @@ fn tick_loop(
                 dt: plan.dt,
                 scripts: &loaded.scripts,
                 signature_m1_types: Some(&loaded.signature_m1_types),
+                object_rules: Some(&loaded.object_rules),
                 depth: 0,
                 trace: Some(&mut trace),
             };
@@ -1141,6 +1143,7 @@ pub fn run_counterfactual(
                         dt: 1.0 / base_rate_hz,
                         scripts: &loaded.scripts,
                         signature_m1_types: Some(&loaded.signature_m1_types),
+                        object_rules: Some(&loaded.object_rules),
                         depth: 0,
                         trace: None,
                     };
@@ -1178,6 +1181,7 @@ pub fn run_counterfactual(
                 dt: plan.dt,
                 scripts: &loaded.scripts,
                 signature_m1_types: Some(&loaded.signature_m1_types),
+                object_rules: Some(&loaded.object_rules),
                 depth: 0,
                 trace: Some(&mut trace),
             };

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -765,6 +765,7 @@ mod tests {
                 dt: 0.01,
                 scripts: &[],
                 signature_m1_types: None,
+                object_rules: None,
                 depth: 0,
                 trace: Some(&mut self.trace),
             }
@@ -1155,6 +1156,7 @@ mod tests {
             dt: 0.01,
             scripts: &[],
             signature_m1_types: Some(&loaded.signature_m1_types),
+            object_rules: Some(&loaded.object_rules),
             depth: 0,
             trace: Some(&mut trace),
         };

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -136,8 +136,16 @@ impl Walker<'_> {
         }
 
         // Parameters are readable even though they are calibration-owned and
-        // therefore excluded from `writable_value_path`.
-        if let Some(value_path) = crate::builtins::object::numeric_value_path(&path, self.project) {
+        // therefore excluded from `writable_value_path`. Enum conversions use
+        // their parallel typed resolver so their receiver edges are retained.
+        let value_path = match method.text() {
+            "AsInteger" | "AsString" => {
+                crate::builtins::enum_conv::enum_value_path(&path, self.project)
+                    .or_else(|| crate::builtins::object::numeric_value_path(&path, self.project))
+            }
+            _ => crate::builtins::object::numeric_value_path(&path, self.project),
+        };
+        if let Some(value_path) = value_path {
             self.sets.reads.insert(value_path);
         }
     }
@@ -257,6 +265,13 @@ mod tests {
         )
         .expect("mini fixture loads")
         .project
+    }
+
+    fn enum_project() -> Project {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums");
+        crate::loader::load(&dir.join("Project.m1prj"), None)
+            .expect("enum fixture loads")
+            .project
     }
 
     /// Parse a synthetic script body under the `Demo.Update.m1scr` name so it
@@ -384,6 +399,37 @@ mod tests {
         );
         assert!(sets.reads.contains("Root.Demo.Speed"), "{sets:?}");
         assert!(sets.reads.contains("Root.Demo.Output"), "{sets:?}");
+    }
+
+    #[test]
+    fn parameter_backed_compound_set_is_not_a_scheduler_write() {
+        let project = mini_project();
+        let script = script_from("Calibration Compound.Set(Output);\n");
+        let sets = io_sets(&script, &project, Some("Root.Demo"));
+
+        assert!(
+            !sets
+                .writes
+                .contains("Root.Demo.Calibration Compound.Calibration"),
+            "the declared Parameter default is calibration-owned: {sets:?}"
+        );
+        assert!(
+            !sets.writes.contains("Root.Demo.Calibration Compound.Value"),
+            "the generated sibling must not bypass the declared default: {sets:?}"
+        );
+        assert!(sets.reads.contains("Root.Demo.Output"), "{sets:?}");
+    }
+
+    #[test]
+    fn enum_conversions_read_channel_and_compound_receivers() {
+        let project = enum_project();
+        let script = script_from(
+            "local direct = Mode.AsString();\nlocal compound = Compound.AsInteger();\n",
+        );
+        let sets = io_sets(&script, &project, Some("Root.Demo"));
+
+        assert!(sets.reads.contains("Root.Demo.Mode"), "{sets:?}");
+        assert!(sets.reads.contains("Root.Demo.Compound.Value"), "{sets:?}");
     }
 
     #[test]

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -134,6 +134,18 @@ impl Walker<'_> {
             }
             return;
         }
+        if matches!(method.text(), "Lookup" | "Get")
+            && self
+                .project
+                .symbols()
+                .get(&path)
+                .is_some_and(|symbol| symbol.kind == m1_typecheck::symbols::SymbolKind::Table)
+        {
+            // Table lookup/indexing reads calibration axes and body cells, not
+            // the generated runtime `.Value` channel. Arguments remain reads
+            // because `walk_call` accounts for them before the receiver.
+            return;
+        }
 
         // Parameters are readable even though they are calibration-owned and
         // therefore excluded from `writable_value_path`. Enum conversions use
@@ -430,6 +442,19 @@ mod tests {
 
         assert!(sets.reads.contains("Root.Demo.Mode"), "{sets:?}");
         assert!(sets.reads.contains("Root.Demo.Compound.Value"), "{sets:?}");
+    }
+
+    #[test]
+    fn table_lookup_and_get_do_not_read_the_generated_value_channel() {
+        let project = mini_project();
+        let script = script_from("local x = Map.Lookup(Speed);\nlocal y = Map.Get(0);\n");
+        let sets = io_sets(&script, &project, Some("Root.Demo"));
+
+        assert!(sets.reads.contains("Root.Demo.Speed"), "{sets:?}");
+        assert!(
+            !sets.reads.contains("Root.Demo.Map.Value"),
+            "calibration-only table calls must not create a runtime channel edge: {sets:?}"
+        );
     }
 
     #[test]

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -96,12 +96,12 @@ impl Walker<'_> {
     }
 
     /// Account the *receiver* of a method call's callee. Mirrors `m1-typecheck`
-    /// schedule.rs: when the receiver resolves to a writable project value,
-    /// `Value.Set*(…)` is an imperative **write** of its concrete channel, and
-    /// any other value method is a **read**, except `GetUnscheduled`, whose
-    /// contract explicitly omits the scheduling edge. A library/object callee
-    /// (`Calculate.Max`) has no channel receiver and is ignored. The arguments
-    /// are handled by the caller, not here.
+    /// schedule.rs: `Value.Set*(…)` is an imperative **write** only when its
+    /// receiver resolves to a firmware-writable channel. Other value methods
+    /// are **reads**, except a supported `GetUnscheduled`, whose contract
+    /// explicitly omits the scheduling edge. A library/object callee
+    /// (`Calculate.Max`) has no project-value receiver and is ignored. The
+    /// arguments are handled by the caller, not here.
     fn account_call_callee(&mut self, call_node: &Node) {
         let Some(callee) = call_node.child_by_field(Field::Function) else {
             return;
@@ -115,21 +115,29 @@ impl Walker<'_> {
         ) else {
             return;
         };
-        // Resolve the receiver to the concrete channel/parameter it stores.
-        // A value compound may write/read through its declared default child.
         let Some(path) = self.canonical_symbol(&receiver) else {
             return;
         };
-        let Some(value_path) = crate::builtins::object::writable_value_path(&path, self.project)
-        else {
-            return;
-        };
-        if method.text() == "GetUnscheduled" {
+
+        if method.text() == "GetUnscheduled"
+            && crate::builtins::object::unscheduled_value_path(&path, self.project).is_some()
+        {
+            // Only channels and generated table values own this method. Its
+            // entire purpose is to suppress the receiver's scheduling edge.
             return;
         }
         if method.text().starts_with("Set") {
-            self.sets.writes.insert(value_path);
-        } else {
+            if let Some(value_path) =
+                crate::builtins::object::writable_value_path(&path, self.project)
+            {
+                self.sets.writes.insert(value_path);
+            }
+            return;
+        }
+
+        // Parameters are readable even though they are calibration-owned and
+        // therefore excluded from `writable_value_path`.
+        if let Some(value_path) = crate::builtins::object::numeric_value_path(&path, self.project) {
             self.sets.reads.insert(value_path);
         }
     }
@@ -358,6 +366,24 @@ mod tests {
             sets.reads.contains("Root.Demo.Gain"),
             "call arguments remain ordinary reads: {sets:?}"
         );
+    }
+
+    #[test]
+    fn parameter_value_method_is_a_read_but_set_is_not_a_write() {
+        let project = mini_project();
+        let script = script_from("local valid = Gain.Validate(Speed);\nGain.Set(Output);\n");
+        let sets = io_sets(&script, &project, Some("Root.Demo"));
+
+        assert!(
+            sets.reads.contains("Root.Demo.Gain"),
+            "parameter validation still reads its receiver: {sets:?}"
+        );
+        assert!(
+            !sets.writes.contains("Root.Demo.Gain"),
+            "parameters remain calibration-owned: {sets:?}"
+        );
+        assert!(sets.reads.contains("Root.Demo.Speed"), "{sets:?}");
+        assert!(sets.reads.contains("Root.Demo.Output"), "{sets:?}");
     }
 
     #[test]

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -29,7 +29,6 @@ use crate::value::Value;
 use m1_core::{Field, Kind, Node};
 use m1_typecheck::Project;
 use m1_typecheck::parsed::ParsedScript;
-use m1_typecheck::symbols::SymbolKind;
 use std::collections::{BTreeSet, HashMap};
 
 /// The canonical read/write sets of one function's body.
@@ -97,11 +96,12 @@ impl Walker<'_> {
     }
 
     /// Account the *receiver* of a method call's callee. Mirrors `m1-typecheck`
-    /// schedule.rs: when the receiver resolves to a project channel/parameter,
-    /// `Chan.Set*(…)` is the imperative setter — a **write** of that channel — and
-    /// any other method (`AsInteger`/`Lookup`/`Get…`/…) is a **read**. A
-    /// library/object callee (`Calculate.Max`) has no channel receiver and is
-    /// ignored. The arguments are handled by the caller, not here.
+    /// schedule.rs: when the receiver resolves to a writable project value,
+    /// `Value.Set*(…)` is an imperative **write** of its concrete channel, and
+    /// any other value method is a **read**, except `GetUnscheduled`, whose
+    /// contract explicitly omits the scheduling edge. A library/object callee
+    /// (`Calculate.Max`) has no channel receiver and is ignored. The arguments
+    /// are handled by the caller, not here.
     fn account_call_callee(&mut self, call_node: &Node) {
         let Some(callee) = call_node.child_by_field(Field::Function) else {
             return;
@@ -115,23 +115,22 @@ impl Walker<'_> {
         ) else {
             return;
         };
-        // The receiver must resolve to a project channel/parameter to count.
+        // Resolve the receiver to the concrete channel/parameter it stores.
+        // A value compound may write/read through its declared default child.
         let Some(path) = self.canonical_symbol(&receiver) else {
             return;
         };
-        let writable = self
-            .project
-            .symbols()
-            .get(&path)
-            .map(|s| matches!(s.kind, SymbolKind::Channel | SymbolKind::Parameter))
-            .unwrap_or(false);
-        if !writable {
+        let Some(value_path) = crate::builtins::object::writable_value_path(&path, self.project)
+        else {
+            return;
+        };
+        if method.text() == "GetUnscheduled" {
             return;
         }
         if method.text().starts_with("Set") {
-            self.sets.writes.insert(path);
+            self.sets.writes.insert(value_path);
         } else {
-            self.sets.reads.insert(path);
+            self.sets.reads.insert(value_path);
         }
     }
 
@@ -338,5 +337,39 @@ mod tests {
 
         assert!(sets.reads.contains("Root.Demo.Output"), "{sets:?}");
         assert!(!sets.writes.contains("Root.Demo.Output"), "{sets:?}");
+    }
+
+    #[test]
+    fn get_unscheduled_omits_only_its_receiver_dependency() {
+        let project = mini_project();
+        let script =
+            script_from("local x = Output.GetUnscheduled();\nlocal y = Speed.Validate(Gain);\n");
+        let sets = io_sets(&script, &project, Some("Root.Demo"));
+
+        assert!(
+            !sets.reads.contains("Root.Demo.Output"),
+            "GetUnscheduled must not create a scheduler edge: {sets:?}"
+        );
+        assert!(
+            sets.reads.contains("Root.Demo.Speed"),
+            "other object methods still read their receiver: {sets:?}"
+        );
+        assert!(
+            sets.reads.contains("Root.Demo.Gain"),
+            "call arguments remain ordinary reads: {sets:?}"
+        );
+    }
+
+    #[test]
+    fn value_compound_set_writes_its_declared_default_channel() {
+        let project = mini_project();
+        let script = script_from("Sensor Compound.Set(2.0);\n");
+        let sets = io_sets(&script, &project, Some("Root.Demo"));
+
+        assert!(
+            sets.writes.contains("Root.Demo.Sensor Compound.Sensor"),
+            "the scheduler must see the same concrete write as runtime: {sets:?}"
+        );
+        assert!(!sets.writes.contains("Root.Demo.Sensor Compound"));
     }
 }

--- a/tests/fixtures/enums/Project.m1prj
+++ b/tests/fixtures/enums/Project.m1prj
@@ -22,6 +22,9 @@
    <Component Classname="BuiltIn.Constant" Name="Root.Demo.Numeric Constant"><Props Type="f32" Value="1.0"/></Component>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Limited Compound"><Props UseDefValue="true" DefValue="This.Value" Validation="MinMax" ValMin="1" ValMax="4"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Limited Compound.Value"><Props Type="u32"/></Component>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Calibration Compound"><Props UseDefValue="true" DefValue="This.Calibration"/></Component>
+   <Component Classname="BuiltIn.Parameter" Name="Root.Demo.Calibration Compound.Calibration"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Calibration Compound.Value"><Props Type="f32"/></Component>
    <Component Classname="BuiltIn.Timer" Name="Root.Demo.Startup Delay"/>
    <Component Classname="MoTeC Input.Sensor" Name="Root.Demo.Typed IO"><Props Type="f32"/></Component>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Service Bits"/>

--- a/tests/fixtures/enums/Project.m1prj
+++ b/tests/fixtures/enums/Project.m1prj
@@ -19,6 +19,7 @@
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Limited Unsigned"><Props Type="u32" Validation="MinMax" ValMin="2" ValMax="10"/></Component>
    <Component Classname="BuiltIn.Parameter" Name="Root.Demo.Positive Float"><Props Type="f32" Validation="Positive"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Free Unsigned"><Props Type="u32"/></Component>
+   <Component Classname="BuiltIn.Constant" Name="Root.Demo.Numeric Constant"><Props Type="f32" Value="1.0"/></Component>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Limited Compound"><Props UseDefValue="true" DefValue="This.Value" Validation="MinMax" ValMin="1" ValMax="4"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Limited Compound.Value"><Props Type="u32"/></Component>
    <Component Classname="BuiltIn.Timer" Name="Root.Demo.Startup Delay"/>

--- a/tests/fixtures/enums/Project.m1prj
+++ b/tests/fixtures/enums/Project.m1prj
@@ -13,6 +13,14 @@
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Compound"/>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Compound.Value"><Props Type="::This.Drive State"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Precharge State"><Props Type="u8"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Limited Signed"><Props Type="s32" Validation="MinMax" ValMin="-2" ValMax="3"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Limited Float"><Props Type="f32" Validation="MinMax" ValMin="-1.5" ValMax="2.25"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Limited Fixed"><Props Type="FixedPoint7dps" Validation="MinMax" ValMin="-1.2345678" ValMax="1.2345678"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Limited Unsigned"><Props Type="u32" Validation="MinMax" ValMin="2" ValMax="10"/></Component>
+   <Component Classname="BuiltIn.Parameter" Name="Root.Demo.Positive Float"><Props Type="f32" Validation="Positive"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Free Unsigned"><Props Type="u32"/></Component>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Limited Compound"><Props UseDefValue="true" DefValue="This.Value" Validation="MinMax" ValMin="1" ValMax="4"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Limited Compound.Value"><Props Type="u32"/></Component>
    <Component Classname="BuiltIn.Timer" Name="Root.Demo.Startup Delay"/>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Service Bits"/>
    <Component Classname="BuiltIn.CAN.Message" Name="Root.Demo.DashVals"/>

--- a/tests/fixtures/enums/Project.m1prj
+++ b/tests/fixtures/enums/Project.m1prj
@@ -22,6 +22,7 @@
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Limited Compound"><Props UseDefValue="true" DefValue="This.Value" Validation="MinMax" ValMin="1" ValMax="4"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Limited Compound.Value"><Props Type="u32"/></Component>
    <Component Classname="BuiltIn.Timer" Name="Root.Demo.Startup Delay"/>
+   <Component Classname="MoTeC Input.Sensor" Name="Root.Demo.Typed IO"><Props Type="f32"/></Component>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Service Bits"/>
    <Component Classname="BuiltIn.CAN.Message" Name="Root.Demo.DashVals"/>
    <Component Classname="BuiltIn.CAN.Signal" Name="Root.Demo.DashVals.Aux Switch"/>

--- a/tests/fixtures/mini/Project.m1prj
+++ b/tests/fixtures/mini/Project.m1prj
@@ -17,6 +17,7 @@
    <Component Classname="BuiltIn.Constant" Name="Root.Demo.LegacyConstant"><Props Value="100"/></Component>
    <Component Classname="BuiltIn.Constant" Name="Root.Demo.BooleanConstant"><Props Value="true"/></Component>
    <Component Classname="BuiltIn.Table" Name="Root.Demo.Map"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Caps="AutoCreated" Name="Root.Demo.Map.Value"><Props Type="f32"/></Component>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Sensor Compound"><Props UseDefValue="true" DefValue="This.Sensor"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Sensor Compound.Sensor"><Props Type="f32"/></Component>
    <Component Classname="BuiltIn.FuncUser" Filename="Demo.Update.m1scr" Name="Root.Demo.Update"/>

--- a/tests/fixtures/mini/Project.m1prj
+++ b/tests/fixtures/mini/Project.m1prj
@@ -20,6 +20,9 @@
    <Component Classname="BuiltIn.Channel" Caps="AutoCreated" Name="Root.Demo.Map.Value"><Props Type="f32"/></Component>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Sensor Compound"><Props UseDefValue="true" DefValue="This.Sensor"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Sensor Compound.Sensor"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Calibration Compound"><Props UseDefValue="true" DefValue="This.Calibration"/></Component>
+   <Component Classname="BuiltIn.Parameter" Name="Root.Demo.Calibration Compound.Calibration"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Calibration Compound.Value"><Props Type="f32"/></Component>
    <Component Classname="BuiltIn.FuncUser" Filename="Demo.Update.m1scr" Name="Root.Demo.Update"/>
   </List></ComponentStream>
  </Project>

--- a/tests/script_exec.rs
+++ b/tests/script_exec.rs
@@ -57,6 +57,7 @@ fn demo_update_script_computes_output() {
         dt: 0.01,
         scripts: &loaded.scripts,
         signature_m1_types: Some(&loaded.signature_m1_types),
+        object_rules: Some(&loaded.object_rules),
         depth: 0,
         trace: Some(&mut trace),
     };
@@ -100,6 +101,7 @@ fn demo_update_is_deterministic_in_inputs() {
             dt: 0.01,
             scripts: &loaded.scripts,
             signature_m1_types: Some(&loaded.signature_m1_types),
+            object_rules: Some(&loaded.object_rules),
             depth: 0,
             trace: None,
         };


### PR DESCRIPTION
## Summary

- route `Library.<object>.<method>` through the same receiver-aware capability and runtime paths as the unqualified library form
- implement typed enum `AsString` plus numeric `Validate`, `Constrain`, and `GetUnscheduled`
- parse project `MinMax` and `Positive` validation metadata, and make `Set` target-coerce, constrain, trace, and schedule the concrete writable value path
- reject unsupported receiver/method pairs precisely and keep coverage classification aligned with runtime dispatch
- preserve the M1-width Calculate and Convert behavior merged in #62

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` (446 library tests plus integration and doctests)
- `cargo test --locked --features ld` (459 library tests plus integration and doctests)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- `cargo +1.88.0 check --locked --all-targets --all-features`
- `git diff --check`
- read-only EV and AV project coverage loads

The proprietary EV/AV inputs were not copied or committed. Both real-project reports retain the pre-existing unsupported `Discrete.Diagnostic.AsInteger` entry; this change does not broaden that unrelated enum-conversion boundary. Object validation remains an explicit evaluator model documented in the README, not an M1 output-value comparison.

Closes #40