### PR TITLE
Remove the legacy 64-bit numeric execution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,15 @@ dependency-cone runners.
   (`duration_s` + `base_rate_hz`), and input sources (constants or `(t, value)`
   time series), with an optional CSV time-series sidecar.
 
-### Pure numeric builtin behavior
+### Runtime numeric behavior
 
-Pure `Calculate` and `Convert` calls use the M1-width scalar model throughout.
+Script execution has four numeric forms: binary32 `FloatingPoint`, signed
+32-bit `Integer`, unsigned 32-bit `UnsignedInteger`, and signed 32-bit
+`FixedPoint7dps` storage scaled by 10^-7. Expressions, builtins, stateful
+operator state, tables, IO defaults, and trace columns keep those forms. A
+scenario, log, or calibration parser may use a wider host type while reading its
+wire format, but it narrows or rejects the value before evaluation starts.
+
 The implemented behavior is still **Assumed** under the maturity contract above:
 
 - `Calculate.Bias(a, b, bias)` maps `-1` to the lower argument, `0` to their

--- a/src/builtins/calculate.rs
+++ b/src/builtins/calculate.rs
@@ -177,12 +177,20 @@ fn average(args: &[Value]) -> Result<Value, EvalError> {
             Ok(Value::m1_float(left.midpoint(right)))
         }
         ValueType::Unsigned => {
-            let sum = u64::from(as_u32_bits(left)?) + u64::from(as_u32_bits(right)?);
-            Ok(Value::m1_unsigned((sum / 2) as u32))
+            let left = as_u32_bits(left)?;
+            let right = as_u32_bits(right)?;
+            Ok(Value::m1_unsigned((left & right) + ((left ^ right) >> 1)))
         }
         ValueType::Integer => {
-            let sum = i64::from(as_i32(left)?) + i64::from(as_i32(right)?);
-            Ok(Value::m1_integer((sum / 2) as i32))
+            let left = as_i32(left)?;
+            let right = as_i32(right)?;
+            let average = if left.signum() != right.signum() {
+                // Opposite signs cannot overflow when added.
+                (left + right) / 2
+            } else {
+                left / 2 + right / 2 + (left % 2 + right % 2) / 2
+            };
+            Ok(Value::m1_integer(average))
         }
         _ => Err(non_numeric("Average", left, right)),
     }
@@ -204,7 +212,6 @@ fn value_type(value: &Value) -> ValueType {
         Value::Bool(_) => ValueType::Boolean,
         Value::Enum { id, .. } => ValueType::Enum(*id),
         Value::Str(_) => ValueType::String,
-        Value::Int(_) | Value::Uint(_) | Value::Float(_) => ValueType::Unknown,
     }
 }
 
@@ -414,6 +421,20 @@ mod tests {
             ),
             Value::m1_unsigned(u32::MAX)
         );
+        assert_eq!(
+            ok(
+                "Average",
+                &[Value::m1_integer(i32::MIN), Value::m1_integer(i32::MAX)]
+            ),
+            Value::m1_integer(0)
+        );
+        assert_eq!(
+            ok(
+                "Average",
+                &[Value::m1_unsigned(0), Value::m1_unsigned(u32::MAX)]
+            ),
+            Value::m1_unsigned(u32::MAX / 2)
+        );
 
         for value in [f32::from_bits(1), -f32::from_bits(1)] {
             assert_eq!(
@@ -524,9 +545,9 @@ mod tests {
     }
 
     #[test]
-    fn rejects_legacy_numeric_arguments() {
+    fn rejects_non_numeric_arguments() {
         assert!(matches!(
-            call("Average", &[Value::Int(1), Value::Int(2)]),
+            call("Average", &[Value::Bool(true), Value::Bool(false)]),
             Err(EvalError::TypeError { .. })
         ));
     }

--- a/src/builtins/convert.rs
+++ b/src/builtins/convert.rs
@@ -51,8 +51,10 @@ fn to_unsigned_integer(argument: &Value) -> Result<Value, EvalError> {
 
 fn to_fixed_7dps(argument: &Value) -> Result<Value, EvalError> {
     let integer = match argument.m1_scalar()? {
-        M1Scalar::Integer(value) => i64::from(value),
-        M1Scalar::UnsignedInteger(value) => i64::from(value),
+        M1Scalar::Integer(value) => value,
+        M1Scalar::UnsignedInteger(value) => {
+            i32::try_from(value).map_err(|_| fixed_range_error(value))?
+        }
         other => {
             return Err(EvalError::TypeError {
                 detail: format!(
@@ -61,15 +63,20 @@ fn to_fixed_7dps(argument: &Value) -> Result<Value, EvalError> {
             });
         }
     };
-    let scaled = integer * FixedPoint7dps::SCALE;
-    let raw = i32::try_from(scaled).map_err(|_| EvalError::TypeError {
-        detail: format!(
-            "Convert.ToFixed7DP input {integer} is outside the Fixed Point 7dps range; integral inputs must be between -214 and 214"
-        ),
-    })?;
+    let raw = integer
+        .checked_mul(10_000_000)
+        .ok_or_else(|| fixed_range_error(integer))?;
     Ok(Value::M1(M1Scalar::FixedPoint7dps(
         FixedPoint7dps::from_raw(raw),
     )))
+}
+
+fn fixed_range_error(value: impl std::fmt::Display) -> EvalError {
+    EvalError::TypeError {
+        detail: format!(
+            "Convert.ToFixed7DP input {value} is outside the Fixed Point 7dps range; integral inputs must be between -214 and 214"
+        ),
+    }
 }
 
 fn round_f32_to_i32(value: f32) -> Result<i32, EvalError> {
@@ -90,15 +97,16 @@ fn round_f32_to_u32(value: f32) -> Result<u32, EvalError> {
 /// division truncates toward zero, so adding one unit when the remainder is at
 /// least half the scale implements halfway-away-from-zero without a float.
 fn round_fixed_to_i32(value: FixedPoint7dps) -> i32 {
-    let raw = i64::from(value.raw());
-    let whole = raw / FixedPoint7dps::SCALE;
-    let remainder = raw % FixedPoint7dps::SCALE;
-    let adjustment = if remainder.abs() * 2 >= FixedPoint7dps::SCALE {
+    let raw = value.raw();
+    let scale = 10_000_000_i32;
+    let whole = raw / scale;
+    let remainder = raw % scale;
+    let adjustment = if remainder.unsigned_abs() * 2 >= scale as u32 {
         remainder.signum()
     } else {
         0
     };
-    (whole + adjustment) as i32
+    whole + adjustment
 }
 
 fn not_convertible(target: &str, value: f32) -> EvalError {
@@ -246,10 +254,6 @@ mod tests {
         ));
         assert!(matches!(
             call("ToInteger", &[Value::Str("x".into())]),
-            Err(EvalError::TypeError { .. })
-        ));
-        assert!(matches!(
-            call("ToInteger", &[Value::Float(1.0)]),
             Err(EvalError::TypeError { .. })
         ));
     }

--- a/src/builtins/io_stub.rs
+++ b/src/builtins/io_stub.rs
@@ -210,16 +210,16 @@ pub fn project_object_call(
     let v = match method {
         // A CAN message `.TxOpen()` returns an opaque transmit handle; offline it
         // is the determinate zero handle.
-        "TxOpen" => Value::Uint(0),
+        "TxOpen" => Value::m1_unsigned(0),
         // A CAN signal `.Receive()` is false offline — no frame has arrived.
         "Receive" => Value::Bool(false),
         // A scaled or floating-point CAN signal read has no offline value; the
         // documented stub is 0.
-        "GetScaled" | "GetFloat" => Value::Float(0.0),
+        "GetScaled" | "GetFloat" => Value::m1_float(0.0),
         // A raw unsigned CAN signal read stubs to 0.
-        "GetUnsignedInteger" => Value::Uint(0),
+        "GetUnsignedInteger" => Value::m1_unsigned(0),
         // A raw signed CAN signal read stubs to 0.
-        "GetInteger" => Value::Int(0),
+        "GetInteger" => Value::m1_integer(0),
         // A single bus bit read is false offline — no frame has set it.
         "GetBit" => Value::Bool(false),
         // Void writers: a CAN transmit / bit set / service-bits push / output set
@@ -281,7 +281,7 @@ fn documented_stub(
 ) -> Result<Option<Value>, EvalError> {
     let v = match (object, method) {
         // The scheduler tick period is exactly the evaluator's tick step.
-        ("System", "TickPeriod") => Value::Float(ctx.dt),
+        ("System", "TickPeriod") => Value::m1_float(ctx.dt as f32),
         // No tuning tool (XCP) is connected during offline evaluation.
         ("System", "XcpConnected") => Value::Bool(false),
         // Void side-effects: no observable result offline. Return a benign value

--- a/src/builtins/limit.rs
+++ b/src/builtins/limit.rs
@@ -6,9 +6,9 @@
 //! - `Limit.Range(x, lo, hi)` — clamp into `[lo, hi]`.
 //!
 //! Each returns `Integer|FloatingPoint`: the result is integral when every
-//! operand is integral (signed/unsigned chosen by `numeric_join`) and float
-//! when any operand is float. Comparison is done in `f64`. Semantics are
-//! paraphrased from our understanding of the M1 library, not copied.
+//! operand is integral (signed/unsigned chosen by `numeric_join`) and binary32
+//! when any operand is floating. Comparisons and results stay in the selected M1
+//! family. Semantics are paraphrased from our understanding of the M1 library.
 
 use crate::error::EvalError;
 use crate::value::{M1Scalar, Value};
@@ -33,49 +33,93 @@ pub fn call(method: &str, args: &[Value]) -> Result<Option<Value>, EvalError> {
 /// `bound` (a lower bound); false ⇒ cap `x` down to at most `bound` (an upper
 /// bound). The result is retyped under the join of `x` and `bound`.
 fn clamp_one(x: &Value, bound: &Value, floor: bool) -> Result<Value, EvalError> {
-    let xf = x.as_f64()?;
-    let bf = bound.as_f64()?;
-    let target = numeric_join(value_type(x), value_type(bound));
-    let out = if floor { xf.max(bf) } else { xf.min(bf) };
-    retype_numeric(out, target)
+    match numeric_join(value_type(x), value_type(bound)) {
+        ValueType::Float => {
+            let x = x.m1_scalar()?.as_f32();
+            let bound = bound.m1_scalar()?.as_f32();
+            Ok(Value::m1_float(if floor {
+                x.max(bound)
+            } else {
+                x.min(bound)
+            }))
+        }
+        ValueType::Unsigned => {
+            let x = as_u32_bits(x)?;
+            let bound = as_u32_bits(bound)?;
+            Ok(Value::m1_unsigned(if floor {
+                x.max(bound)
+            } else {
+                x.min(bound)
+            }))
+        }
+        ValueType::Integer => {
+            let x = as_i32(x)?;
+            let bound = as_i32(bound)?;
+            Ok(Value::m1_integer(if floor {
+                x.max(bound)
+            } else {
+                x.min(bound)
+            }))
+        }
+        _ => Err(non_numeric()),
+    }
 }
 
 /// Clamp `x` into `[lo, hi]`. The result kind is the join of all three operands.
 /// A reversed range (`lo > hi`) clamps to `hi` (the upper bound wins), which is
 /// our documented choice for malformed ranges.
 fn clamp_range(x: &Value, lo: &Value, hi: &Value) -> Result<Value, EvalError> {
-    let xf = x.as_f64()?;
-    let lof = lo.as_f64()?;
-    let hif = hi.as_f64()?;
-    let clamped = xf.max(lof).min(hif);
     let target = numeric_join(numeric_join(value_type(x), value_type(lo)), value_type(hi));
-    retype_numeric(clamped, target)
-}
-
-/// Re-express a clamped `f64` under the target numeric kind so an all-integer
-/// clamp stays integral.
-fn retype_numeric(out: f64, target: ValueType) -> Result<Value, EvalError> {
     match target {
-        ValueType::Float => Ok(Value::Float(out)),
-        ValueType::Unsigned => Ok(Value::Uint(out as u64)),
-        ValueType::Integer => Ok(Value::Int(out as i64)),
-        _ => Err(EvalError::TypeError {
-            detail: "Limit on non-numeric operands".to_string(),
-        }),
+        ValueType::Float => Ok(Value::m1_float(
+            x.m1_scalar()?
+                .as_f32()
+                .max(lo.m1_scalar()?.as_f32())
+                .min(hi.m1_scalar()?.as_f32()),
+        )),
+        ValueType::Unsigned => Ok(Value::m1_unsigned(
+            as_u32_bits(x)?.max(as_u32_bits(lo)?).min(as_u32_bits(hi)?),
+        )),
+        ValueType::Integer => Ok(Value::m1_integer(
+            as_i32(x)?.max(as_i32(lo)?).min(as_i32(hi)?),
+        )),
+        _ => Err(non_numeric()),
     }
 }
 
 fn value_type(v: &Value) -> ValueType {
     match v {
         Value::Bool(_) => ValueType::Boolean,
-        Value::Int(_) => ValueType::Integer,
-        Value::Uint(_) => ValueType::Unsigned,
-        Value::Float(_) => ValueType::Float,
         Value::M1(M1Scalar::Integer(_)) => ValueType::Integer,
         Value::M1(M1Scalar::UnsignedInteger(_)) => ValueType::Unsigned,
         Value::M1(M1Scalar::FloatingPoint(_) | M1Scalar::FixedPoint7dps(_)) => ValueType::Float,
         Value::Enum { id, .. } => ValueType::Enum(*id),
         Value::Str(_) => ValueType::String,
+    }
+}
+
+fn as_i32(value: &Value) -> Result<i32, EvalError> {
+    match value.m1_scalar()? {
+        M1Scalar::Integer(value) => Ok(value),
+        other => Err(EvalError::TypeError {
+            detail: format!("{other:?} is not an M1 Integer"),
+        }),
+    }
+}
+
+fn as_u32_bits(value: &Value) -> Result<u32, EvalError> {
+    match value.m1_scalar()? {
+        M1Scalar::Integer(value) => Ok(value as u32),
+        M1Scalar::UnsignedInteger(value) => Ok(value),
+        other => Err(EvalError::TypeError {
+            detail: format!("{other:?} is not an integral M1 value"),
+        }),
+    }
+}
+
+fn non_numeric() -> EvalError {
+    EvalError::TypeError {
+        detail: "Limit on non-numeric operands".to_string(),
     }
 }
 
@@ -89,14 +133,26 @@ mod tests {
 
     #[test]
     fn limit_max_caps_above() {
-        assert_eq!(ok("Max", &[Value::Int(8), Value::Int(5)]), Value::Int(5));
-        assert_eq!(ok("Max", &[Value::Int(3), Value::Int(5)]), Value::Int(3));
+        assert_eq!(
+            ok("Max", &[Value::m1_integer(8), Value::m1_integer(5)]),
+            Value::m1_integer(5)
+        );
+        assert_eq!(
+            ok("Max", &[Value::m1_integer(3), Value::m1_integer(5)]),
+            Value::m1_integer(3)
+        );
     }
 
     #[test]
     fn limit_min_floors_below() {
-        assert_eq!(ok("Min", &[Value::Int(2), Value::Int(5)]), Value::Int(5));
-        assert_eq!(ok("Min", &[Value::Int(8), Value::Int(5)]), Value::Int(8));
+        assert_eq!(
+            ok("Min", &[Value::m1_integer(2), Value::m1_integer(5)]),
+            Value::m1_integer(5)
+        );
+        assert_eq!(
+            ok("Min", &[Value::m1_integer(8), Value::m1_integer(5)]),
+            Value::m1_integer(8)
+        );
     }
 
     #[test]
@@ -104,36 +160,55 @@ mod tests {
         assert_eq!(
             ok(
                 "Range",
-                &[Value::Float(7.0), Value::Float(0.0), Value::Float(5.0)]
+                &[
+                    Value::m1_float(7.0),
+                    Value::m1_float(0.0),
+                    Value::m1_float(5.0)
+                ]
             ),
-            Value::Float(5.0)
+            Value::m1_float(5.0)
         );
         assert_eq!(
             ok(
                 "Range",
-                &[Value::Float(-1.0), Value::Float(0.0), Value::Float(5.0)]
+                &[
+                    Value::m1_float(-1.0),
+                    Value::m1_float(0.0),
+                    Value::m1_float(5.0)
+                ]
             ),
-            Value::Float(0.0)
+            Value::m1_float(0.0)
         );
         assert_eq!(
             ok(
                 "Range",
-                &[Value::Float(3.0), Value::Float(0.0), Value::Float(5.0)]
+                &[
+                    Value::m1_float(3.0),
+                    Value::m1_float(0.0),
+                    Value::m1_float(5.0)
+                ]
             ),
-            Value::Float(3.0)
+            Value::m1_float(3.0)
         );
         // All-integer range stays integral.
         assert_eq!(
-            ok("Range", &[Value::Int(9), Value::Int(0), Value::Int(5)]),
-            Value::Int(5)
+            ok(
+                "Range",
+                &[
+                    Value::m1_integer(9),
+                    Value::m1_integer(0),
+                    Value::m1_integer(5)
+                ]
+            ),
+            Value::m1_integer(5)
         );
     }
 
     #[test]
     fn float_operand_promotes() {
         assert_eq!(
-            ok("Max", &[Value::Int(8), Value::Float(5.0)]),
-            Value::Float(5.0)
+            ok("Max", &[Value::m1_integer(8), Value::m1_float(5.0)]),
+            Value::m1_float(5.0)
         );
     }
 

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -84,54 +84,40 @@ pub fn dispatch(
         CallRoute::PureLibrary(library_object) => {
             validate_arity(&library_object, object, method, args.len())?;
             match library_object.as_str() {
-                // Issue #38 migrated Calculate and Convert onto M1 scalars.
                 "Calculate" => {
                     calculate::call(method, args)?.ok_or_else(|| unsupported(object, method))
                 }
                 "Convert" => {
                     convert::call(method, args)?.ok_or_else(|| unsupported(object, method))
                 }
-                // Limit remains on the named legacy compatibility boundary
-                // until its own migration slice.
-                "Limit" => {
-                    let legacy_args = legacy_builtin_arguments(args);
-                    match limit::call(method, &legacy_args)? {
-                        Some(value) => value.restore_legacy_builtin_result(),
-                        None => Err(unsupported(object, method)),
-                    }
-                }
+                "Limit" => limit::call(method, args)?.ok_or_else(|| unsupported(object, method)),
                 _ => unreachable!(),
             }
         }
         CallRoute::StatefulLibrary(library_object) => {
             validate_arity(&library_object, object, method, args.len())?;
-            let legacy_args = legacy_builtin_arguments(args);
-            match stateful::call(&library_object, method, &legacy_args, site, ctx)? {
-                Some(v) => v.restore_legacy_builtin_result(),
+            match stateful::call(&library_object, method, args, site, ctx)? {
+                Some(v) => Ok(v),
                 None => Err(unsupported(object, method)),
             }
         }
         CallRoute::IoLibrary(library_object) => {
-            let legacy_args = legacy_builtin_arguments(args);
-            io_stub::call(&library_object, object, method, &legacy_args, ctx)?
-                .restore_legacy_builtin_result()
+            io_stub::call(&library_object, object, method, args, ctx)
         }
         CallRoute::MathAssumption(library_object) => {
             validate_arity(&library_object, object, method, args.len())?;
-            let legacy_args = legacy_builtin_arguments(args);
-            let result = match method {
+            match method {
                 "atan2" => {
-                    let y = legacy_args[0].as_f64()?;
-                    let x = legacy_args[1].as_f64()?;
-                    Ok(Value::Float(y.atan2(x)))
+                    let y = args[0].m1_scalar()?.as_f32();
+                    let x = args[1].m1_scalar()?.as_f32();
+                    Ok(Value::m1_float(y.atan2(x)))
                 }
                 // `Math.fabs` also appears in real ECU scripts (AV-M1
                 // Control.Update): a plain absolute value, same routing
                 // rationale as `atan2`.
-                "fabs" => Ok(Value::Float(legacy_args[0].as_f64()?.abs())),
+                "fabs" => Ok(Value::m1_float(args[0].m1_scalar()?.as_f32().abs())),
                 _ => Err(unsupported(object, method)),
-            }?;
-            result.restore_legacy_builtin_result()
+            }
         }
         CallRoute::EnumAsInteger => {
             validate_object_arity(object, method, args.len())?;
@@ -166,29 +152,14 @@ pub fn dispatch(
         CallRoute::Timer => {
             validate_object_arity(object, method, args.len())?;
             let object_key = timer_object_key(object, ctx);
-            let legacy_args = legacy_builtin_arguments(args);
-            match stateful::timer(method, &legacy_args, object_key, ctx)? {
-                Some(value) => value.restore_legacy_builtin_result(),
+            match stateful::timer(method, args, object_key, ctx)? {
+                Some(value) => Ok(value),
                 None => Err(unsupported(object, method)),
             }
         }
-        CallRoute::ProjectIo => {
-            let legacy_args = legacy_builtin_arguments(args);
-            io_stub::project_object_call(object, method, &legacy_args, ctx)?
-                .restore_legacy_builtin_result()
-        }
+        CallRoute::ProjectIo => io_stub::project_object_call(object, method, args, ctx),
         CallRoute::Unsupported => Err(unsupported(object, method)),
     }
-}
-
-/// Widen M1 scalar arguments for builtin engines that have not migrated yet.
-/// Core expressions, Calculate, Convert, tables, project writes, and user
-/// functions do not use this compatibility path.
-fn legacy_builtin_arguments(args: &[Value]) -> Vec<Value> {
-    args.iter()
-        .cloned()
-        .map(Value::into_legacy_builtin_argument)
-        .collect()
 }
 
 /// Dispatch a bare user-function call such as `Update(...)`. Bare callees cannot
@@ -1167,7 +1138,7 @@ mod tests {
             h.call(
                 "Debounce",
                 "Filter",
-                &[Value::Bool(true), Value::Float(0.1)]
+                &[Value::Bool(true), Value::m1_float(0.1)]
             )
             .unwrap(),
             Value::Bool(true)
@@ -1356,7 +1327,7 @@ mod tests {
     #[test]
     fn set_on_a_table_is_unsupported() {
         let mut h = Harness::new();
-        match h.call("Map", "Set", &[Value::Int(1)]) {
+        match h.call("Map", "Set", &[Value::m1_integer(1)]) {
             Err(EvalError::UnsupportedBuiltin { object, method }) => {
                 assert_eq!(object, "Map");
                 assert_eq!(method, "Set");
@@ -2098,8 +2069,9 @@ mod tests {
         let remaining = h
             .call("Startup Delay", "Remaining", &[])
             .unwrap()
-            .as_f64()
-            .unwrap();
+            .m1_scalar()
+            .unwrap()
+            .as_f64();
         assert!((remaining - 0.02).abs() < 1e-7);
         match h.call("Precharge State", "Start", &[Value::m1_float(0.03)]) {
             Err(EvalError::UnsupportedBuiltin { .. }) => {}

--- a/src/builtins/stateful.rs
+++ b/src/builtins/stateful.rs
@@ -59,6 +59,26 @@ pub fn call(
     }
 }
 
+/// Read a script numeric operand in the binary32 family used by stateful math.
+fn numeric_f32(value: &Value) -> Result<f32, EvalError> {
+    Ok(value.m1_scalar()?.as_f32())
+}
+
+/// Read a numeric operand as seconds. Timing state uses the scheduler's host
+/// precision, but the script value crosses this boundary only after binary32
+/// conversion.
+fn seconds(value: &Value) -> Result<f64, EvalError> {
+    Ok(f64::from(numeric_f32(value)?))
+}
+
+fn advance_time(current: f64, dt: f64) -> f64 {
+    current + dt
+}
+
+fn reduce_time(current: f64, dt: f64) -> f64 {
+    (current - dt).max(0.0)
+}
+
 /// Evaluate a `Timer` object method (`Start`/`Stop`/`Reset`/`Remaining`).
 /// Returns `Ok(None)` for a non-Timer method so the caller fails loud.
 ///
@@ -92,7 +112,7 @@ pub fn timer(
     let result = match method {
         "Start" => {
             // Start (or restart) counting down from `period`.
-            remaining = args[0].as_f64()?.max(0.0);
+            remaining = seconds(&args[0])?.max(0.0);
             running = true;
             Value::Bool(true) // Void in M1; we return a benign value.
         }
@@ -108,12 +128,12 @@ pub fn timer(
         "Remaining" => {
             // Advance the countdown one tick on read, clamped at zero.
             if running {
-                remaining = (remaining - dt).max(0.0);
+                remaining = reduce_time(remaining, dt);
                 if remaining == 0.0 {
                     running = false;
                 }
             }
-            Value::Float(remaining)
+            Value::m1_float(remaining as f32)
         }
         _ => unreachable!("guarded above"),
     };
@@ -124,7 +144,7 @@ pub fn timer(
 /// The blend factor `a0 = dt / (tc + dt)` for a first-order filter with time
 /// constant `tc`. Clamped to `[0, 1]`: a non-positive `tc` makes the output
 /// follow the input (`a0 = 1`); a huge `tc` makes `a0 -> 0` (maximum smoothing).
-fn first_order_alpha(tc: f64, dt: f64) -> f64 {
+fn first_order_alpha(tc: f32, dt: f32) -> f32 {
     let denom = tc + dt;
     if denom <= 0.0 {
         return 1.0;
@@ -152,13 +172,13 @@ fn filter(
 /// the module header. Seeds to the first input; `reset` reloads the state to the
 /// current input.
 fn first_order(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let tc = args[1].as_f64()?;
+    let x = numeric_f32(&args[0])?;
+    let tc = numeric_f32(&args[1])?;
     let reset = match args.get(2) {
         Some(v) => v.as_bool()?,
         None => false,
     };
-    let dt = ctx.dt;
+    let dt = ctx.dt as f32;
     let a0 = first_order_alpha(tc, dt);
 
     let slot = ctx.state.entry(site);
@@ -172,7 +192,7 @@ fn first_order(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Valu
         _ => x,
     };
     *slot = OpState::Filter { y };
-    Ok(Value::Float(y))
+    Ok(Value::m1_float(y))
 }
 
 /// `Filter.Maximum`/`Minimum`(x, tc [, reset]). `want_max` selects the decaying
@@ -185,13 +205,13 @@ fn extremum(
     ctx: &mut EvalCtx,
     want_max: bool,
 ) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let tc = args[1].as_f64()?;
+    let x = numeric_f32(&args[0])?;
+    let tc = numeric_f32(&args[1])?;
     let reset = match args.get(2) {
         Some(v) => v.as_bool()?,
         None => false,
     };
-    let a0 = first_order_alpha(tc, ctx.dt);
+    let a0 = first_order_alpha(tc, ctx.dt as f32);
 
     let slot = ctx.state.entry(site);
     let prev = match slot {
@@ -214,7 +234,7 @@ fn extremum(
         }
     };
     *slot = OpState::Filter { y };
-    Ok(Value::Float(y))
+    Ok(Value::m1_float(y))
 }
 
 // ---- Integral family --------------------------------------------------------
@@ -248,12 +268,12 @@ fn integral(
 /// `Integral.Normal(x, min, max, reset, preset)` — trapezoidal accumulation,
 /// clamped to `[min, max]`, with `reset` reloading the clamped `preset`.
 fn integral_normal(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let min = args[1].as_f64()?;
-    let max = args[2].as_f64()?;
+    let x = numeric_f32(&args[0])?;
+    let min = numeric_f32(&args[1])?;
+    let max = numeric_f32(&args[2])?;
     let reset = args[3].as_bool()?;
-    let preset = args[4].as_f64()?;
-    let dt = ctx.dt;
+    let preset = numeric_f32(&args[4])?;
+    let dt = ctx.dt as f32;
 
     let slot = ctx.state.entry(site);
     let prev = match slot {
@@ -272,11 +292,11 @@ fn integral_normal(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<
         }
     };
     *slot = OpState::Integral { acc, prev_x };
-    Ok(Value::Float(acc))
+    Ok(Value::m1_float(acc))
 }
 
 /// Clamp `v` into `[lo, hi]`. A reversed range (`lo > hi`) collapses to `hi`.
-fn clamp(v: f64, lo: f64, hi: f64) -> f64 {
+fn clamp(v: f32, lo: f32, hi: f32) -> f32 {
     v.max(lo).min(hi)
 }
 
@@ -300,7 +320,7 @@ fn clamp(v: f64, lo: f64, hi: f64) -> f64 {
 
 /// The fixed time constant (seconds) for `Derivative.Filtered`'s internal
 /// smoother. A documented Phase-1 assumption pending M1 Sim validation.
-const FILTERED_DERIVATIVE_TC: f64 = 0.1;
+const FILTERED_DERIVATIVE_TC: f32 = 0.1;
 
 /// Dispatch the `Derivative.*` family.
 fn derivative(
@@ -325,8 +345,8 @@ fn derivative_normal(
     ctx: &mut EvalCtx,
     filtered: bool,
 ) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let dt = ctx.dt;
+    let x = numeric_f32(&args[0])?;
+    let dt = ctx.dt as f32;
     let slot = ctx.state.entry(site);
     let prev = match slot {
         OpState::Derivative { prev_x, prev_d } => Some((*prev_x, *prev_d)),
@@ -351,7 +371,7 @@ fn derivative_normal(
         prev_x: x,
         prev_d: prev_d_out,
     };
-    Ok(Value::Float(d))
+    Ok(Value::m1_float(d))
 }
 
 /// `Derivative.Adaptive(x, delta, max_dt)` — recompute the slope only when the
@@ -362,9 +382,9 @@ fn derivative_adaptive(
     site: CallSite,
     ctx: &mut EvalCtx,
 ) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let delta = args[1].as_f64()?;
-    let max_dt = args[2].as_f64()?;
+    let x = numeric_f32(&args[0])?;
+    let delta = numeric_f32(&args[1])?;
+    let max_dt = seconds(&args[2])?;
     let dt = ctx.dt;
     let slot = ctx.state.entry(site);
 
@@ -381,13 +401,13 @@ fn derivative_adaptive(
         // First tick: seed the reference input, no slope yet.
         None => (0.0, x, 0.0),
         Some((last_x, prev_d, elapsed)) => {
-            let elapsed = elapsed + dt;
+            let elapsed = advance_time(elapsed, dt);
             let moved_enough = (x - last_x).abs() >= delta.abs();
             let timed_out = max_dt > 0.0 && elapsed >= max_dt;
             if moved_enough || timed_out {
                 // Accept an update: slope over the actual elapsed interval.
                 let d = if elapsed > 0.0 {
-                    (x - last_x) / elapsed
+                    (x - last_x) / elapsed as f32
                 } else {
                     prev_d
                 };
@@ -403,7 +423,7 @@ fn derivative_adaptive(
         prev_d: d,
         elapsed,
     };
-    Ok(Value::Float(d))
+    Ok(Value::m1_float(d))
 }
 
 // ---- Delay family -----------------------------------------------------------
@@ -444,7 +464,7 @@ fn edge_delay(
     rising: bool,
 ) -> Result<Value, EvalError> {
     let cond = args[0].as_bool()?;
-    let delay = args[1].as_f64()?;
+    let delay = seconds(&args[1])?;
     let dt = ctx.dt;
     let slot = ctx.state.entry(site);
     let prev = match slot {
@@ -462,7 +482,7 @@ fn edge_delay(
         Some((output, held)) => {
             if cond == delayed_value {
                 // Building toward the delayed edge: accumulate, switch when ripe.
-                let held = held + dt;
+                let held = advance_time(held, dt);
                 let output = if held >= delay { delayed_value } else { output };
                 (output, held)
             } else {
@@ -485,10 +505,10 @@ fn edge_delay(
 /// no `delta` the argument must be exactly unchanged. Uses the `ChangeBy` slot to
 /// hold the reference value and the held time.
 fn delay_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let delay = args[1].as_f64()?;
+    let x = numeric_f32(&args[0])?;
+    let delay = seconds(&args[1])?;
     let delta = match args.get(2) {
-        Some(v) => v.as_f64()?.abs(),
+        Some(v) => numeric_f32(v)?.abs(),
         None => 0.0,
     };
     let dt = ctx.dt;
@@ -509,7 +529,7 @@ fn delay_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Val
                 // Moved beyond tolerance: restart timing from the new value.
                 (x, 0.0, false)
             } else {
-                let held = held + dt;
+                let held = advance_time(held, dt);
                 (reference, held, held >= delay)
             }
         }
@@ -551,7 +571,7 @@ fn debounce(
 /// output holds its last committed value until the new value is confirmed.
 fn debounce_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
     let cond = args[0].as_bool()?;
-    let filter = args[1].as_f64()?;
+    let filter = seconds(&args[1])?;
     let dt = ctx.dt;
     let slot = ctx.state.entry(site);
     let prev = match slot {
@@ -570,7 +590,7 @@ fn debounce_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<
                 // New candidate: restart timing from this tick.
                 (output, cond, 0.0)
             } else {
-                let held = held + dt;
+                let held = advance_time(held, dt);
                 // Once the candidate has been stable long enough, commit it.
                 let output = if held >= filter { cond } else { output };
                 (output, candidate, held)
@@ -587,17 +607,16 @@ fn debounce_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<
 
 /// The filtered debounce: low-pass the 0/1 condition with time constant
 /// `response`, then a 0.2/0.8 Schmitt trigger. The filtered level lives in the
-/// `Filter` slot's `y`; the committed boolean lives in `Timed::output` — but we
-/// only have one slot per site, so we pack the filtered level into `held` and the
-/// output into `output` of a `Timed` state (candidate unused).
+/// `DebounceFilter` slot's binary32 `level`; the same slot stores the committed
+/// boolean output.
 fn debounce_filter(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
     let cond = args[0].as_bool()?;
-    let response = args[1].as_f64()?;
-    let a0 = first_order_alpha(response, ctx.dt);
+    let response = numeric_f32(&args[1])?;
+    let a0 = first_order_alpha(response, ctx.dt as f32);
     let target = if cond { 1.0 } else { 0.0 };
     let slot = ctx.state.entry(site);
     let (prev_level, prev_out) = match slot {
-        OpState::Timed { output, held, .. } => (*held, *output),
+        OpState::DebounceFilter { output, level } => (*level, *output),
         _ => (target, cond), // seed the filter to the first input
     };
     let level = a0 * target + (1.0 - a0) * prev_level;
@@ -609,11 +628,7 @@ fn debounce_filter(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<
     } else {
         prev_out
     };
-    *slot = OpState::Timed {
-        output,
-        candidate: cond,
-        held: level,
-    };
+    *slot = OpState::DebounceFilter { output, level };
     Ok(Value::Bool(output))
 }
 
@@ -676,10 +691,10 @@ fn change_by(
     ctx: &mut EvalCtx,
     dir: ChangeDir,
 ) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let delta = args[1].as_f64()?.abs();
+    let x = numeric_f32(&args[0])?;
+    let delta = numeric_f32(&args[1])?.abs();
     let filter = match args.get(2) {
-        Some(v) => Some(v.as_f64()?),
+        Some(v) => Some(seconds(v)?),
         None => None,
     };
     let dt = ctx.dt;
@@ -693,7 +708,7 @@ fn change_by(
         _ => None,
     };
 
-    let qualifies = |from: f64, to: f64| -> bool {
+    let qualifies = |from: f32, to: f32| -> bool {
         match dir {
             ChangeDir::By => (to - from).abs() >= delta,
             ChangeDir::Up => to - from >= delta,
@@ -711,7 +726,7 @@ fn change_by(
                 Some(filter) => {
                     if qualifies(prev_x, x) {
                         // The change condition holds this tick; time it.
-                        let held = held + dt;
+                        let held = advance_time(held, dt);
                         if !pending && held >= filter {
                             // Emit a single pulse and mark armed-spent.
                             (true, prev_x, held, true)
@@ -745,7 +760,7 @@ fn change_edge(
 ) -> Result<Value, EvalError> {
     let cond = args[0].as_bool()?;
     let filter = match args.get(1) {
-        Some(v) => Some(v.as_f64()?),
+        Some(v) => Some(seconds(v)?),
         None => None,
     };
     let dt = ctx.dt;
@@ -779,7 +794,7 @@ fn change_edge(
                         (false, cond, dt)
                     } else if held > 0.0 && cond == prev {
                         // Level held since the edge: accumulate; pulse once ripe.
-                        let held = held + dt;
+                        let held = advance_time(held, dt);
                         if held >= filter {
                             (true, cond, 0.0) // pulse, then disarm
                         } else {
@@ -831,8 +846,8 @@ fn calculate_stateful(
 /// `Calculate.Stable(x, filter)` — true once `x` has been exactly unchanged for
 /// `>= filter` seconds; any change restarts the timer (output false meanwhile).
 fn calc_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let filter = args[1].as_f64()?;
+    let x = numeric_f32(&args[0])?;
+    let filter = seconds(&args[1])?;
     let dt = ctx.dt;
     let slot = ctx.state.entry(site);
     let prev = match slot {
@@ -845,7 +860,7 @@ fn calc_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Valu
             if x != reference {
                 (x, 0.0, false)
             } else {
-                let held = held + dt;
+                let held = advance_time(held, dt);
                 (reference, held, held >= filter)
             }
         }
@@ -867,10 +882,10 @@ fn calc_between(
     ctx: &mut EvalCtx,
     beyond: bool,
 ) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let min = args[1].as_f64()?;
-    let max = args[2].as_f64()?;
-    let filter = args[3].as_f64()?;
+    let x = numeric_f32(&args[0])?;
+    let min = numeric_f32(&args[1])?;
+    let max = numeric_f32(&args[2])?;
+    let filter = seconds(&args[3])?;
     let dt = ctx.dt;
     let in_range = x >= min && x <= max;
     let cond = if beyond { !in_range } else { in_range };
@@ -882,10 +897,10 @@ fn calc_between(
 /// for `>= filter`; holds its state in the dead band. The held-state output and
 /// the timed candidate share the `Timed` slot.
 fn calc_hysteresis(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let x = args[0].as_f64()?;
-    let low = args[1].as_f64()?;
-    let high = args[2].as_f64()?;
-    let filter = args[3].as_f64()?;
+    let x = numeric_f32(&args[0])?;
+    let low = numeric_f32(&args[1])?;
+    let high = numeric_f32(&args[2])?;
+    let filter = seconds(&args[3])?;
     let dt = ctx.dt;
     // Candidate target: above-high wants true, below-low wants false, else hold.
     let want = if x >= high {
@@ -913,7 +928,7 @@ fn calc_hysteresis(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<
                 (target, 0.0)
             } else if target == candidate {
                 // Continuing to push toward the new state: accumulate.
-                let held = held + dt;
+                let held = advance_time(held, dt);
                 if held >= filter {
                     output = target;
                 }
@@ -948,11 +963,11 @@ fn timed_predicate(cond: bool, filter: f64, dt: f64, ctx: &mut EvalCtx, site: Ca
         // satisfied long enough (it just started, so false).
         (false, cond, 0.0)
     } else if cond {
-        let held = held + dt;
+        let held = advance_time(held, dt);
         (held >= filter, cond, held)
     } else {
         // cond false and stable: output false.
-        (false, cond, held + dt)
+        (false, cond, advance_time(held, dt))
     };
     *slot = OpState::Timed {
         output,
@@ -1024,41 +1039,49 @@ mod tests {
     }
 
     fn approx(a: f64, b: f64) {
-        assert!((a - b).abs() < 1e-9, "expected {b}, got {a}");
+        assert!((a - b).abs() < 1e-6, "expected {b}, got {a}");
+    }
+
+    fn n(value: f64) -> Value {
+        Value::m1_float(value as f32)
     }
 
     #[test]
     fn first_order_step_response_matches_hand_derivation() {
         // dt = 0.1, tc = 0.1  =>  a0 = 0.1 / (0.1 + 0.1) = 0.5.
         let mut h = Harness::new(0.1);
-        let tc = Value::Float(0.1);
+        let tc = n(0.1);
 
         // Tick 1: seeds to the first input (0.0). No transient.
         approx(
-            h.tick("Filter", "FirstOrder", &[Value::Float(0.0), tc.clone()])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "FirstOrder", &[n(0.0), tc.clone()])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             0.0,
         );
         // Step the input to 1.0. y = 0.5*1 + 0.5*0 = 0.5.
         approx(
-            h.tick("Filter", "FirstOrder", &[Value::Float(1.0), tc.clone()])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "FirstOrder", &[n(1.0), tc.clone()])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             0.5,
         );
         // Hold at 1.0. y = 0.5*1 + 0.5*0.5 = 0.75.
         approx(
-            h.tick("Filter", "FirstOrder", &[Value::Float(1.0), tc.clone()])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "FirstOrder", &[n(1.0), tc.clone()])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             0.75,
         );
         // Hold. y = 0.5*1 + 0.5*0.75 = 0.875.
         approx(
-            h.tick("Filter", "FirstOrder", &[Value::Float(1.0), tc])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "FirstOrder", &[n(1.0), tc])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             0.875,
         );
     }
@@ -1067,27 +1090,24 @@ mod tests {
     fn first_order_reset_reloads_to_current_input() {
         // a0 = 0.5 again.
         let mut h = Harness::new(0.1);
-        let tc = Value::Float(0.1);
+        let tc = n(0.1);
         h.tick(
             "Filter",
             "FirstOrder",
-            &[Value::Float(0.0), tc.clone(), Value::Bool(false)],
+            &[n(0.0), tc.clone(), Value::Bool(false)],
         );
         // Build up some state.
         h.tick(
             "Filter",
             "FirstOrder",
-            &[Value::Float(10.0), tc.clone(), Value::Bool(false)],
+            &[n(10.0), tc.clone(), Value::Bool(false)],
         );
         // Reset true: output snaps to the current input regardless of history.
         approx(
-            h.tick(
-                "Filter",
-                "FirstOrder",
-                &[Value::Float(3.0), tc, Value::Bool(true)],
-            )
-            .as_f64()
-            .unwrap(),
+            h.tick("Filter", "FirstOrder", &[n(3.0), tc, Value::Bool(true)])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             3.0,
         );
     }
@@ -1096,33 +1116,37 @@ mod tests {
     fn filter_maximum_instant_rise_filtered_fall() {
         // a0 = 0.5.
         let mut h = Harness::new(0.1);
-        let tc = Value::Float(0.1);
+        let tc = n(0.1);
         // Seed at 0.
         approx(
-            h.tick("Filter", "Maximum", &[Value::Float(0.0), tc.clone()])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "Maximum", &[n(0.0), tc.clone()])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             0.0,
         );
         // Rise to 5: instant attack -> 5.
         approx(
-            h.tick("Filter", "Maximum", &[Value::Float(5.0), tc.clone()])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "Maximum", &[n(5.0), tc.clone()])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             5.0,
         );
         // Drop to 1: filtered fall -> 0.5*1 + 0.5*5 = 3.0.
         approx(
-            h.tick("Filter", "Maximum", &[Value::Float(1.0), tc.clone()])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "Maximum", &[n(1.0), tc.clone()])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             3.0,
         );
         // A new higher value 4 < 3.0? No, 4 >= 3.0 -> instant -> 4.
         approx(
-            h.tick("Filter", "Maximum", &[Value::Float(4.0), tc])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "Maximum", &[n(4.0), tc])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             4.0,
         );
     }
@@ -1130,25 +1154,28 @@ mod tests {
     #[test]
     fn filter_minimum_instant_fall_filtered_rise() {
         let mut h = Harness::new(0.1);
-        let tc = Value::Float(0.1);
+        let tc = n(0.1);
         approx(
-            h.tick("Filter", "Minimum", &[Value::Float(10.0), tc.clone()])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "Minimum", &[n(10.0), tc.clone()])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             10.0,
         );
         // Drop to 2: instant attack downward -> 2.
         approx(
-            h.tick("Filter", "Minimum", &[Value::Float(2.0), tc.clone()])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "Minimum", &[n(2.0), tc.clone()])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             2.0,
         );
         // Rise to 6: filtered rise -> 0.5*6 + 0.5*2 = 4.0.
         approx(
-            h.tick("Filter", "Minimum", &[Value::Float(6.0), tc])
-                .as_f64()
-                .unwrap(),
+            h.tick("Filter", "Minimum", &[n(6.0), tc])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             4.0,
         );
     }
@@ -1156,7 +1183,7 @@ mod tests {
     #[test]
     fn distinct_call_sites_keep_independent_state() {
         let mut h = Harness::new(0.1);
-        let tc = Value::Float(0.1);
+        let tc = n(0.1);
         // Two different sites driven through the store directly.
         let site_a = CallSite::new("Demo.Update.m1scr", 0);
         let site_b = CallSite::new("Demo.Update.m1scr", 50);
@@ -1179,13 +1206,13 @@ mod tests {
             let v = call(
                 "Filter",
                 "FirstOrder",
-                &[Value::Float(seed), tc.clone()],
+                &[n(seed), tc.clone()],
                 site,
                 &mut ctx,
             )
             .unwrap()
             .unwrap();
-            approx(v.as_f64().unwrap(), seed);
+            approx(v.m1_scalar().unwrap().as_f64(), seed);
         }
         // Two independent slots.
         assert_eq!(h.state.0.len(), 2);
@@ -1223,16 +1250,11 @@ mod tests {
         h.tick(
             "Integral",
             "Normal",
-            &[
-                Value::Float(x),
-                Value::Float(min),
-                Value::Float(max),
-                Value::Bool(reset),
-                Value::Float(preset),
-            ],
+            &[n(x), n(min), n(max), Value::Bool(reset), n(preset)],
         )
-        .as_f64()
+        .m1_scalar()
         .unwrap()
+        .as_f64()
     }
 
     #[test]
@@ -1273,7 +1295,10 @@ mod tests {
     // ---- Task 17: Derivative.* ----
 
     fn deriv(h: &mut Harness, method: &str, args: &[Value]) -> f64 {
-        h.tick("Derivative", method, args).as_f64().unwrap()
+        h.tick("Derivative", method, args)
+            .m1_scalar()
+            .unwrap()
+            .as_f64()
     }
 
     #[test]
@@ -1281,13 +1306,13 @@ mod tests {
         // dt = 0.1.
         let mut h = Harness::new(0.1);
         // First tick: 0 (no slope yet), seeds prev = 1.0.
-        approx(deriv(&mut h, "Normal", &[Value::Float(1.0)]), 0.0);
+        approx(deriv(&mut h, "Normal", &[n(1.0)]), 0.0);
         // (3 - 1)/0.1 = 20.
-        approx(deriv(&mut h, "Normal", &[Value::Float(3.0)]), 20.0);
+        approx(deriv(&mut h, "Normal", &[n(3.0)]), 20.0);
         // (3 - 3)/0.1 = 0.
-        approx(deriv(&mut h, "Normal", &[Value::Float(3.0)]), 0.0);
+        approx(deriv(&mut h, "Normal", &[n(3.0)]), 0.0);
         // (2.5 - 3)/0.1 = -5.
-        approx(deriv(&mut h, "Normal", &[Value::Float(2.5)]), -5.0);
+        approx(deriv(&mut h, "Normal", &[n(2.5)]), -5.0);
     }
 
     #[test]
@@ -1295,18 +1320,18 @@ mod tests {
         // dt = 0.1, fixed tc = 0.1 -> a0 = 0.5 in the internal smoother.
         let mut h = Harness::new(0.1);
         // First tick: 0 (seed).
-        approx(deriv(&mut h, "Filtered", &[Value::Float(0.0)]), 0.0);
+        approx(deriv(&mut h, "Filtered", &[n(0.0)]), 0.0);
         // raw = (1 - 0)/0.1 = 10; d = 0.5*10 + 0.5*0 = 5.0.
-        approx(deriv(&mut h, "Filtered", &[Value::Float(1.0)]), 5.0);
+        approx(deriv(&mut h, "Filtered", &[n(1.0)]), 5.0);
         // raw = (2 - 1)/0.1 = 10; d = 0.5*10 + 0.5*5 = 7.5.
-        approx(deriv(&mut h, "Filtered", &[Value::Float(2.0)]), 7.5);
+        approx(deriv(&mut h, "Filtered", &[n(2.0)]), 7.5);
     }
 
     #[test]
     fn derivative_adaptive_holds_until_delta_or_timeout() {
         // dt = 0.1, delta = 1.0, max_dt = 0.5.
         let mut h = Harness::new(0.1);
-        let args = |x: f64| [Value::Float(x), Value::Float(1.0), Value::Float(0.5)];
+        let args = |x: f64| [n(x), n(1.0), n(0.5)];
         // First tick: seed at 0.0, output 0.
         approx(deriv(&mut h, "Adaptive", &args(0.0)), 0.0);
         // Move +0.3 (< delta 1.0) and elapsed 0.1 (< 0.5): hold previous (0).
@@ -1330,37 +1355,39 @@ mod tests {
     }
 
     fn delay_rising(h: &mut Harness, cond: bool, delay: f64) -> bool {
-        h.tick("Delay", "Rising", &[b(cond), Value::Float(delay)])
+        h.tick("Delay", "Rising", &[b(cond), n(delay)])
             .as_bool()
             .unwrap()
     }
 
     fn delay_falling(h: &mut Harness, cond: bool, delay: f64) -> bool {
-        h.tick("Delay", "Falling", &[b(cond), Value::Float(delay)])
+        h.tick("Delay", "Falling", &[b(cond), n(delay)])
             .as_bool()
             .unwrap()
     }
 
     #[test]
     fn delay_rising_delays_only_the_rising_edge() {
-        // dt = 0.1, delay = 0.3. Output goes true after cond held true 0.3 s,
-        // and drops immediately on falling.
+        // The M1 0.3f threshold widens slightly above three exact 0.1 s
+        // scheduler ticks, so the fourth held tick commits the edge.
         let mut h = Harness::new(0.1);
         assert!(!delay_rising(&mut h, true, 0.3)); // T1 seed: false
         assert!(!delay_rising(&mut h, true, 0.3)); // held 0.1
         assert!(!delay_rising(&mut h, true, 0.3)); // held 0.2
-        assert!(delay_rising(&mut h, true, 0.3)); //  held 0.3 -> true
+        assert!(!delay_rising(&mut h, true, 0.3)); // held 0.3 < widened threshold
+        assert!(delay_rising(&mut h, true, 0.3)); //  held 0.4 -> true
         assert!(!delay_rising(&mut h, false, 0.3)); // immediate fall
         assert!(!delay_rising(&mut h, true, 0.3)); // re-arming, held 0.1
     }
 
     #[test]
     fn delay_falling_delays_only_the_falling_edge() {
-        // dt = 0.1, delay = 0.2.
+        // The M1 0.2f threshold is slightly above two exact 0.1 s ticks.
         let mut h = Harness::new(0.1);
         assert!(delay_falling(&mut h, true, 0.2)); // T1 seed: true (default high)
         assert!(delay_falling(&mut h, false, 0.2)); // held-false 0.1, still true
-        assert!(!delay_falling(&mut h, false, 0.2)); // held 0.2 -> false
+        assert!(delay_falling(&mut h, false, 0.2)); // held 0.2 < widened threshold
+        assert!(!delay_falling(&mut h, false, 0.2)); // held 0.3 -> false
         assert!(!delay_falling(&mut h, false, 0.2)); // stays false
         assert!(delay_falling(&mut h, true, 0.2)); //  immediate rise
     }
@@ -1369,17 +1396,18 @@ mod tests {
 
     #[test]
     fn debounce_stable_commits_after_filter_time() {
-        // dt = 0.1, filter = 0.2.
+        // The binary32 filter threshold is slightly above 0.2 exact seconds.
         let mut h = Harness::new(0.1);
         let d = |h: &mut Harness, c: bool| {
-            h.tick("Debounce", "Stable", &[b(c), Value::Float(0.2)])
+            h.tick("Debounce", "Stable", &[b(c), n(0.2)])
                 .as_bool()
                 .unwrap()
         };
         assert!(!d(&mut h, false)); // seed output false
         assert!(!d(&mut h, true)); //  new candidate true, held 0
         assert!(!d(&mut h, true)); //  held 0.1
-        assert!(d(&mut h, true)); //   held 0.2 -> commit true
+        assert!(!d(&mut h, true)); //  held 0.2 < widened threshold
+        assert!(d(&mut h, true)); //   held 0.3 -> commit true
         assert!(d(&mut h, false)); //  new candidate false, output holds true
     }
 
@@ -1389,7 +1417,7 @@ mod tests {
         // Seeded to the first input (false -> level 0).
         let mut h = Harness::new(0.1);
         let d = |h: &mut Harness, c: bool| {
-            h.tick("Debounce", "Filter", &[b(c), Value::Float(0.1)])
+            h.tick("Debounce", "Filter", &[b(c), n(0.1)])
                 .as_bool()
                 .unwrap()
         };
@@ -1439,11 +1467,8 @@ mod tests {
     #[test]
     fn change_by_pulses_on_magnitude_change() {
         let mut h = Harness::new(0.1);
-        let c = |h: &mut Harness, x: f64| {
-            h.tick("Change", "By", &[Value::Float(x), Value::Float(5.0)])
-                .as_bool()
-                .unwrap()
-        };
+        let c =
+            |h: &mut Harness, x: f64| h.tick("Change", "By", &[n(x), n(5.0)]).as_bool().unwrap();
         assert!(!c(&mut h, 0.0)); // seed
         assert!(!c(&mut h, 2.0)); // delta 2 < 5
         assert!(c(&mut h, 8.0)); //  delta 6 >= 5
@@ -1454,22 +1479,16 @@ mod tests {
     #[test]
     fn change_up_and_down_are_directional() {
         let mut h = Harness::new(0.1);
-        let up = |h: &mut Harness, x: f64| {
-            h.tick("Change", "Up", &[Value::Float(x), Value::Float(5.0)])
-                .as_bool()
-                .unwrap()
-        };
+        let up =
+            |h: &mut Harness, x: f64| h.tick("Change", "Up", &[n(x), n(5.0)]).as_bool().unwrap();
         assert!(!up(&mut h, 0.0)); // seed
         assert!(!up(&mut h, 2.0)); // +2 < 5
         assert!(up(&mut h, 8.0)); //  +6 >= 5
         assert!(!up(&mut h, 1.0)); // went down: not an Up
 
         let mut h2 = Harness::new(0.1);
-        let down = |h: &mut Harness, x: f64| {
-            h.tick("Change", "Down", &[Value::Float(x), Value::Float(5.0)])
-                .as_bool()
-                .unwrap()
-        };
+        let down =
+            |h: &mut Harness, x: f64| h.tick("Change", "Down", &[n(x), n(5.0)]).as_bool().unwrap();
         assert!(!down(&mut h2, 10.0)); // seed
         assert!(down(&mut h2, 3.0)); //  -7 >= 5
         assert!(!down(&mut h2, 8.0)); // went up: not a Down
@@ -1477,22 +1496,18 @@ mod tests {
 
     #[test]
     fn change_by_filtered_requires_sustained_change() {
-        // dt = 0.1, filter = 0.2: the change condition must hold 0.2 s, then one
-        // pulse.
+        // The binary32 filter threshold is slightly above 0.2 exact seconds.
         let mut h = Harness::new(0.1);
         let c = |h: &mut Harness, x: f64| {
-            h.tick(
-                "Change",
-                "By",
-                &[Value::Float(x), Value::Float(5.0), Value::Float(0.2)],
-            )
-            .as_bool()
-            .unwrap()
+            h.tick("Change", "By", &[n(x), n(5.0), n(0.2)])
+                .as_bool()
+                .unwrap()
         };
         assert!(!c(&mut h, 0.0)); // seed (reference = 0)
         // Jump to 9 (delta 9 >= 5). It stays >= delta vs the held reference 0.
         assert!(!c(&mut h, 9.0)); // held 0.1 (< 0.2)
-        assert!(c(&mut h, 9.0)); //  held 0.2 -> single pulse
+        assert!(!c(&mut h, 9.0)); // held 0.2 < widened threshold
+        assert!(c(&mut h, 9.0)); //  held 0.3 -> single pulse
         assert!(!c(&mut h, 9.0)); // already pulsed (armed-spent)
         assert!(!c(&mut h, 9.0)); // still spent
     }
@@ -1522,11 +1537,59 @@ mod tests {
             timer(method, args, key.clone(), &mut ctx).unwrap().unwrap()
         };
         // Start counting down from 0.25.
-        run(&mut h, "Start", &[Value::Float(0.25)]);
-        approx(run(&mut h, "Remaining", &[]).as_f64().unwrap(), 0.15);
-        approx(run(&mut h, "Remaining", &[]).as_f64().unwrap(), 0.05);
-        approx(run(&mut h, "Remaining", &[]).as_f64().unwrap(), 0.0); // clamps
-        approx(run(&mut h, "Remaining", &[]).as_f64().unwrap(), 0.0); // stays
+        run(&mut h, "Start", &[n(0.25)]);
+        approx(
+            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
+            0.15,
+        );
+        approx(
+            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
+            0.05,
+        );
+        approx(
+            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
+            0.0,
+        ); // clamps
+        approx(
+            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
+            0.0,
+        ); // stays
+    }
+
+    #[test]
+    fn timer_progresses_when_dt_is_smaller_than_a_binary32_ulp() {
+        let mut h = Harness::new(0.01);
+        let key = CallSite::new("Root.Demo.LargeTimer", 0);
+        let run = |h: &mut Harness, method: &str, args: &[Value]| -> Value {
+            let mut ctx = EvalCtx {
+                project: &h.project,
+                calib: &h.calib,
+                env: &mut h.env,
+                state: &mut h.state,
+                group: Some("Root.Demo"),
+                fn_symbol: Some("Root.Demo.Update"),
+                script_name: "Demo.Update.m1scr",
+                dt: h.dt,
+                scripts: &[],
+                signature_m1_types: None,
+                object_rules: None,
+                depth: 0,
+                trace: None,
+            };
+            timer(method, args, key.clone(), &mut ctx).unwrap().unwrap()
+        };
+
+        let initial = f64::from(1_000_000_000_f32);
+        run(&mut h, "Start", &[n(initial)]);
+        run(&mut h, "Remaining", &[]);
+        match h.state.0.get(&key) {
+            Some(OpState::Timer { remaining, running }) => {
+                assert!(*running);
+                assert!(*remaining < initial, "large timer did not advance");
+                assert!((initial - remaining - 0.01).abs() < 1e-6);
+            }
+            other => panic!("expected running timer state, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1551,12 +1614,18 @@ mod tests {
             };
             timer(method, args, key.clone(), &mut ctx).unwrap().unwrap()
         };
-        run(&mut h, "Start", &[Value::Float(1.0)]);
+        run(&mut h, "Start", &[n(1.0)]);
         run(&mut h, "Stop", &[]);
         // Stopped: reading does not decrement.
-        approx(run(&mut h, "Remaining", &[]).as_f64().unwrap(), 1.0);
+        approx(
+            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
+            1.0,
+        );
         run(&mut h, "Reset", &[]);
-        approx(run(&mut h, "Remaining", &[]).as_f64().unwrap(), 0.0);
+        approx(
+            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
+            0.0,
+        );
     }
 
     // ---- Task 18: stateful Calculate predicates ----
@@ -1565,13 +1634,14 @@ mod tests {
     fn calculate_stable_true_after_unchanged_for_filter() {
         let mut h = Harness::new(0.1);
         let s = |h: &mut Harness, x: f64| {
-            h.tick("Calculate", "Stable", &[Value::Float(x), Value::Float(0.2)])
+            h.tick("Calculate", "Stable", &[n(x), n(0.2)])
                 .as_bool()
                 .unwrap()
         };
         assert!(!s(&mut h, 5.0)); // seed
         assert!(!s(&mut h, 5.0)); // held 0.1
-        assert!(s(&mut h, 5.0)); //  held 0.2 -> stable
+        assert!(!s(&mut h, 5.0)); // held 0.2 < widened threshold
+        assert!(s(&mut h, 5.0)); //  held 0.3 -> stable
         assert!(!s(&mut h, 7.0)); // changed -> restart
     }
 
@@ -1579,42 +1649,26 @@ mod tests {
     fn calculate_between_and_beyond_are_timed() {
         let mut h = Harness::new(0.1);
         let bet = |h: &mut Harness, x: f64| {
-            h.tick(
-                "Calculate",
-                "Between",
-                &[
-                    Value::Float(x),
-                    Value::Float(0.0),
-                    Value::Float(10.0),
-                    Value::Float(0.2),
-                ],
-            )
-            .as_bool()
-            .unwrap()
+            h.tick("Calculate", "Between", &[n(x), n(0.0), n(10.0), n(0.2)])
+                .as_bool()
+                .unwrap()
         };
         assert!(!bet(&mut h, 5.0)); // in range, held 0
         assert!(!bet(&mut h, 5.0)); // held 0.1
-        assert!(bet(&mut h, 5.0)); //  held 0.2 -> true
+        assert!(!bet(&mut h, 5.0)); // held 0.2 < widened threshold
+        assert!(bet(&mut h, 5.0)); //  held 0.3 -> true
         assert!(!bet(&mut h, 50.0)); // out of range -> drops, restart
 
         let mut h2 = Harness::new(0.1);
         let bey = |h: &mut Harness, x: f64| {
-            h.tick(
-                "Calculate",
-                "Beyond",
-                &[
-                    Value::Float(x),
-                    Value::Float(0.0),
-                    Value::Float(10.0),
-                    Value::Float(0.2),
-                ],
-            )
-            .as_bool()
-            .unwrap()
+            h.tick("Calculate", "Beyond", &[n(x), n(0.0), n(10.0), n(0.2)])
+                .as_bool()
+                .unwrap()
         };
         assert!(!bey(&mut h2, 50.0)); // out of range, held 0
         assert!(!bey(&mut h2, 50.0)); // held 0.1
-        assert!(bey(&mut h2, 50.0)); //  held 0.2 -> true
+        assert!(!bey(&mut h2, 50.0)); // held 0.2 < widened threshold
+        assert!(bey(&mut h2, 50.0)); //  held 0.3 -> true
     }
 
     #[test]
@@ -1622,25 +1676,18 @@ mod tests {
         // low = 2, high = 8, filter = 0.2, dt = 0.1.
         let mut h = Harness::new(0.1);
         let hy = |h: &mut Harness, x: f64| {
-            h.tick(
-                "Calculate",
-                "Hysteresis",
-                &[
-                    Value::Float(x),
-                    Value::Float(2.0),
-                    Value::Float(8.0),
-                    Value::Float(0.2),
-                ],
-            )
-            .as_bool()
-            .unwrap()
+            h.tick("Calculate", "Hysteresis", &[n(x), n(2.0), n(8.0), n(0.2)])
+                .as_bool()
+                .unwrap()
         };
         assert!(!hy(&mut h, 0.0)); // below low, false
         assert!(!hy(&mut h, 10.0)); // above high, timing 0.1
-        assert!(hy(&mut h, 10.0)); //  timing 0.2 -> true
+        assert!(!hy(&mut h, 10.0)); // timing 0.2 < widened threshold
+        assert!(hy(&mut h, 10.0)); //  timing 0.3 -> true
         assert!(hy(&mut h, 10.0)); //  stays true
         assert!(hy(&mut h, 1.0)); //   below low, timing 0.1, holds true
-        assert!(!hy(&mut h, 1.0)); //  timing 0.2 -> false
+        assert!(hy(&mut h, 1.0)); //   timing 0.2 < widened threshold
+        assert!(!hy(&mut h, 1.0)); //  timing 0.3 -> false
         assert!(!hy(&mut h, 1.0)); //  stays false
     }
 
@@ -1652,12 +1699,9 @@ mod tests {
         // set in one function invocation is still present after leave/enter.
         let mut env = Env::new();
         env.enter_function();
-        env.set_static("Root.Demo.Update", "accum", Value::Float(2.0));
+        env.set_static("Root.Demo.Update", "accum", n(2.0));
         env.leave_function();
         env.enter_function();
-        assert_eq!(
-            env.get_static("Root.Demo.Update", "accum"),
-            Some(&Value::Float(2.0))
-        );
+        assert_eq!(env.get_static("Root.Demo.Update", "accum"), Some(&n(2.0)));
     }
 }

--- a/src/builtins/stateful.rs
+++ b/src/builtins/stateful.rs
@@ -625,7 +625,10 @@ fn edge_delay(
 fn delay_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
     let x = args[0].m1_scalar()?;
     let delay = seconds(&args[1])?;
-    let delta = args.get(2).map(Value::m1_scalar).transpose()?;
+    // The catalogue declares `delta` as FloatingPoint even when `argument` is
+    // integral. Preserve the sampled argument/reference in its exact M1 family,
+    // but apply the signature's binary32 coercion at this call boundary.
+    let delta = args.get(2).map(numeric_f32).transpose()?;
     let dt = ctx.dt;
     let slot = ctx.state.entry(site);
     let prev = match slot {
@@ -641,7 +644,10 @@ fn delay_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Val
         None => (x, 0.0, false),
         Some((reference, held, _)) => {
             let moved = match delta {
-                Some(delta) => scalar_change_cmp(reference, x, delta).1 == Some(Ordering::Greater),
+                Some(delta) => {
+                    scalar_change_cmp(reference, x, M1Scalar::FloatingPoint(delta)).1
+                        == Some(Ordering::Greater)
+                }
                 None => !scalar_equal(reference, x),
             };
             if moved {
@@ -1723,6 +1729,30 @@ mod tests {
         assert!(!stable(&mut h, i32::MAX - 2));
         assert!(stable(&mut h, i32::MAX - 1)); // exactly one raw unit: tolerated
         assert!(!stable(&mut h, i32::MAX)); // two raw units from the reference
+    }
+
+    #[test]
+    fn delay_stable_coerces_its_declared_float_delta_before_comparing() {
+        let mut h = Harness::new(0.1);
+        let stable = |h: &mut Harness, argument| {
+            h.tick(
+                "Delay",
+                "Stable",
+                &[
+                    Value::m1_integer(argument),
+                    n(0.0),
+                    Value::m1_integer(16_777_219),
+                ],
+            )
+            .as_bool()
+            .unwrap()
+        };
+
+        assert!(!stable(&mut h, 0));
+        // The signature widens delta to binary32, where 16_777_219 rounds to
+        // 16_777_220. The movement therefore equals the tolerance and remains
+        // stable even though the sampled integer reference stays exact.
+        assert!(stable(&mut h, 16_777_220));
     }
 
     // ---- Task 18: Debounce.* ----

--- a/src/builtins/stateful.rs
+++ b/src/builtins/stateful.rs
@@ -34,7 +34,9 @@
 use crate::env::{CallSite, OpState};
 use crate::error::EvalError;
 use crate::expr::EvalCtx;
-use crate::value::Value;
+use crate::value::{M1Scalar, Value};
+use m1_typecheck::types::{ValueType, numeric_join};
+use std::cmp::Ordering;
 
 /// Evaluate one stateful builtin call `object.method(args)`. Returns `Ok(None)`
 /// when `object` is not a stateful family handled here, so the dispatcher can
@@ -62,6 +64,122 @@ pub fn call(
 /// Read a script numeric operand in the binary32 family used by stateful math.
 fn numeric_f32(value: &Value) -> Result<f32, EvalError> {
     Ok(value.m1_scalar()?.as_f32())
+}
+
+fn scalar_type(value: M1Scalar) -> ValueType {
+    match value {
+        M1Scalar::Integer(_) => ValueType::Integer,
+        M1Scalar::UnsignedInteger(_) => ValueType::Unsigned,
+        M1Scalar::FloatingPoint(_) | M1Scalar::FixedPoint7dps(_) => ValueType::Float,
+    }
+}
+
+fn scalar_u32_bits(value: M1Scalar) -> u32 {
+    match value {
+        M1Scalar::Integer(value) => value as u32,
+        M1Scalar::UnsignedInteger(value) => value,
+        _ => unreachable!("numeric_join selected Unsigned for integral scalars"),
+    }
+}
+
+/// Compare two stateful numeric operands under the evaluator's M1 promotion
+/// rules. Two fixed-point values compare their raw scaled integers exactly;
+/// mixed fixed/float or integral/float pairs promote to binary32. Mixed signed
+/// and unsigned integers compare as their unsigned 32-bit patterns.
+fn scalar_cmp(left: M1Scalar, right: M1Scalar) -> Option<Ordering> {
+    if let (M1Scalar::FixedPoint7dps(left), M1Scalar::FixedPoint7dps(right)) = (left, right) {
+        return Some(left.raw().cmp(&right.raw()));
+    }
+
+    match numeric_join(scalar_type(left), scalar_type(right)) {
+        ValueType::Float => left.as_f32().partial_cmp(&right.as_f32()),
+        ValueType::Unsigned => Some(scalar_u32_bits(left).cmp(&scalar_u32_bits(right))),
+        ValueType::Integer => match (left, right) {
+            (M1Scalar::Integer(left), M1Scalar::Integer(right)) => Some(left.cmp(&right)),
+            _ => unreachable!("numeric_join selected Integer for signed scalars"),
+        },
+        _ => unreachable!("M1Scalar always has a numeric ValueType"),
+    }
+}
+
+fn scalar_equal(left: M1Scalar, right: M1Scalar) -> bool {
+    scalar_cmp(left, right) == Some(Ordering::Equal)
+}
+
+#[derive(Clone, Copy)]
+enum ScalarMagnitude {
+    Integral(u32),
+    FixedPoint7dps(u32),
+    FloatingPoint(f32),
+}
+
+fn fixed_magnitude_f32(raw_magnitude: u32) -> f32 {
+    // A fixed-point difference can span the full u32 magnitude even though one
+    // stored endpoint is i32. Widen the exact raw integer only for the scale
+    // conversion, then narrow before the M1 binary32 comparison.
+    (f64::from(raw_magnitude) / crate::value::FixedPoint7dps::SCALE as f64) as f32
+}
+
+/// Calculate `|to - from|` after applying the M1 promotion rule to that pair.
+/// Integral and same-family fixed-point differences use full-width `abs_diff`,
+/// so neither subtraction nor absolute value can overflow at an endpoint.
+fn scalar_magnitude(from: M1Scalar, to: M1Scalar) -> ScalarMagnitude {
+    if let (M1Scalar::FixedPoint7dps(from), M1Scalar::FixedPoint7dps(to)) = (from, to) {
+        return ScalarMagnitude::FixedPoint7dps(from.raw().abs_diff(to.raw()));
+    }
+
+    match numeric_join(scalar_type(from), scalar_type(to)) {
+        ValueType::Float => ScalarMagnitude::FloatingPoint((to.as_f32() - from.as_f32()).abs()),
+        ValueType::Unsigned => {
+            ScalarMagnitude::Integral(scalar_u32_bits(from).abs_diff(scalar_u32_bits(to)))
+        }
+        ValueType::Integer => match (from, to) {
+            (M1Scalar::Integer(from), M1Scalar::Integer(to)) => {
+                ScalarMagnitude::Integral(from.abs_diff(to))
+            }
+            _ => unreachable!("numeric_join selected Integer for signed scalars"),
+        },
+        _ => unreachable!("M1Scalar always has a numeric ValueType"),
+    }
+}
+
+/// Compare a non-negative change magnitude with `|delta|`. Cross-family
+/// comparisons narrow to binary32 at the same point as an M1 numeric join;
+/// same-family integral and fixed-point magnitudes remain exact.
+fn scalar_magnitude_cmp(magnitude: ScalarMagnitude, delta: M1Scalar) -> Option<Ordering> {
+    match magnitude {
+        ScalarMagnitude::Integral(magnitude) => match delta {
+            M1Scalar::Integer(delta) => Some(magnitude.cmp(&delta.unsigned_abs())),
+            M1Scalar::UnsignedInteger(delta) => Some(magnitude.cmp(&delta)),
+            M1Scalar::FloatingPoint(delta) => (magnitude as f32).partial_cmp(&delta.abs()),
+            M1Scalar::FixedPoint7dps(delta) => {
+                (magnitude as f32).partial_cmp(&M1Scalar::FixedPoint7dps(delta).as_f32().abs())
+            }
+        },
+        ScalarMagnitude::FixedPoint7dps(raw_magnitude) => match delta {
+            M1Scalar::FixedPoint7dps(delta) => Some(raw_magnitude.cmp(&delta.raw().unsigned_abs())),
+            _ => {
+                // The exact raw subtraction is complete before this intentional
+                // promotion to the binary32 family used by a mixed comparison.
+                fixed_magnitude_f32(raw_magnitude).partial_cmp(&delta.as_f32().abs())
+            }
+        },
+        ScalarMagnitude::FloatingPoint(magnitude) => magnitude.partial_cmp(&delta.as_f32().abs()),
+    }
+}
+
+/// Return `(to cmp from, |to - from| cmp |delta|)` under M1 pairwise numeric
+/// promotion. Direction depends only on the two sampled values. Their exact
+/// difference is then compared with the delta in its accepted scalar family.
+fn scalar_change_cmp(
+    from: M1Scalar,
+    to: M1Scalar,
+    delta: M1Scalar,
+) -> (Option<Ordering>, Option<Ordering>) {
+    (
+        scalar_cmp(to, from),
+        scalar_magnitude_cmp(scalar_magnitude(from, to), delta),
+    )
 }
 
 /// Read a numeric operand as seconds. Timing state uses the scheduler's host
@@ -505,12 +623,9 @@ fn edge_delay(
 /// no `delta` the argument must be exactly unchanged. Uses the `ChangeBy` slot to
 /// hold the reference value and the held time.
 fn delay_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let x = numeric_f32(&args[0])?;
+    let x = args[0].m1_scalar()?;
     let delay = seconds(&args[1])?;
-    let delta = match args.get(2) {
-        Some(v) => numeric_f32(v)?.abs(),
-        None => 0.0,
-    };
+    let delta = args.get(2).map(Value::m1_scalar).transpose()?;
     let dt = ctx.dt;
     let slot = ctx.state.entry(site);
     let prev = match slot {
@@ -525,7 +640,11 @@ fn delay_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Val
         // First tick: start timing from the current value, not yet stable.
         None => (x, 0.0, false),
         Some((reference, held, _)) => {
-            if (x - reference).abs() > delta {
+            let moved = match delta {
+                Some(delta) => scalar_change_cmp(reference, x, delta).1 == Some(Ordering::Greater),
+                None => !scalar_equal(reference, x),
+            };
+            if moved {
                 // Moved beyond tolerance: restart timing from the new value.
                 (x, 0.0, false)
             } else {
@@ -691,8 +810,8 @@ fn change_by(
     ctx: &mut EvalCtx,
     dir: ChangeDir,
 ) -> Result<Value, EvalError> {
-    let x = numeric_f32(&args[0])?;
-    let delta = numeric_f32(&args[1])?.abs();
+    let x = args[0].m1_scalar()?;
+    let delta = args[1].m1_scalar()?;
     let filter = match args.get(2) {
         Some(v) => Some(seconds(v)?),
         None => None,
@@ -708,11 +827,17 @@ fn change_by(
         _ => None,
     };
 
-    let qualifies = |from: f32, to: f32| -> bool {
+    let qualifies = |from: M1Scalar, to: M1Scalar| -> bool {
+        let (direction, magnitude) = scalar_change_cmp(from, to, delta);
+        let large_enough = matches!(magnitude, Some(Ordering::Equal | Ordering::Greater));
         match dir {
-            ChangeDir::By => (to - from).abs() >= delta,
-            ChangeDir::Up => to - from >= delta,
-            ChangeDir::Down => from - to >= delta,
+            ChangeDir::By => large_enough,
+            ChangeDir::Up => {
+                matches!(direction, Some(Ordering::Equal | Ordering::Greater)) && large_enough
+            }
+            ChangeDir::Down => {
+                matches!(direction, Some(Ordering::Equal | Ordering::Less)) && large_enough
+            }
         }
     };
 
@@ -846,7 +971,7 @@ fn calculate_stateful(
 /// `Calculate.Stable(x, filter)` — true once `x` has been exactly unchanged for
 /// `>= filter` seconds; any change restarts the timer (output false meanwhile).
 fn calc_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let x = numeric_f32(&args[0])?;
+    let x = args[0].m1_scalar()?;
     let filter = seconds(&args[1])?;
     let dt = ctx.dt;
     let slot = ctx.state.entry(site);
@@ -857,7 +982,7 @@ fn calc_stable(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Valu
     let (reference, held, output) = match prev {
         None => (x, 0.0, false),
         Some((reference, held)) => {
-            if x != reference {
+            if !scalar_equal(x, reference) {
                 (x, 0.0, false)
             } else {
                 let held = advance_time(held, dt);
@@ -882,12 +1007,15 @@ fn calc_between(
     ctx: &mut EvalCtx,
     beyond: bool,
 ) -> Result<Value, EvalError> {
-    let x = numeric_f32(&args[0])?;
-    let min = numeric_f32(&args[1])?;
-    let max = numeric_f32(&args[2])?;
+    let x = args[0].m1_scalar()?;
+    let min = args[1].m1_scalar()?;
+    let max = args[2].m1_scalar()?;
     let filter = seconds(&args[3])?;
     let dt = ctx.dt;
-    let in_range = x >= min && x <= max;
+    let in_range = matches!(
+        scalar_cmp(x, min),
+        Some(Ordering::Equal | Ordering::Greater)
+    ) && matches!(scalar_cmp(x, max), Some(Ordering::Equal | Ordering::Less));
     let cond = if beyond { !in_range } else { in_range };
     Ok(Value::Bool(timed_predicate(cond, filter, dt, ctx, site)))
 }
@@ -897,15 +1025,18 @@ fn calc_between(
 /// for `>= filter`; holds its state in the dead band. The held-state output and
 /// the timed candidate share the `Timed` slot.
 fn calc_hysteresis(args: &[Value], site: CallSite, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let x = numeric_f32(&args[0])?;
-    let low = numeric_f32(&args[1])?;
-    let high = numeric_f32(&args[2])?;
+    let x = args[0].m1_scalar()?;
+    let low = args[1].m1_scalar()?;
+    let high = args[2].m1_scalar()?;
     let filter = seconds(&args[3])?;
     let dt = ctx.dt;
     // Candidate target: above-high wants true, below-low wants false, else hold.
-    let want = if x >= high {
+    let want = if matches!(
+        scalar_cmp(x, high),
+        Some(Ordering::Equal | Ordering::Greater)
+    ) {
         Some(true)
-    } else if x <= low {
+    } else if matches!(scalar_cmp(x, low), Some(Ordering::Equal | Ordering::Less)) {
         Some(false)
     } else {
         None
@@ -1044,6 +1175,174 @@ mod tests {
 
     fn n(value: f64) -> Value {
         Value::m1_float(value as f32)
+    }
+
+    fn adjacent_scalar_cases() -> [(&'static str, M1Scalar, M1Scalar, M1Scalar); 4] {
+        let float_low = 16_777_216_f32;
+        let float_high = f32::from_bits(float_low.to_bits() + 1);
+        [
+            (
+                "Integer",
+                M1Scalar::Integer(16_777_216),
+                M1Scalar::Integer(16_777_217),
+                M1Scalar::Integer(1),
+            ),
+            (
+                "UnsignedInteger",
+                M1Scalar::UnsignedInteger(u32::MAX - 1),
+                M1Scalar::UnsignedInteger(u32::MAX),
+                M1Scalar::UnsignedInteger(1),
+            ),
+            (
+                "FixedPoint7dps",
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::from_raw(i32::MAX - 1)),
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::MAX),
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::from_raw(1)),
+            ),
+            (
+                "FloatingPoint",
+                M1Scalar::FloatingPoint(float_low),
+                M1Scalar::FloatingPoint(float_high),
+                M1Scalar::FloatingPoint(float_high - float_low),
+            ),
+        ]
+    }
+
+    #[test]
+    fn family_aware_comparisons_keep_adjacent_values_and_full_width_differences() {
+        for (family, low, high, delta) in adjacent_scalar_cases() {
+            assert_eq!(scalar_cmp(low, high), Some(Ordering::Less), "{family}");
+            assert!(!scalar_equal(low, high), "{family}");
+            assert_eq!(
+                scalar_change_cmp(low, high, delta),
+                (Some(Ordering::Greater), Some(Ordering::Equal)),
+                "{family}"
+            );
+        }
+
+        for (family, low, high, delta, magnitude) in [
+            (
+                "Integer",
+                M1Scalar::Integer(i32::MIN),
+                M1Scalar::Integer(i32::MAX),
+                M1Scalar::Integer(i32::MAX),
+                Ordering::Greater,
+            ),
+            (
+                "UnsignedInteger",
+                M1Scalar::UnsignedInteger(0),
+                M1Scalar::UnsignedInteger(u32::MAX),
+                M1Scalar::UnsignedInteger(u32::MAX),
+                Ordering::Equal,
+            ),
+            (
+                "FixedPoint7dps",
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::MIN),
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::MAX),
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::MAX),
+                Ordering::Greater,
+            ),
+        ] {
+            assert_eq!(
+                scalar_change_cmp(low, high, delta),
+                (Some(Ordering::Greater), Some(magnitude)),
+                "{family}"
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_family_comparisons_follow_m1_promotion() {
+        assert!(scalar_equal(
+            M1Scalar::Integer(-1),
+            M1Scalar::UnsignedInteger(u32::MAX)
+        ));
+        assert!(scalar_equal(
+            M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::from_raw(10_000_000)),
+            M1Scalar::FloatingPoint(1.0)
+        ));
+
+        // Signed and unsigned operands share the integral overload, whose M1
+        // join selects unsigned without narrowing either sampled value.
+        assert_eq!(
+            scalar_change_cmp(
+                M1Scalar::Integer(16_777_216),
+                M1Scalar::Integer(16_777_217),
+                M1Scalar::UnsignedInteger(1),
+            ),
+            (Some(Ordering::Greater), Some(Ordering::Equal))
+        );
+        assert_eq!(
+            scalar_change_cmp(
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::ZERO),
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::from_raw(10_000_000)),
+                M1Scalar::FloatingPoint(1.0),
+            ),
+            (Some(Ordering::Greater), Some(Ordering::Equal))
+        );
+
+        let promoted_fixed_difference =
+            M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::from_raw(16_777_217)).as_f32();
+        assert_eq!(
+            scalar_change_cmp(
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::ZERO),
+                M1Scalar::FixedPoint7dps(crate::value::FixedPoint7dps::from_raw(16_777_217)),
+                M1Scalar::FloatingPoint(promoted_fixed_difference),
+            ),
+            (Some(Ordering::Greater), Some(Ordering::Equal))
+        );
+    }
+
+    #[test]
+    fn mixed_family_stateful_operators_follow_m1_promotion() {
+        let mut change = Harness::new(0.1);
+        let change_args = |value| [Value::m1_integer(value), Value::m1_unsigned(1)];
+        assert!(
+            !change
+                .tick("Change", "By", &change_args(16_777_216))
+                .as_bool()
+                .unwrap()
+        );
+        assert!(
+            change
+                .tick("Change", "By", &change_args(16_777_217))
+                .as_bool()
+                .unwrap()
+        );
+
+        let promoted_equal = [
+            Value::m1_integer(-1),
+            Value::m1_unsigned(u32::MAX),
+            Value::m1_unsigned(u32::MAX),
+            n(0.0),
+        ];
+        let mut between = Harness::new(0.1);
+        assert!(
+            !between
+                .tick("Calculate", "Between", &promoted_equal)
+                .as_bool()
+                .unwrap()
+        );
+        assert!(
+            between
+                .tick("Calculate", "Between", &promoted_equal)
+                .as_bool()
+                .unwrap()
+        );
+
+        let mut stable = Harness::new(0.1);
+        assert!(
+            !stable
+                .tick("Delay", "Stable", &[Value::m1_integer(-1), n(0.0)],)
+                .as_bool()
+                .unwrap()
+        );
+        assert!(
+            stable
+                .tick("Delay", "Stable", &[Value::m1_unsigned(u32::MAX), n(0.0)],)
+                .as_bool()
+                .unwrap()
+        );
     }
 
     #[test]
@@ -1392,6 +1691,40 @@ mod tests {
         assert!(delay_falling(&mut h, true, 0.2)); //  immediate rise
     }
 
+    #[test]
+    fn delay_stable_detects_adjacent_values_in_every_scalar_family() {
+        for (family, low, high, _) in adjacent_scalar_cases() {
+            let mut h = Harness::new(0.1);
+            let stable = |h: &mut Harness, value: M1Scalar| {
+                h.tick("Delay", "Stable", &[Value::M1(value), n(0.0)])
+                    .as_bool()
+                    .unwrap()
+            };
+            assert!(!stable(&mut h, low), "{family} seed");
+            assert!(!stable(&mut h, high), "{family} adjacent change");
+            assert!(stable(&mut h, high), "{family} repeated value");
+        }
+    }
+
+    #[test]
+    fn delay_stable_fixed_tolerance_compares_raw_units() {
+        let mut h = Harness::new(0.1);
+        let fixed = |raw| {
+            Value::M1(M1Scalar::FixedPoint7dps(
+                crate::value::FixedPoint7dps::from_raw(raw),
+            ))
+        };
+        let stable = |h: &mut Harness, raw| {
+            h.tick("Delay", "Stable", &[fixed(raw), n(0.0), n(0.0000001)])
+                .as_bool()
+                .unwrap()
+        };
+
+        assert!(!stable(&mut h, i32::MAX - 2));
+        assert!(stable(&mut h, i32::MAX - 1)); // exactly one raw unit: tolerated
+        assert!(!stable(&mut h, i32::MAX)); // two raw units from the reference
+    }
+
     // ---- Task 18: Debounce.* ----
 
     #[test]
@@ -1474,6 +1807,53 @@ mod tests {
         assert!(c(&mut h, 8.0)); //  delta 6 >= 5
         assert!(!c(&mut h, 8.0)); // delta 0
         assert!(c(&mut h, 1.0)); //  delta 7 >= 5
+    }
+
+    #[test]
+    fn change_by_up_and_down_preserve_every_scalar_family() {
+        for (family, low, high, delta) in adjacent_scalar_cases() {
+            let args = |value| [Value::M1(value), Value::M1(delta)];
+
+            let mut by = Harness::new(0.1);
+            assert!(
+                !by.tick("Change", "By", &args(low)).as_bool().unwrap(),
+                "{family} By seed"
+            );
+            assert!(
+                by.tick("Change", "By", &args(high)).as_bool().unwrap(),
+                "{family} By adjacent change"
+            );
+
+            let mut up = Harness::new(0.1);
+            assert!(!up.tick("Change", "Up", &args(low)).as_bool().unwrap());
+            assert!(
+                up.tick("Change", "Up", &args(high)).as_bool().unwrap(),
+                "{family} Up adjacent change"
+            );
+
+            let mut down = Harness::new(0.1);
+            assert!(!down.tick("Change", "Down", &args(high)).as_bool().unwrap());
+            assert!(
+                down.tick("Change", "Down", &args(low)).as_bool().unwrap(),
+                "{family} Down adjacent change"
+            );
+        }
+    }
+
+    #[test]
+    fn filtered_change_by_keeps_an_exact_integer_reference() {
+        let mut h = Harness::new(0.1);
+        let call = |h: &mut Harness, value| {
+            h.tick(
+                "Change",
+                "By",
+                &[Value::m1_integer(value), Value::m1_integer(1), n(0.0)],
+            )
+            .as_bool()
+            .unwrap()
+        };
+        assert!(!call(&mut h, 16_777_216));
+        assert!(call(&mut h, 16_777_217));
     }
 
     #[test]
@@ -1689,6 +2069,93 @@ mod tests {
         assert!(hy(&mut h, 1.0)); //   timing 0.2 < widened threshold
         assert!(!hy(&mut h, 1.0)); //  timing 0.3 -> false
         assert!(!hy(&mut h, 1.0)); //  stays false
+    }
+
+    #[test]
+    fn calculate_predicates_preserve_every_scalar_family() {
+        for (family, low, high, _) in adjacent_scalar_cases() {
+            let stable_args = |value| [Value::M1(value), n(0.0)];
+            let mut stable = Harness::new(0.1);
+            assert!(
+                !stable
+                    .tick("Calculate", "Stable", &stable_args(low))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Stable seed"
+            );
+            assert!(
+                !stable
+                    .tick("Calculate", "Stable", &stable_args(high))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Stable adjacent change"
+            );
+            assert!(
+                stable
+                    .tick("Calculate", "Stable", &stable_args(high))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Stable repeated value"
+            );
+
+            let range_args = |value| [Value::M1(value), Value::M1(high), Value::M1(high), n(0.0)];
+            let mut between = Harness::new(0.1);
+            assert!(
+                !between
+                    .tick("Calculate", "Between", &range_args(low))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Between below adjacent bound"
+            );
+            assert!(
+                !between
+                    .tick("Calculate", "Between", &range_args(low))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Between remains outside"
+            );
+
+            let mut beyond = Harness::new(0.1);
+            assert!(
+                !beyond
+                    .tick("Calculate", "Beyond", &range_args(low))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Beyond starts timing"
+            );
+            assert!(
+                beyond
+                    .tick("Calculate", "Beyond", &range_args(low))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Beyond accepts adjacent outside value"
+            );
+
+            let hysteresis_args =
+                |value| [Value::M1(value), Value::M1(low), Value::M1(high), n(0.0)];
+            let mut hysteresis = Harness::new(0.1);
+            assert!(
+                !hysteresis
+                    .tick("Calculate", "Hysteresis", &hysteresis_args(low))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Hysteresis low state"
+            );
+            assert!(
+                !hysteresis
+                    .tick("Calculate", "Hysteresis", &hysteresis_args(high))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Hysteresis starts high timing"
+            );
+            assert!(
+                hysteresis
+                    .tick("Calculate", "Hysteresis", &hysteresis_args(high))
+                    .as_bool()
+                    .unwrap(),
+                "{family} Hysteresis accepts adjacent high value"
+            );
+        }
     }
 
     // ---- Task 18: static-local persistence ----

--- a/src/calib.rs
+++ b/src/calib.rs
@@ -35,9 +35,7 @@
 //! kept out of this pure reader.
 
 use crate::error::EvalError;
-#[cfg(test)]
-use crate::value::FixedPoint7dps;
-use crate::value::{M1Scalar, M1ScalarKind, Value};
+use crate::value::{FixedPoint7dps, M1Scalar};
 use std::collections::HashMap;
 
 /// A calibration table's concrete numbers: one breakpoint vector per input
@@ -117,9 +115,8 @@ impl Calibration {
 }
 
 /// Parse one calibration cell according to its declared M1 storage type.
-/// Enum and Boolean cells are non-numeric and return `None`. An absent type uses the named
-/// legacy-untyped compatibility rule: old configuration files treated every
-/// numeric cell as floating point, so the value is narrowed to binary32.
+/// Enum and Boolean cells are non-numeric and return `None`. An absent type uses
+/// the historical untyped-cell rule: numeric cells are parsed as binary32.
 fn cell_value(
     cell: roxmltree::Node<'_, '_>,
     declared_type: Option<&str>,
@@ -128,38 +125,32 @@ fn cell_value(
     let Some(text) = cell.text().map(str::trim).filter(|text| !text.is_empty()) else {
         return Ok(None);
     };
-    let ty = declared_type.unwrap_or("legacy-untyped-f32");
+    let ty = declared_type.unwrap_or("untyped-f32");
     let width_error = || EvalError::MissingCalibration {
         path: format!("calibration cell in {context} does not fit M1 type {ty}: {text:?}"),
     };
 
     let scalar = match ty {
         "enum" | "bool" => return Ok(None),
-        "f32" | "f64" | "legacy-untyped-f32" => {
-            let host = text.parse::<f64>().map_err(|_| width_error())?;
-            let narrowed = host as f32;
-            if !host.is_finite() || narrowed.is_infinite() {
+        "f32" | "f64" | "untyped-f32" => {
+            let narrowed = text.parse::<f32>().map_err(|_| width_error())?;
+            if !narrowed.is_finite() {
                 return Err(width_error());
             }
             M1Scalar::FloatingPoint(narrowed)
         }
         "s8" | "s16" | "s32" | "s64" => text
-            .parse::<i64>()
+            .parse::<i32>()
             .ok()
-            .and_then(|value| i32::try_from(value).ok())
             .map(M1Scalar::Integer)
             .ok_or_else(width_error)?,
         "u8" | "u16" | "u32" | "u64" => text
-            .parse::<u64>()
+            .parse::<u32>()
             .ok()
-            .and_then(|value| u32::try_from(value).ok())
             .map(M1Scalar::UnsignedInteger)
             .ok_or_else(width_error)?,
         "FixedPoint7dps" | "fixed7dps" => {
-            let host = text.parse::<f64>().map_err(|_| width_error())?;
-            Value::Float(host)
-                .try_as_m1_scalar_for(M1ScalarKind::FixedPoint7dps)
-                .map_err(|_| width_error())?
+            M1Scalar::FixedPoint7dps(FixedPoint7dps::parse_decimal(text).ok_or_else(width_error)?)
         }
         other => {
             return Err(EvalError::MissingCalibration {

--- a/src/counterfactual.rs
+++ b/src/counterfactual.rs
@@ -127,29 +127,18 @@ fn parse_const_rhs(rhs: &str) -> Result<Option<Value>, EvalError> {
         return Ok(Some(Value::Bool(false)));
     }
     if is_decimal_integer_literal(rhs) {
-        let i = rhs.parse::<i64>().map_err(|_| EvalError::TypeError {
+        let i = rhs.parse::<i32>().map_err(|_| EvalError::TypeError {
             detail: format!("override integer {rhs:?} is outside the M1 i32 range"),
         })?;
-        return i32::try_from(i)
-            .map(Value::m1_integer)
-            .map(Some)
-            .map_err(|_| EvalError::TypeError {
-                detail: format!("override integer {rhs:?} is outside the M1 i32 range"),
-            });
+        return Ok(Some(Value::m1_integer(i)));
     }
-    if let Ok(f) = rhs.parse::<f64>() {
+    if let Ok(f) = rhs.parse::<f32>() {
         // Reject non-finite "numbers" (`inf`, `nan`) as constants: a logged
         // channel literal is never infinite/NaN, and treating those words as
         // numeric would silently swallow what was almost certainly a typo'd
         // expression. They fall through to the Expr arm, which fails loud later.
         if f.is_finite() {
-            let narrowed = f as f32;
-            if narrowed.is_infinite() {
-                return Err(EvalError::TypeError {
-                    detail: format!("override float {rhs:?} is outside the M1 binary32 range"),
-                });
-            }
-            return Ok(Some(Value::m1_float(narrowed)));
+            return Ok(Some(Value::m1_float(f)));
         }
         if is_decimal_numeric_literal(rhs) {
             return Err(EvalError::TypeError {
@@ -181,7 +170,7 @@ mod tests {
 
     #[test]
     fn const_integer_rhs_is_int_const() {
-        // A bare integer literal -> Const(Value::Int), channel verbatim.
+        // A bare integer literal becomes an M1 Integer; channel text is verbatim.
         let ov = Override::parse("Root.CF.Sensor=5").expect("parses");
         assert_eq!(
             ov,
@@ -195,7 +184,7 @@ mod tests {
 
     #[test]
     fn const_float_rhs_is_float_const() {
-        // A literal with a decimal point -> Const(Value::Float).
+        // A literal with a decimal point becomes M1 binary32.
         let ov = Override::parse("Root.CF.Sensor=5.0").expect("parses");
         assert_eq!(
             ov,

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -769,7 +769,7 @@ Output = i;
         }
 
         let mut env = crate::env::Env::new();
-        env.set_local("Kick", crate::value::Value::Int(0));
+        env.set_local("Kick", crate::value::Value::m1_integer(0));
         let mut state = crate::env::StateStore::new();
         let mut ctx = crate::expr::EvalCtx {
             project: &loaded.project,

--- a/src/env.rs
+++ b/src/env.rs
@@ -25,7 +25,7 @@
 //! fixed parse). The concrete per-operator state lives in [`OpState`], filled in
 //! by the M6 stateful-builtin milestone; this module provides the keyed slot.
 
-use crate::value::Value;
+use crate::value::{M1Scalar, Value};
 use m1_core::Node;
 use std::collections::HashMap;
 
@@ -106,10 +106,10 @@ pub enum OpState {
     /// This is separate from [`OpState::Timed`] so a script value never hides in
     /// a host-width timing field.
     DebounceFilter { output: bool, level: f32 },
-    /// `Change.{By,Up,Down}`: the previous numeric argument value, plus a timer
-    /// and pending flag for the filtered overloads.
+    /// `Change.{By,Up,Down}`, `Delay.Stable`, and `Calculate.Stable`: the exact
+    /// previous M1 scalar, plus a timer and pending/output flag.
     ChangeBy {
-        prev_x: f32,
+        prev_x: M1Scalar,
         held: f64,
         pending: bool,
     },

--- a/src/env.rs
+++ b/src/env.rs
@@ -79,18 +79,18 @@ pub enum OpState {
     Uninit,
     /// First-order filter family (`Filter.FirstOrder/Maximum/Minimum`): the
     /// previous filtered output `y[n-1]`.
-    Filter { y: f64 },
+    Filter { y: f32 },
     /// `Integral.Normal`: the running clamped accumulator and the previous input
     /// (for trapezoidal area).
-    Integral { acc: f64, prev_x: f64 },
+    Integral { acc: f32, prev_x: f32 },
     /// `Derivative.{Normal,Filtered}`: the previous input, plus the previous
     /// filtered-derivative output for the `Filtered` variant.
-    Derivative { prev_x: f64, prev_d: f64 },
+    Derivative { prev_x: f32, prev_d: f32 },
     /// `Derivative.Adaptive`: the input value at the last accepted update, the
     /// previous emitted derivative, and the time elapsed since the last update.
     DerivativeAdaptive {
-        last_x: f64,
-        prev_d: f64,
+        last_x: f32,
+        prev_d: f32,
         elapsed: f64,
     },
     /// Debounce/Delay timer family (`Delay.Rising/Falling`, `Debounce.*`,
@@ -102,10 +102,14 @@ pub enum OpState {
         candidate: bool,
         held: f64,
     },
+    /// `Debounce.Filter`: its binary32 filtered level and committed boolean.
+    /// This is separate from [`OpState::Timed`] so a script value never hides in
+    /// a host-width timing field.
+    DebounceFilter { output: bool, level: f32 },
     /// `Change.{By,Up,Down}`: the previous numeric argument value, plus a timer
     /// and pending flag for the filtered overloads.
     ChangeBy {
-        prev_x: f64,
+        prev_x: f32,
         held: f64,
         pending: bool,
     },
@@ -275,10 +279,10 @@ mod tests {
     fn set_get_roundtrip_on_spaced_path() {
         let mut env = Env::new();
         // M1 identifiers may contain spaces — the whole path is one key.
-        env.set("Root.A.Cooling Fan.Output", Value::Float(1.5));
+        env.set("Root.A.Cooling Fan.Output", Value::m1_float(1.5));
         assert_eq!(
             env.get("Root.A.Cooling Fan.Output"),
-            Some(&Value::Float(1.5))
+            Some(&Value::m1_float(1.5))
         );
         // A different spelling (split on space) must NOT collide.
         assert_eq!(env.get("Root.A.Cooling"), None);
@@ -288,9 +292,9 @@ mod tests {
     fn locals_clear_on_leave_function_but_statics_persist() {
         let mut env = Env::new();
         env.enter_function();
-        env.set_local("scaled", Value::Int(3));
-        env.set_static("Root.Demo.Update", "accum", Value::Float(10.0));
-        assert_eq!(env.get_local("scaled"), Some(&Value::Int(3)));
+        env.set_local("scaled", Value::m1_integer(3));
+        env.set_static("Root.Demo.Update", "accum", Value::m1_float(10.0));
+        assert_eq!(env.get_local("scaled"), Some(&Value::m1_integer(3)));
 
         env.leave_function();
         // Locals are gone.
@@ -298,7 +302,7 @@ mod tests {
         // The static survives.
         assert_eq!(
             env.get_static("Root.Demo.Update", "accum"),
-            Some(&Value::Float(10.0))
+            Some(&Value::m1_float(10.0))
         );
 
         // Re-entering keeps the static available, fresh locals.
@@ -306,7 +310,7 @@ mod tests {
         assert_eq!(env.get_local("scaled"), None);
         assert_eq!(
             env.get_static("Root.Demo.Update", "accum"),
-            Some(&Value::Float(10.0))
+            Some(&Value::m1_float(10.0))
         );
     }
 
@@ -316,10 +320,10 @@ mod tests {
         // Unassigned by default.
         assert_eq!(env.get_out(), None);
         // A body assigns Out; the slot holds it.
-        env.set_out(Value::Float(6.0));
-        assert_eq!(env.get_out(), Some(&Value::Float(6.0)));
+        env.set_out(Value::m1_float(6.0));
+        assert_eq!(env.get_out(), Some(&Value::m1_float(6.0)));
         // Clearing returns the prior value and empties the slot.
-        assert_eq!(env.clear_out(), Some(Value::Float(6.0)));
+        assert_eq!(env.clear_out(), Some(Value::m1_float(6.0)));
         assert_eq!(env.get_out(), None);
         // Clearing an empty slot returns None.
         assert_eq!(env.clear_out(), None);
@@ -328,27 +332,27 @@ mod tests {
     #[test]
     fn out_slot_is_independent_of_locals_and_statics() {
         let mut env = Env::new();
-        env.set_local("y", Value::Int(7));
-        env.set_out(Value::Int(99));
+        env.set_local("y", Value::m1_integer(7));
+        env.set_out(Value::m1_integer(99));
         // Leaving a function clears locals but does NOT touch the out slot — the
         // caller (`userfn::call`) owns save/restore of the out slot explicitly.
         env.leave_function();
         assert_eq!(env.get_local("y"), None);
-        assert_eq!(env.get_out(), Some(&Value::Int(99)));
+        assert_eq!(env.get_out(), Some(&Value::m1_integer(99)));
     }
 
     #[test]
     fn statics_of_different_functions_do_not_collide() {
         let mut env = Env::new();
-        env.set_static("Root.Demo.Update", "x", Value::Int(1));
-        env.set_static("Root.Other.Update", "x", Value::Int(2));
+        env.set_static("Root.Demo.Update", "x", Value::m1_integer(1));
+        env.set_static("Root.Other.Update", "x", Value::m1_integer(2));
         assert_eq!(
             env.get_static("Root.Demo.Update", "x"),
-            Some(&Value::Int(1))
+            Some(&Value::m1_integer(1))
         );
         assert_eq!(
             env.get_static("Root.Other.Update", "x"),
-            Some(&Value::Int(2))
+            Some(&Value::m1_integer(2))
         );
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -113,9 +113,8 @@ fn eval_number(node: &Node) -> Result<Value, EvalError> {
     match type_of_number_literal(text) {
         ValueType::Unsigned => parse_uint(text).map(Value::m1_unsigned),
         ValueType::Float => {
-            let host = text.parse::<f64>().map_err(|_| bad_number(text))?;
-            let narrowed = host as f32;
-            if !host.is_finite() || narrowed.is_infinite() {
+            let narrowed = text.parse::<f32>().map_err(|_| bad_number(text))?;
+            if !narrowed.is_finite() {
                 Err(bad_number(text))
             } else {
                 Ok(Value::m1_float(narrowed))
@@ -531,28 +530,23 @@ fn project_constant_value(symbol: &Symbol, project: &Project) -> Result<Option<V
         let normalized = declared.to_ascii_lowercase();
         let value = match normalized.as_str() {
             "f32" | "f64" => {
-                let host = text.parse::<f64>().map_err(|_| invalid())?;
-                let narrowed = host as f32;
-                if !host.is_finite() || narrowed.is_infinite() {
+                let narrowed = text.parse::<f32>().map_err(|_| invalid())?;
+                if !narrowed.is_finite() {
                     return Err(invalid());
                 }
                 Value::m1_float(narrowed)
             }
             "s8" | "s16" | "s32" | "s64" => text
-                .parse::<i64>()
+                .parse::<i32>()
                 .ok()
-                .and_then(|value| i32::try_from(value).ok())
                 .map(Value::m1_integer)
                 .ok_or_else(invalid)?,
             "u8" | "u16" | "u32" | "u64" => parse_uint(text)
                 .map(Value::m1_unsigned)
                 .map_err(|_| invalid())?,
             "fixedpoint7dps" | "fixed7dps" => {
-                let host = text.parse::<f64>().map_err(|_| invalid())?;
-                let scalar = Value::Float(host)
-                    .try_as_m1_scalar_for(M1ScalarKind::FixedPoint7dps)
-                    .map_err(|_| invalid())?;
-                Value::M1(scalar)
+                let fixed = FixedPoint7dps::parse_decimal(text).ok_or_else(invalid)?;
+                Value::M1(M1Scalar::FixedPoint7dps(fixed))
             }
             "bool" => match text.to_ascii_lowercase().as_str() {
                 "true" => Value::Bool(true),
@@ -588,9 +582,8 @@ fn project_constant_value(symbol: &Symbol, project: &Project) -> Result<Option<V
     let value = match type_of_number_literal(text) {
         ValueType::Unsigned => parse_uint(text).map(Value::m1_unsigned),
         ValueType::Float => {
-            let host = text.parse::<f64>().map_err(|_| invalid())?;
-            let narrowed = host as f32;
-            if !host.is_finite() || narrowed.is_infinite() {
+            let narrowed = text.parse::<f32>().map_err(|_| invalid())?;
+            if !narrowed.is_finite() {
                 return Err(invalid());
             }
             Ok(Value::m1_float(narrowed))
@@ -710,9 +703,6 @@ pub(crate) fn coerce_for_declared_type(
 
     let scalar = match &value {
         Value::M1(scalar) => *scalar,
-        Value::Int(_) | Value::Uint(_) | Value::Float(_) => {
-            return Err(value.m1_scalar().unwrap_err());
-        }
         _ => {
             return Err(declared_type_error(
                 target,
@@ -727,13 +717,12 @@ pub(crate) fn coerce_for_declared_type(
         ValueType::Unsigned => coerce_for_scalar_kind(target, value, M1ScalarKind::UnsignedInteger),
         ValueType::Float => coerce_for_scalar_kind(target, value, M1ScalarKind::FloatingPoint),
         ValueType::Enum(id) => {
-            let n = scalar.as_f64();
             let member = project
                 .symbols()
                 .enum_type(id)
                 .members
                 .iter()
-                .find(|(_, declared)| (*declared as f64) == n)
+                .find(|(_, declared)| scalar_matches_enum_value(scalar, *declared))
                 .map(|(name, _)| name.clone());
             match member {
                 Some(member) => Ok(Value::Enum { id, member }),
@@ -749,6 +738,19 @@ pub(crate) fn coerce_for_declared_type(
             &value,
             declared_type_name(declared),
         )),
+    }
+}
+
+fn scalar_matches_enum_value(scalar: M1Scalar, declared: i64) -> bool {
+    match scalar {
+        M1Scalar::Integer(value) => i64::from(value) == declared,
+        M1Scalar::UnsignedInteger(value) => u32::try_from(declared) == Ok(value),
+        M1Scalar::FloatingPoint(value) => i32::try_from(declared)
+            .ok()
+            .is_some_and(|declared| f64::from(declared) == f64::from(value)),
+        M1Scalar::FixedPoint7dps(value) => declared
+            .checked_mul(FixedPoint7dps::SCALE)
+            .is_some_and(|raw| raw == i64::from(value.raw())),
     }
 }
 
@@ -840,7 +842,7 @@ fn eval_unary(node: &Node, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
     if op.kind() == Kind::Minus
         && operand.kind() == Kind::Number
         && type_of_number_literal(operand.text().trim()) == ValueType::Integer
-        && operand.text().trim().parse::<i64>().ok() == Some(i64::from(i32::MAX) + 1)
+        && operand.text().trim().parse::<u32>().ok() == Some(i32::MAX as u32 + 1)
     {
         return Ok(Value::m1_integer(i32::MIN));
     }
@@ -1146,9 +1148,6 @@ fn bit_i32(op: Kind, a: i32, b: u32) -> i32 {
 fn value_type(v: &Value) -> ValueType {
     match v {
         Value::Bool(_) => ValueType::Boolean,
-        Value::Int(_) => ValueType::Integer,
-        Value::Uint(_) => ValueType::Unsigned,
-        Value::Float(_) => ValueType::Float,
         Value::M1(M1Scalar::Integer(_)) => ValueType::Integer,
         Value::M1(M1Scalar::UnsignedInteger(_)) => ValueType::Unsigned,
         Value::M1(M1Scalar::FloatingPoint(_) | M1Scalar::FixedPoint7dps(_)) => ValueType::Float,
@@ -1366,6 +1365,22 @@ mod tests {
     }
 
     #[test]
+    fn float_to_enum_coercion_requires_an_exact_integer_value() {
+        assert!(scalar_matches_enum_value(
+            M1Scalar::FloatingPoint(16_777_216.0),
+            16_777_216
+        ));
+        assert!(!scalar_matches_enum_value(
+            M1Scalar::FloatingPoint(16_777_216.0),
+            16_777_217
+        ));
+        assert!(!scalar_matches_enum_value(
+            M1Scalar::FloatingPoint(i32::MAX as f32),
+            i64::from(i32::MAX)
+        ));
+    }
+
+    #[test]
     fn project_target_metadata_distinguishes_float_and_fixed_point() {
         let h = Harness::new();
         let fixed = Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(
@@ -1444,7 +1459,7 @@ mod tests {
             Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::ZERO))
         );
 
-        // A legacy-untyped calibration cell parses as binary32. It cannot
+        // An untyped calibration cell parses as binary32. It cannot
         // silently change an explicitly fixed parameter's storage family.
         h.calib
             .params

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -145,7 +145,7 @@ mod tests {
     fn local_variable_is_local() {
         let project = mini_project();
         let mut locals = HashMap::new();
-        locals.insert("scaled".to_string(), Value::Float(0.0));
+        locals.insert("scaled".to_string(), Value::m1_float(0.0));
         // A bare local name shadows project lookup per the M1 scope order.
         let t = classify("scaled", Some("Root.Demo"), None, &project, &locals);
         assert_eq!(t, Target::Local("scaled".to_string()));
@@ -181,7 +181,7 @@ mod tests {
     fn local_only_shadows_a_single_segment_not_a_builtin_callee() {
         let project = mini_project();
         let mut locals = HashMap::new();
-        locals.insert("Calculate".to_string(), Value::Int(0));
+        locals.insert("Calculate".to_string(), Value::m1_integer(0));
 
         assert_eq!(
             classify("Calculate.Max", Some("Root.Demo"), None, &project, &locals,),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub mod error;
 pub use error::EvalError;
 
 pub mod value;
-pub use value::{FixedPoint7dps, LegacyNumericKind, M1Scalar, M1ScalarKind, Value};
+pub use value::{FixedPoint7dps, M1Scalar, M1ScalarKind, Value};
 
 pub mod calib;
 pub use calib::{CalTable, Calibration};

--- a/src/log/ld.rs
+++ b/src/log/ld.rs
@@ -677,7 +677,7 @@ mod tests {
         let points = super::decode_channel_points(&bytes, sensor).expect("sensor data");
         let values: Vec<f64> = points
             .iter()
-            .map(|(_, v)| v.as_f64().expect("numeric"))
+            .map(|(_, v)| v.m1_scalar().expect("numeric").as_f64())
             .collect();
         for (got, want) in values.iter().zip([10.0_f64, 20.0, 30.0, 40.0].iter()) {
             assert!((got - want).abs() < 1e-9, "decoded {got} != {want}");
@@ -686,8 +686,8 @@ mod tests {
         // Other: F32 {1.5, 2.5}, unit scaling -> identity.
         let other = &channels[1];
         let other_points = super::decode_channel_points(&bytes, other).expect("other data");
-        assert!((other_points[0].1.as_f64().unwrap() - 1.5).abs() < 1e-9);
-        assert!((other_points[1].1.as_f64().unwrap() - 2.5).abs() < 1e-9);
+        assert!((other_points[0].1.m1_scalar().unwrap().as_f64() - 1.5).abs() < 1e-9);
+        assert!((other_points[1].1.m1_scalar().unwrap().as_f64() - 2.5).abs() < 1e-9);
     }
 
     /// Build a synthetic single-channel `.ld` image from a fully-specified metadata
@@ -758,7 +758,7 @@ mod tests {
         };
         let values: Vec<f64> = points
             .iter()
-            .map(|(_, v)| v.as_f64().expect("numeric"))
+            .map(|(_, v)| v.m1_scalar().expect("numeric").as_f64())
             .collect();
         for (got, want) in values.iter().zip([10.0_f64, 20.0, 30.0, 40.0].iter()) {
             assert!((got - want).abs() < 1e-9, "decoded {got} != {want}");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1405,7 +1405,12 @@ mod tests {
         };
         let trace = run(&loaded, &scenario).expect("enum-seeded run evaluates");
         let flag = trace.channels.get("Root.Demo.Flag").expect("Flag traced");
-        assert_eq!(flag.last().and_then(|v| v.as_f64().ok()), Some(1.0));
+        assert_eq!(
+            flag.last()
+                .and_then(|value| value.m1_scalar().ok())
+                .map(|value| value.as_f64()),
+            Some(1.0)
+        );
     }
 
     #[test]
@@ -1546,10 +1551,9 @@ const = 3.0
         // scheduler ran the 200 Hz function 167 times (round(500/200) = 3) on a
         // 500 Hz base. Each function counts its own invocations.
         //
-        // Exact dt: trapezoidal Integral.Normal of a constant Seed = 3 advances
-        // by Seed*dt per run from the second run on (run k holds 3*dt*k), so
-        // after 200 runs Mid Total = 3.0 * 0.005 * 199 = 2.985 exactly — only
-        // when dt is exactly 5 ms AND the invocation count is exactly 200.
+        // `Integral.Normal` accumulates in M1 binary32. Reproduce those 199
+        // additions here so the assertion checks both the exact 5 ms schedule
+        // and binary32 rounding at every state update.
         let loaded = ratemix();
         let toml = r#"
 mode = "whole-project"
@@ -1572,10 +1576,9 @@ const = 3.0
         assert_eq!(last_f64("Root.RX.Fast Count"), 500.0, "500 Hz runs/second");
         assert_eq!(last_f64("Root.RX.Mid Count"), 200.0, "200 Hz runs/second");
         let total = last_f64("Root.RX.Mid Total");
-        assert!(
-            (total - 2.985).abs() < 1e-6,
-            "exact dt=5 ms trapezoidal accumulation, got {total}"
-        );
+        let dt = 0.005_f32;
+        let expected = (1..200).fold(0.0_f32, |acc, _| acc + (3.0 + 3.0) * 0.5 * dt);
+        assert_eq!(total, f64::from(expected));
     }
 
     #[test]

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -380,9 +380,9 @@ pub(crate) fn parse_time_series_csv(
                 continue;
             }
             let explicit_non_finite = explicit_non_finite_float(trimmed);
-            let host = match explicit_non_finite {
+            let narrowed = match explicit_non_finite {
                 Some(value) => value,
-                None => trimmed.parse::<f64>().map_err(|_| EvalError::TypeError {
+                None => trimmed.parse::<f32>().map_err(|_| EvalError::TypeError {
                     detail: format!(
                         "CSV row {} column {:?} value {trimmed:?} is not numeric",
                         row_idx + 2,
@@ -390,8 +390,7 @@ pub(crate) fn parse_time_series_csv(
                     ),
                 })?,
             };
-            let narrowed = host as f32;
-            if explicit_non_finite.is_none() && (!host.is_finite() || narrowed.is_infinite()) {
+            if explicit_non_finite.is_none() && !narrowed.is_finite() {
                 return Err(EvalError::TypeError {
                     detail: format!(
                         "CSV row {} column {:?} value {trimmed:?} is outside M1 binary32 range",
@@ -412,11 +411,11 @@ pub(crate) fn parse_time_series_csv(
 /// Keeping this lexical check separate lets CSV preserve real binary32
 /// sentinels while still rejecting a finite decimal such as `1e9999` that
 /// overflowed during host parsing.
-fn explicit_non_finite_float(text: &str) -> Option<f64> {
+fn explicit_non_finite_float(text: &str) -> Option<f32> {
     match text.to_ascii_lowercase().as_str() {
-        "nan" | "+nan" | "-nan" => Some(f64::NAN),
-        "inf" | "+inf" | "infinity" | "+infinity" => Some(f64::INFINITY),
-        "-inf" | "-infinity" => Some(f64::NEG_INFINITY),
+        "nan" | "+nan" | "-nan" => Some(f32::NAN),
+        "inf" | "+inf" | "infinity" | "+infinity" => Some(f32::INFINITY),
+        "-inf" | "-infinity" => Some(f32::NEG_INFINITY),
         _ => None,
     }
 }
@@ -508,7 +507,7 @@ struct RawIo {
 
 /// A raw scalar value from the wire: a typed M1 object, number, boolean, or
 /// string. TOML/JSON numbers come through as either integer or float and use the
-/// legacy-compatible M1 narrowing rule.
+/// M1-width narrowing rule at the wire boundary.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum RawValue {
@@ -521,8 +520,8 @@ enum RawValue {
 }
 
 /// Explicit typed scenario syntax for callers that must distinguish all four
-/// M1 numeric families. Existing bare numbers remain the legacy-compatible
-/// syntax and narrow according to their JSON/TOML number family.
+/// M1 numeric families. Bare wire numbers narrow according to their JSON/TOML
+/// number family.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawM1Value {
@@ -1141,7 +1140,7 @@ const = { fixed_raw = 12345678 }
     }
 
     #[test]
-    fn legacy_scenario_numbers_narrow_or_return_clear_width_errors() {
+    fn bare_scenario_numbers_narrow_or_return_clear_width_errors() {
         let underflow = r#"{
             "mode": "whole-project",
             "duration_s": 0.1,

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -218,9 +218,6 @@ fn m1_scalar_json(value: M1Scalar) -> String {
 fn value_json(v: &Value) -> String {
     match v {
         Value::Bool(b) => b.to_string(),
-        Value::Int(x) => x.to_string(),
-        Value::Uint(x) => x.to_string(),
-        Value::Float(x) => f64_json(*x),
         Value::M1(value) => m1_scalar_json(*value),
         Value::Enum { member, .. } => json_string(member),
         Value::Str(s) => json_string(s),
@@ -231,9 +228,6 @@ fn value_json(v: &Value) -> String {
 fn value_csv(v: &Value) -> String {
     match v {
         Value::Bool(b) => b.to_string(),
-        Value::Int(x) => x.to_string(),
-        Value::Uint(x) => x.to_string(),
-        Value::Float(x) => f64_text(*x),
         Value::M1(value) => m1_scalar_text(*value),
         Value::Enum { member, .. } => member.clone(),
         Value::Str(s) => s.clone(),
@@ -273,14 +267,14 @@ mod tests {
     fn push_ticks_and_record_channels_align_to_time() {
         let mut tr = Trace::new();
         tr.push_tick(0.0);
-        tr.record_channel("Root.Demo.Out", Value::Float(1.0));
+        tr.record_channel("Root.Demo.Out", Value::m1_float(1.0));
         tr.push_tick(0.1);
-        tr.record_channel("Root.Demo.Out", Value::Float(2.0));
+        tr.record_channel("Root.Demo.Out", Value::m1_float(2.0));
 
         assert_eq!(tr.time, vec![0.0, 0.1]);
         assert_eq!(
             tr.channels.get("Root.Demo.Out").unwrap(),
-            &vec![Value::Float(1.0), Value::Float(2.0)]
+            &vec![Value::m1_float(1.0), Value::m1_float(2.0)]
         );
         // Column length tracks the time axis.
         assert_eq!(tr.channels["Root.Demo.Out"].len(), tr.time.len());
@@ -291,10 +285,13 @@ mod tests {
         let mut tr = Trace::new();
         let site = ("Demo.Update.m1scr".to_string(), 42);
         tr.push_tick(0.0);
-        tr.record_expr(site.clone(), Value::Int(7));
+        tr.record_expr(site.clone(), Value::m1_integer(7));
         tr.push_tick(0.1);
-        tr.record_expr(site.clone(), Value::Int(8));
-        assert_eq!(tr.exprs[&site], vec![Value::Int(7), Value::Int(8)]);
+        tr.record_expr(site.clone(), Value::m1_integer(8));
+        assert_eq!(
+            tr.exprs[&site],
+            vec![Value::m1_integer(7), Value::m1_integer(8)]
+        );
     }
 
     #[test]
@@ -309,9 +306,9 @@ mod tests {
     fn to_csv_shape_has_header_and_rows() {
         let mut tr = Trace::new();
         tr.push_tick(0.0);
-        tr.record_channel("Out", Value::Float(1.0));
+        tr.record_channel("Out", Value::m1_float(1.0));
         tr.push_tick(0.1);
-        tr.record_channel("Out", Value::Float(2.0));
+        tr.record_channel("Out", Value::m1_float(2.0));
 
         let csv = tr.to_csv();
         let lines: Vec<&str> = csv.lines().collect();
@@ -326,7 +323,7 @@ mod tests {
     fn to_json_is_deterministic_and_well_formed() {
         let mut tr = Trace::new();
         tr.push_tick(0.0);
-        tr.record_channel("B", Value::Int(2));
+        tr.record_channel("B", Value::m1_integer(2));
         tr.record_channel("A", Value::Bool(true));
         tr.mark_external("A");
         let json = tr.to_json();
@@ -360,20 +357,19 @@ mod tests {
     #[test]
     fn non_finite_floats_serialize_as_valid_json_nulls() {
         let mut tr = Trace::new();
-        for (legacy, m1) in [
+        for (time, m1) in [
             (f64::NAN, f32::NAN),
             (f64::INFINITY, f32::INFINITY),
             (f64::NEG_INFINITY, f32::NEG_INFINITY),
         ] {
-            tr.push_tick(legacy);
-            tr.record_channel("Legacy", Value::Float(legacy));
-            tr.record_channel("M1", Value::M1(M1Scalar::FloatingPoint(m1)));
+            tr.push_tick(time);
+            tr.record_channel("M1", Value::m1_float(m1));
         }
 
         let json = tr.to_json();
         assert_eq!(
             json,
-            "{\"time\":[null,null,null],\"channels\":{\"Legacy\":[null,null,null],\"M1\":[null,null,null]},\"external\":[]}"
+            "{\"time\":[null,null,null],\"channels\":{\"M1\":[null,null,null]},\"external\":[]}"
         );
         let parsed: serde_json::Value =
             serde_json::from_str(&json).expect("trace output must be valid JSON");

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,14 +2,10 @@
 //! Runtime value types and strict coercions.
 //!
 //! M1 is strongly typed: there is no implicit `int -> bool` or `bool -> int`
-//! coercion. [`M1Scalar`] holds the actual M1-width numeric forms. The legacy
-//! `i64`/`u64`/`f64` variants on [`Value`] remain temporarily so the evaluator
-//! can migrate one boundary at a time without changing existing callers.
-//!
-//! The numeric coercions here exist only to drive code that has not migrated
-//! yet. Anything non-numeric (`Bool`, `Enum`, `Str`) is an explicit
-//! `EvalError::TypeError` rather than a silent fallback. The evaluator never
-//! substitutes a guessed numeric value.
+//! coercion. [`M1Scalar`] is the evaluator's only numeric runtime form. Its four
+//! variants match the widths and signedness used by M1. Host-width numbers may
+//! appear while parsing wire formats, measuring time, interpolating tables, or
+//! rendering reports, but they never enter script execution as [`Value`]s.
 
 use crate::error::EvalError;
 use m1_typecheck::Project;
@@ -39,9 +35,77 @@ impl FixedPoint7dps {
         self.0
     }
 
-    /// Convert to a host float for temporary compatibility boundaries.
+    /// Widen exactly for table interpolation, timing comparisons, or reporting.
     pub fn as_f64(self) -> f64 {
         f64::from(self.0) / Self::SCALE as f64
+    }
+
+    /// Parse an exact decimal or scientific-notation value into scaled storage.
+    ///
+    /// The parser uses integer decimal arithmetic. It rejects values with a
+    /// non-zero digit beyond seven decimal places and values outside the signed
+    /// 32-bit raw range, rather than rounding through a host float.
+    pub fn parse_decimal(text: &str) -> Option<Self> {
+        let text = text.trim();
+        let (negative, unsigned) = match text.as_bytes().first() {
+            Some(b'-') => (true, &text[1..]),
+            Some(b'+') => (false, &text[1..]),
+            _ => (false, text),
+        };
+        if unsigned.is_empty() {
+            return None;
+        }
+
+        let mut exponent_split = unsigned.split(['e', 'E']);
+        let mantissa = exponent_split.next()?;
+        let exponent = match exponent_split.next() {
+            Some(value) if !value.is_empty() => value.parse::<i32>().ok()?,
+            Some(_) => return None,
+            None => 0,
+        };
+        if exponent_split.next().is_some() {
+            return None;
+        }
+
+        let mut decimal_split = mantissa.split('.');
+        let whole = decimal_split.next()?;
+        let fractional = decimal_split.next().unwrap_or("");
+        if decimal_split.next().is_some()
+            || (whole.is_empty() && fractional.is_empty())
+            || !whole.bytes().all(|byte| byte.is_ascii_digit())
+            || !fractional.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            return None;
+        }
+
+        let mut digits = format!("{whole}{fractional}");
+        let decimal_shift = exponent
+            .checked_add(7)
+            .and_then(|value| value.checked_sub(i32::try_from(fractional.len()).ok()?))?;
+
+        if digits.bytes().all(|byte| byte == b'0') {
+            return Some(Self::ZERO);
+        }
+        if decimal_shift < 0 {
+            let discarded = usize::try_from(decimal_shift.unsigned_abs()).ok()?;
+            let kept = digits.len().checked_sub(discarded)?;
+            if !digits[kept..].bytes().all(|byte| byte == b'0') {
+                return None;
+            }
+            digits.truncate(kept);
+        }
+
+        let significant = digits.trim_start_matches('0');
+        let coefficient = significant.parse::<u128>().ok()?;
+        let magnitude = if decimal_shift > 0 {
+            coefficient.checked_mul(10_u128.checked_pow(decimal_shift as u32)?)?
+        } else {
+            coefficient
+        };
+
+        let signed = i128::try_from(magnitude).ok()?;
+        let signed = if negative { -signed } else { signed };
+        i32::try_from(signed).ok().map(Self::from_raw)
     }
 }
 
@@ -98,7 +162,7 @@ impl M1Scalar {
         }
     }
 
-    /// Widen to the host numeric format used by the temporary evaluator path.
+    /// Widen for exact interpolation, timing comparisons, or reporting.
     pub fn as_f64(self) -> f64 {
         match self {
             Self::FloatingPoint(value) => f64::from(value),
@@ -121,46 +185,12 @@ impl M1Scalar {
             Self::FixedPoint7dps(value) => value.as_f64() as f32,
         }
     }
-
-    /// Convert to one of the legacy numeric [`Value`] variants.
-    ///
-    /// This is an explicit compatibility boundary scheduled for removal with
-    /// the legacy execution path. Widening the three binary forms is lossless;
-    /// fixed point is represented by its scaled decimal value as an `f64`.
-    /// [`Value::try_as_m1_scalar_for`] restores the original scalar when the
-    /// caller supplies this value's [`M1ScalarKind`].
-    pub fn into_legacy_value(self) -> Value {
-        match self {
-            Self::FloatingPoint(value) => Value::Float(f64::from(value)),
-            Self::Integer(value) => Value::Int(i64::from(value)),
-            Self::UnsignedInteger(value) => Value::Uint(u64::from(value)),
-            Self::FixedPoint7dps(value) => Value::Float(value.as_f64()),
-        }
-    }
-}
-
-/// Identifies a temporary host-width numeric variant so migration code can
-/// count the legacy values still crossing a boundary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LegacyNumericKind {
-    Int64,
-    Uint64,
-    Float64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Bool(bool),
-    /// Temporary signed host-width representation. Use [`Value::M1`] for new
-    /// M1-width values.
-    Int(i64),
-    /// Temporary unsigned host-width representation. Use [`Value::M1`] for new
-    /// M1-width values.
-    Uint(u64),
-    /// Temporary host-width floating representation. Use [`Value::M1`] for new
-    /// M1-width values.
-    Float(f64),
-    /// A numeric value represented with its actual M1 width and signedness.
+    /// A numeric value represented with its M1 width and signedness.
     M1(M1Scalar),
     Enum {
         id: usize,
@@ -186,148 +216,18 @@ impl Value {
     }
 
     /// Return the M1 scalar held by this value.
-    ///
-    /// Unlike [`Value::try_as_m1_scalar`], this rejects every legacy numeric
-    /// variant. Core evaluator paths use this accessor so a host-width value
-    /// cannot silently re-enter script execution outside a named boundary.
     pub fn m1_scalar(&self) -> Result<M1Scalar, EvalError> {
         match self {
             Self::M1(value) => Ok(*value),
-            Self::Int(_) | Self::Uint(_) | Self::Float(_) => Err(EvalError::TypeError {
-                detail: format!("legacy numeric value {self:?} reached an M1-only evaluator path"),
-            }),
             other => Err(EvalError::TypeError {
                 detail: format!("{other:?} is not numeric"),
             }),
         }
     }
 
-    /// Narrow a legacy builtin result to its corresponding M1 scalar family.
-    ///
-    /// This is the named output boundary for builtin implementations that are
-    /// migrated by issue #38. Signed and unsigned results are range checked;
-    /// legacy floats round to binary32 and reject finite overflow. Non-numeric
-    /// results already use their final representation and pass through.
-    pub(crate) fn restore_legacy_builtin_result(self) -> Result<Self, EvalError> {
-        match self {
-            Self::Int(value) => i32::try_from(value)
-                .map(Self::m1_integer)
-                .map_err(|_| numeric_width_error(&Self::Int(value), "Integer (i32)")),
-            Self::Uint(value) => u32::try_from(value)
-                .map(Self::m1_unsigned)
-                .map_err(|_| numeric_width_error(&Self::Uint(value), "UnsignedInteger (u32)")),
-            Self::Float(value) => Self::Float(value)
-                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
-                .map(Self::M1),
-            value => Ok(value),
-        }
-    }
-
-    /// Widen an M1 scalar for a legacy builtin implementation.
-    ///
-    /// This is the named input boundary paired with
-    /// [`Value::restore_legacy_builtin_result`]. It is deliberately unavailable as
-    /// a general evaluator coercion.
-    pub(crate) fn into_legacy_builtin_argument(self) -> Self {
-        match self {
-            Self::M1(value) => value.into_legacy_value(),
-            value => value,
-        }
-    }
-
-    /// Coerce a numeric value to `f64`. Non-numeric values are a `TypeError`;
-    /// we never invent a default number.
-    pub fn as_f64(&self) -> Result<f64, EvalError> {
-        match self {
-            Value::Float(x) => Ok(*x),
-            Value::Int(x) => Ok(*x as f64),
-            Value::Uint(x) => Ok(*x as f64),
-            Value::M1(value) => Ok(value.as_f64()),
-            other => Err(EvalError::TypeError {
-                detail: format!("{other:?} is not numeric"),
-            }),
-        }
-    }
-
-    /// Convert a numeric value to its unambiguous M1-width representation.
-    ///
-    /// Existing M1 values pass through unchanged. Legacy `Int` and `Uint` values
-    /// map to their matching M1 integer types. A legacy [`Value::Float`] is
-    /// ambiguous because it may represent either M1 `FloatingPoint` or
-    /// `FixedPoint7dps`, so this convenience method rejects it. Use
-    /// [`Value::try_as_m1_scalar_for`] at typed migration boundaries.
-    pub fn try_as_m1_scalar(&self) -> Result<M1Scalar, EvalError> {
-        match self {
-            Value::M1(value) => Ok(*value),
-            Value::Int(_) => self.try_as_m1_scalar_for(M1ScalarKind::Integer),
-            Value::Uint(_) => self.try_as_m1_scalar_for(M1ScalarKind::UnsignedInteger),
-            Value::Float(_) => Err(EvalError::TypeError {
-                detail: format!(
-                    "{self:?} is ambiguous between M1 FloatingPoint and FixedPoint7dps; use Value::try_as_m1_scalar_for"
-                ),
-            }),
-            other => Err(EvalError::TypeError {
-                detail: format!("{other:?} is not numeric"),
-            }),
-        }
-    }
-
-    /// Restore a value at a typed legacy-to-M1 compatibility boundary.
-    ///
-    /// This conversion restores storage identity; it is not a language cast.
-    /// Legacy `Int`, `Uint`, and `Float` values must target their corresponding
-    /// storage family. `Float` may target either `FloatingPoint` or
-    /// `FixedPoint7dps`, which resolves the ambiguity in the legacy model.
-    /// Fixed Point restoration accepts only values exactly produced by the 7dps
-    /// scale, so it recovers the original raw `i32` without applying the rounding
-    /// or range-validation rules owned by `Convert.ToFixed7DP`.
-    pub fn try_as_m1_scalar_for(&self, target: M1ScalarKind) -> Result<M1Scalar, EvalError> {
-        match (self, target) {
-            (Value::M1(value), target) if value.kind() == target => Ok(*value),
-            (Value::M1(value), target) => Err(incompatible_scalar_kind(*value, target)),
-            (Value::Int(value), M1ScalarKind::Integer) => i32::try_from(*value)
-                .map(M1Scalar::Integer)
-                .map_err(|_| numeric_width_error(self, "Integer (i32)")),
-            (Value::Uint(value), M1ScalarKind::UnsignedInteger) => u32::try_from(*value)
-                .map(M1Scalar::UnsignedInteger)
-                .map_err(|_| numeric_width_error(self, "UnsignedInteger (u32)")),
-            (Value::Float(value), M1ScalarKind::FloatingPoint) => {
-                let narrowed = *value as f32;
-                if value.is_finite() && narrowed.is_infinite() {
-                    Err(numeric_width_error(self, "FloatingPoint (binary32)"))
-                } else {
-                    Ok(M1Scalar::FloatingPoint(narrowed))
-                }
-            }
-            (Value::Float(value), M1ScalarKind::FixedPoint7dps) => {
-                restore_fixed_point_7dps(self, *value).map(M1Scalar::FixedPoint7dps)
-            }
-            (Value::Int(_) | Value::Uint(_) | Value::Float(_), target) => {
-                Err(incompatible_legacy_kind(self, target))
-            }
-            (other, _) => Err(EvalError::TypeError {
-                detail: format!("{other:?} is not numeric"),
-            }),
-        }
-    }
-
-    /// Identify the temporary host-width numeric form, if this value uses one.
-    /// This makes remaining legacy traffic countable during the migration.
-    pub const fn legacy_numeric_kind(&self) -> Option<LegacyNumericKind> {
-        match self {
-            Value::Int(_) => Some(LegacyNumericKind::Int64),
-            Value::Uint(_) => Some(LegacyNumericKind::Uint64),
-            Value::Float(_) => Some(LegacyNumericKind::Float64),
-            _ => None,
-        }
-    }
-
-    /// Whether this is either an M1-width or temporary legacy numeric value.
+    /// Whether this value is numeric.
     pub const fn is_numeric(&self) -> bool {
-        matches!(
-            self,
-            Value::Int(_) | Value::Uint(_) | Value::Float(_) | Value::M1(_)
-        )
+        matches!(self, Value::M1(_))
     }
 
     /// Extract a boolean. M1 has no truthiness on numbers, so only `Bool`
@@ -376,48 +276,6 @@ impl Value {
     }
 }
 
-fn numeric_width_error(value: &Value, target: &str) -> EvalError {
-    EvalError::TypeError {
-        detail: format!("{value:?} is outside the range of M1 {target}"),
-    }
-}
-
-fn incompatible_scalar_kind(value: M1Scalar, target: M1ScalarKind) -> EvalError {
-    EvalError::TypeError {
-        detail: format!(
-            "M1 {:?} cannot be restored as M1 {target:?}; language casts are not compatibility conversions",
-            value.kind()
-        ),
-    }
-}
-
-fn incompatible_legacy_kind(value: &Value, target: M1ScalarKind) -> EvalError {
-    EvalError::TypeError {
-        detail: format!(
-            "{value:?} cannot restore M1 {target:?}; language casts are not compatibility conversions"
-        ),
-    }
-}
-
-fn restore_fixed_point_7dps(source: &Value, value: f64) -> Result<FixedPoint7dps, EvalError> {
-    if !value.is_finite() {
-        return Err(numeric_width_error(source, "FixedPoint7dps"));
-    }
-
-    let scaled = value * FixedPoint7dps::SCALE as f64;
-    if scaled < f64::from(i32::MIN) || scaled > f64::from(i32::MAX) {
-        return Err(numeric_width_error(source, "FixedPoint7dps"));
-    }
-
-    let restored = FixedPoint7dps::from_raw(scaled.round() as i32);
-    if restored.as_f64().to_bits() != value.to_bits() {
-        return Err(EvalError::TypeError {
-            detail: format!("{source:?} is not an exact M1 FixedPoint7dps compatibility value"),
-        });
-    }
-    Ok(restored)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -431,8 +289,6 @@ mod tests {
             .expect("enums fixture loads")
             .project
     }
-
-    // ---- as_enum_int (.AsInteger over EnumType.members) ----
 
     #[test]
     fn as_enum_int_returns_container_order_not_ordinal() {
@@ -473,157 +329,14 @@ mod tests {
     #[test]
     fn as_enum_int_on_non_enum_fails_loud() {
         let project = enums_project();
-        match Value::Int(3).as_enum_int(&project) {
+        match Value::m1_integer(3).as_enum_int(&project) {
             Err(EvalError::TypeError { .. }) => {}
             other => panic!("expected TypeError on non-enum value, got {other:?}"),
         }
     }
 
     #[test]
-    fn float_and_int_coerce_to_f64() {
-        assert_eq!(Value::Float(2.5).as_f64().unwrap(), 2.5);
-        assert_eq!(Value::Int(-3).as_f64().unwrap(), -3.0);
-        assert_eq!(Value::Uint(7).as_f64().unwrap(), 7.0);
-        assert_eq!(
-            Value::M1(M1Scalar::FloatingPoint(2.5)).as_f64().unwrap(),
-            2.5
-        );
-        assert_eq!(
-            Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(
-                12_345_678
-            )))
-            .as_f64()
-            .unwrap(),
-            1.2345678
-        );
-        assert!(Value::Str("x".into()).as_f64().is_err());
-    }
-
-    #[test]
-    fn m1_scalar_boundaries_are_explicit() {
-        assert_eq!(
-            Value::Int(i64::from(i32::MIN)).try_as_m1_scalar().unwrap(),
-            M1Scalar::Integer(i32::MIN)
-        );
-        assert_eq!(
-            Value::Int(i64::from(i32::MAX)).try_as_m1_scalar().unwrap(),
-            M1Scalar::Integer(i32::MAX)
-        );
-        assert!(
-            Value::Int(i64::from(i32::MIN) - 1)
-                .try_as_m1_scalar()
-                .is_err()
-        );
-        assert!(
-            Value::Int(i64::from(i32::MAX) + 1)
-                .try_as_m1_scalar()
-                .is_err()
-        );
-
-        assert_eq!(
-            Value::Uint(0).try_as_m1_scalar().unwrap(),
-            M1Scalar::UnsignedInteger(0)
-        );
-        assert_eq!(
-            Value::Uint(u64::from(u32::MAX)).try_as_m1_scalar().unwrap(),
-            M1Scalar::UnsignedInteger(u32::MAX)
-        );
-        assert!(
-            Value::Uint(u64::from(u32::MAX) + 1)
-                .try_as_m1_scalar()
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn binary32_conversion_exposes_precision_and_range() {
-        let narrowed = Value::Float(16_777_217.0)
-            .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
-            .unwrap();
-        assert_eq!(narrowed, M1Scalar::FloatingPoint(16_777_216.0));
-        assert_eq!(narrowed.into_legacy_value(), Value::Float(16_777_216.0));
-
-        assert_eq!(
-            Value::Float(f64::from(f32::MIN))
-                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
-                .unwrap(),
-            M1Scalar::FloatingPoint(f32::MIN)
-        );
-        assert_eq!(
-            Value::Float(f64::from(f32::MAX))
-                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
-                .unwrap(),
-            M1Scalar::FloatingPoint(f32::MAX)
-        );
-        let smallest_subnormal = f32::from_bits(1);
-        assert_eq!(
-            Value::Float(f64::from(smallest_subnormal))
-                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
-                .unwrap(),
-            M1Scalar::FloatingPoint(smallest_subnormal)
-        );
-        let negative_zero = Value::Float(-0.0)
-            .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
-            .unwrap();
-        assert!(matches!(
-            negative_zero,
-            M1Scalar::FloatingPoint(value) if value.to_bits() == (-0.0_f32).to_bits()
-        ));
-        assert!(
-            Value::Float(f64::MAX)
-                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
-                .is_err()
-        );
-        assert!(matches!(
-            Value::Float(f64::NAN).try_as_m1_scalar_for(M1ScalarKind::FloatingPoint),
-            Ok(M1Scalar::FloatingPoint(value)) if value.is_nan()
-        ));
-        assert_eq!(
-            Value::Float(f64::NEG_INFINITY)
-                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
-                .unwrap(),
-            M1Scalar::FloatingPoint(f32::NEG_INFINITY)
-        );
-    }
-
-    #[test]
-    fn inferred_conversion_rejects_ambiguous_legacy_float_storage() {
-        assert!(Value::Float(1.0).try_as_m1_scalar().is_err());
-        assert_eq!(
-            Value::Int(-1).try_as_m1_scalar().unwrap(),
-            M1Scalar::Integer(-1)
-        );
-        assert_eq!(
-            Value::Uint(1).try_as_m1_scalar().unwrap(),
-            M1Scalar::UnsignedInteger(1)
-        );
-
-        let fixed = M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(1));
-        assert_eq!(Value::M1(fixed).try_as_m1_scalar().unwrap(), fixed);
-    }
-
-    #[test]
-    fn every_m1_scalar_has_an_explicit_legacy_compatibility_conversion() {
-        assert_eq!(
-            M1Scalar::Integer(i32::MIN).into_legacy_value(),
-            Value::Int(i64::from(i32::MIN))
-        );
-        assert_eq!(
-            M1Scalar::UnsignedInteger(u32::MAX).into_legacy_value(),
-            Value::Uint(u64::from(u32::MAX))
-        );
-        assert_eq!(
-            M1Scalar::FloatingPoint(f32::MIN_POSITIVE).into_legacy_value(),
-            Value::Float(f64::from(f32::MIN_POSITIVE))
-        );
-        assert_eq!(
-            M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(-1)).into_legacy_value(),
-            Value::Float(-0.0000001)
-        );
-    }
-
-    #[test]
-    fn every_m1_scalar_kind_round_trips_through_legacy_storage() {
+    fn every_m1_scalar_family_keeps_its_runtime_width() {
         let scalars = [
             M1Scalar::FloatingPoint(-0.0),
             M1Scalar::FloatingPoint(f32::from_bits(1)),
@@ -638,52 +351,45 @@ mod tests {
         ];
 
         for scalar in scalars {
-            let legacy = scalar.into_legacy_value();
-            let restored = legacy.try_as_m1_scalar_for(scalar.kind()).unwrap();
-            assert_eq!(restored, scalar, "failed to restore {scalar:?}");
+            let value = Value::M1(scalar);
+            assert_eq!(value.m1_scalar().unwrap(), scalar);
+            assert!(value.is_numeric());
         }
     }
 
     #[test]
-    fn fixed_point_legacy_round_trip_restores_exact_raw_storage() {
-        for raw in [i32::MIN, -12_345_678, -1, 0, 1, 12_345_678, i32::MAX] {
-            let scalar = M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(raw));
-            let legacy = scalar.into_legacy_value();
-            assert_eq!(
-                legacy
-                    .try_as_m1_scalar_for(M1ScalarKind::FixedPoint7dps)
-                    .unwrap(),
-                scalar,
-                "failed to restore fixed-point raw value {raw}"
-            );
+    fn fixed_point_decimal_parser_is_exact_at_storage_boundaries() {
+        for (text, raw) in [
+            ("-214.7483648", i32::MIN),
+            ("-1.2345678", -12_345_678),
+            ("-0.0000001", -1),
+            ("0", 0),
+            (".0000001", 1),
+            ("1.234567800", 12_345_678),
+            ("1.0000000000000000000000000000000000000000", 10_000_000),
+            ("12345678e-7", 12_345_678),
+            ("214.7483647", i32::MAX),
+        ] {
+            assert_eq!(FixedPoint7dps::parse_decimal(text).unwrap().raw(), raw);
         }
-    }
-
-    #[test]
-    fn fixed_point_compatibility_restore_rejects_lossy_values_and_language_casts() {
-        for value in [1.23456789, -0.0, 214.7483648, f64::NAN, f64::INFINITY] {
+        for text in [
+            "214.7483648",
+            "-214.7483649",
+            "1.23456781",
+            "1e1000",
+            "NaN",
+            "Infinity",
+            "",
+        ] {
             assert!(
-                Value::Float(value)
-                    .try_as_m1_scalar_for(M1ScalarKind::FixedPoint7dps)
-                    .is_err(),
-                "unexpectedly restored {value:?} as exact fixed point"
+                FixedPoint7dps::parse_decimal(text).is_none(),
+                "accepted {text:?}"
             );
         }
-
-        assert!(
-            Value::Int(1)
-                .try_as_m1_scalar_for(M1ScalarKind::FloatingPoint)
-                .is_err()
-        );
-        assert!(
-            Value::M1(M1Scalar::Integer(1))
-                .try_as_m1_scalar_for(M1ScalarKind::UnsignedInteger)
-                .is_err()
-        );
     }
 
     #[test]
-    fn fixed_point_7dps_uses_signed_scaled_i32_storage() {
+    fn fixed_point_storage_formats_and_widens_exactly() {
         let positive = FixedPoint7dps::from_raw(12_345_678);
         let negative = FixedPoint7dps::from_raw(-12_345_678);
         assert_eq!(positive.raw(), 12_345_678);
@@ -692,38 +398,20 @@ mod tests {
         assert_eq!(FixedPoint7dps::ZERO.as_f64(), 0.0);
         assert_eq!(FixedPoint7dps::MIN.as_f64(), -214.7483648);
         assert_eq!(FixedPoint7dps::MAX.as_f64(), 214.7483647);
-
-        assert_eq!(
-            M1Scalar::FixedPoint7dps(positive).into_legacy_value(),
-            Value::Float(1.2345678)
-        );
+        assert_eq!(positive.to_string(), "1.2345678");
+        assert_eq!(FixedPoint7dps::MIN.to_string(), "-214.7483648");
+        assert_eq!(FixedPoint7dps::MAX.to_string(), "214.7483647");
     }
 
     #[test]
-    fn legacy_numeric_forms_are_measurable() {
-        assert_eq!(
-            Value::Int(0).legacy_numeric_kind(),
-            Some(LegacyNumericKind::Int64)
-        );
-        assert_eq!(
-            Value::Uint(0).legacy_numeric_kind(),
-            Some(LegacyNumericKind::Uint64)
-        );
-        assert_eq!(
-            Value::Float(0.0).legacy_numeric_kind(),
-            Some(LegacyNumericKind::Float64)
-        );
-        assert_eq!(Value::M1(M1Scalar::Integer(0)).legacy_numeric_kind(), None);
-        assert_eq!(Value::Bool(false).legacy_numeric_kind(), None);
-    }
-
-    #[test]
-    fn enum_is_not_numeric() {
+    fn non_numeric_values_fail_numeric_access() {
         let v = Value::Enum {
             id: 1,
             member: "On".into(),
         };
-        assert!(v.as_f64().is_err());
+        assert!(v.m1_scalar().is_err());
+        assert!(!v.is_numeric());
+        assert!(Value::Str("x".into()).m1_scalar().is_err());
     }
 
     #[test]
@@ -731,22 +419,14 @@ mod tests {
         assert!(Value::Bool(true).as_bool().unwrap());
         assert!(!Value::Bool(false).as_bool().unwrap());
         // M1 is strongly typed: no int->bool.
-        assert!(Value::Int(1).as_bool().is_err());
-        assert!(Value::Float(0.0).as_bool().is_err());
+        assert!(Value::m1_integer(1).as_bool().is_err());
+        assert!(Value::m1_float(0.0).as_bool().is_err());
     }
 
     #[test]
     fn truthy_forwards_to_as_bool() {
         assert!(Value::Bool(true).truthy().unwrap());
         assert!(!Value::Bool(false).truthy().unwrap());
-        assert!(Value::Uint(0).truthy().is_err());
-    }
-
-    #[test]
-    fn as_f64_error_is_type_error() {
-        match Value::Str("nope".into()).as_f64() {
-            Err(EvalError::TypeError { .. }) => {}
-            other => panic!("expected TypeError, got {other:?}"),
-        }
+        assert!(Value::m1_unsigned(0).truthy().is_err());
     }
 }

--- a/tests/ld_smoke.rs
+++ b/tests/ld_smoke.rs
@@ -156,7 +156,8 @@ fn real_ld_header_and_channels_decode() {
         let mut all_finite = true;
         for (_, v) in points {
             let x = v
-                .as_f64()
+                .m1_scalar()
+                .map(m1_eval::M1Scalar::as_f64)
                 .unwrap_or_else(|e| panic!("channel {:?} value not numeric: {e}", series.channel));
             total_values += 1;
             if !x.is_finite() {
@@ -202,7 +203,7 @@ fn real_ld_header_and_channels_decode() {
             continue;
         };
         for (t, v) in points {
-            if let Ok(x) = v.as_f64()
+            if let Ok(x) = v.m1_scalar().map(m1_eval::M1Scalar::as_f64)
                 && x.is_finite()
             {
                 sample_report = Some((series.channel.clone(), *t, x));

--- a/tests/numeric_model.rs
+++ b/tests/numeric_model.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Regression guard for the final M1-width runtime numeric model.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn rust_sources(dir: &Path, files: &mut Vec<PathBuf>) {
+    let mut entries = fs::read_dir(dir)
+        .expect("source directory is readable")
+        .map(|entry| entry.expect("source entry is readable").path())
+        .collect::<Vec<_>>();
+    entries.sort();
+    for path in entries {
+        if path.is_dir() {
+            rust_sources(&path, files);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            files.push(path);
+        }
+    }
+}
+
+fn has_path_token(source: &str, token: &str) -> bool {
+    source.match_indices(token).any(|(offset, _)| {
+        source[..offset]
+            .chars()
+            .next_back()
+            .is_none_or(|before| !before.is_ascii_alphanumeric() && before != '_')
+    })
+}
+
+#[test]
+fn runtime_source_has_no_host_width_value_variants_or_adapters() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rust_sources(&root, &mut files);
+
+    let value_paths =
+        ["Int", "Uint", "Float"].map(|variant| ["Value", "::", variant, "("].concat());
+    let removed_names = [
+        ["Legacy", "Numeric", "Kind"].concat(),
+        ["into", "_legacy", "_value"].concat(),
+        ["into", "_legacy", "_builtin", "_argument"].concat(),
+        ["legacy", "_builtin", "_arguments"].concat(),
+        ["restore", "_legacy", "_builtin", "_result"].concat(),
+        ["try", "_as", "_m1", "_scalar"].concat(),
+        ["legacy", "_numeric", "_kind"].concat(),
+    ];
+
+    let value_source = fs::read_to_string(root.join("value.rs")).expect("value.rs is UTF-8");
+    for variant in ["Int", "Uint", "Float"] {
+        let declaration = ["\n    ", variant, "("].concat();
+        assert!(
+            !value_source.contains(&declaration),
+            "value.rs still declares removed runtime variant {variant}"
+        );
+    }
+
+    for path in files {
+        let source = fs::read_to_string(&path).expect("Rust source is UTF-8");
+        for token in &value_paths {
+            assert!(
+                !has_path_token(&source, token),
+                "{} still contains removed runtime path {token}",
+                path.display()
+            );
+        }
+        for name in &removed_names {
+            assert!(
+                !source.contains(name),
+                "{} still contains removed numeric adapter {name}",
+                path.display()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- remove the legacy host-width numeric `Value` variants and compatibility adapters
- route arithmetic, builtins, state, calibration, tables, scenarios, logs, and traces through the four M1 scalar families
- preserve `f64` only for scheduler timing, reporting, and deliberate exact interpolation/wire conversion boundaries
- add regression coverage for overflow, rounding, conversion, comparison, fixed-point parsing, timing precision, and serialization

## Validation

- `cargo test --locked --all-targets`
- `cargo test --locked --all-targets --features ld`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `cargo +1.88.0 check --locked --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- AV coverage and EV trigger-resolution smoke
- two independent exact-head reviews

The two broader EV execution failures also occur identically on the parent commit and are not regressions from this change. No suitable real M1 `.ld` corpus was available; the optional proprietary smoke remains environment-gated.

Closes #39
