### PR TITLE
fix: restore EV and AV whole-project smokes

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,20 @@ m1-eval --project Project.m1prj --coverage
 See [`docs/cli.md`](docs/cli.md) for the full flag list, the scenario file
 format, and the exit-code contract.
 
+The real-project smoke tests remain read-only and keep proprietary files out of
+the repository. Point each variable at a corpus repository root, version
+directory, or exact `Project.m1prj`; the tests discover the matching project and
+root `parameters.m1cfg`, then report every substituted input:
+
+```sh
+M1_EVAL_EVM1_DIR=/path/to/EV-M1 \
+M1_EVAL_AVM1_DIR=/path/to/av-firmware \
+  cargo test --test evm1_smoke -- --nocapture
+```
+
+Either corpus test prints a clear skip reason when its variable is absent; the
+available corpus still runs, and neither test is ignored.
+
 ## What it adds (Phase 3 — log-driven counterfactual replay)
 
 **Phase 3** is the headline feature. Import a recorded MoTeC run, treat every

--- a/src/builtins/enum_conv.rs
+++ b/src/builtins/enum_conv.rs
@@ -24,12 +24,23 @@
 //! `.` — never on whitespace.
 
 use crate::error::EvalError;
-use crate::expr::EvalCtx;
+use crate::expr::{EvalCtx, coerce_for_declared_type};
 use crate::ident::{Target, classify};
 use crate::value::Value;
 use m1_typecheck::Project;
-use m1_typecheck::symbols::SymbolKind;
+use m1_typecheck::symbols::{EnumId, SymbolKind};
+use m1_typecheck::types::ValueType;
 use std::collections::{HashMap, HashSet};
+
+/// The concrete channel that stores an enum source and its authoritative type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EnumValueSource {
+    path: String,
+    enum_id: EnumId,
+    /// Package-generated storage may expose the enum's integer representation;
+    /// ordinary typed sources retain the stricter enum-value contract.
+    numeric_storage: bool,
+}
 
 /// Convert `<object>.AsInteger()` to its declared enum integer.
 ///
@@ -103,29 +114,33 @@ fn enum_value(object: &str, ctx: &mut EvalCtx) -> Result<Option<Value>, EvalErro
         // fall through to other dispatch.
         return Ok(None);
     };
-    let Some(value_path) = enum_value_path(&canon, ctx.project) else {
+    let Some(source) = enum_value_source(&canon, ctx.project) else {
         return Ok(None);
     };
-    read_enum_at(&value_path, ctx).map(Some)
+    read_enum_at(&source, ctx).map(Some)
 }
 
 /// Resolve an enum-valued project object to the symbol `read_symbol` consumes.
 /// Constants and direct typed objects keep their own path. A value compound
 /// follows its declared default, then its generated `.Value` child.
 pub(crate) fn enum_value_path(canon: &str, project: &Project) -> Option<String> {
-    enum_value_path_inner(canon, project, &mut HashSet::new())
+    enum_value_source(canon, project).map(|source| source.path)
 }
 
-fn enum_value_path_inner(
+fn enum_value_source(canon: &str, project: &Project) -> Option<EnumValueSource> {
+    enum_value_source_inner(canon, project, &mut HashSet::new())
+}
+
+fn enum_value_source_inner(
     canon: &str,
     project: &Project,
     seen: &mut HashSet<String>,
-) -> Option<String> {
+) -> Option<EnumValueSource> {
     if !seen.insert(canon.to_string()) {
         return None;
     }
     let symbol = project.symbols().get(canon)?;
-    if symbol.value_type.is_enum()
+    if let ValueType::Enum(enum_id) = symbol.value_type
         && matches!(
             symbol.kind,
             SymbolKind::Channel
@@ -136,7 +151,11 @@ fn enum_value_path_inner(
                 | SymbolKind::Other
         )
     {
-        return Some(canon.to_string());
+        return Some(EnumValueSource {
+            path: canon.to_string(),
+            enum_id,
+            numeric_storage: false,
+        });
     }
 
     if symbol.kind == SymbolKind::Group
@@ -144,9 +163,42 @@ fn enum_value_path_inner(
     {
         let locals = HashMap::new();
         if let Target::Symbol(path) = classify(default, Some(canon), None, project, &locals)
-            && let Some(value_path) = enum_value_path_inner(&path, project, seen)
+            && let Some(source) = enum_value_source_inner(&path, project, seen)
         {
-            return Some(value_path);
+            return Some(source);
+        }
+    }
+
+    // `MoTeC Input.Sensor` generates an untyped `Diagnostic.Value` channel.
+    // M1 nevertheless exposes the compound as `Sensor Diagnostic Enumeration`:
+    // real scripts compare `Sensor.Diagnostic.AsInteger()` with members of that
+    // catalogue enum. Recover the omitted type from the package class and the
+    // generated child shape, never from a corpus-specific symbol path.
+    if symbol.kind == SymbolKind::Group
+        && canon
+            .rsplit_once('.')
+            .is_some_and(|(_, leaf)| leaf == "Diagnostic")
+        && let Some((owner, _)) = canon.rsplit_once('.')
+        && project
+            .symbols()
+            .get(owner)
+            .and_then(|owner| owner.classname.as_deref())
+            == Some("MoTeC Input.Sensor")
+        && let Some(enum_id) = project
+            .symbols()
+            .enum_by_name("Sensor Diagnostic Enumeration")
+    {
+        let path = format!("{canon}.Value");
+        if project
+            .symbols()
+            .get(&path)
+            .is_some_and(|value| value.kind == SymbolKind::Channel)
+        {
+            return Some(EnumValueSource {
+                path,
+                enum_id,
+                numeric_storage: true,
+            });
         }
     }
 
@@ -158,7 +210,7 @@ fn enum_value_path_inner(
         return project
             .symbols()
             .get(&value_path)
-            .and_then(|_| enum_value_path_inner(&value_path, project, seen));
+            .and_then(|_| enum_value_source_inner(&value_path, project, seen));
     }
     None
 }
@@ -168,16 +220,22 @@ fn enum_value_path_inner(
 /// the same semantics as a plain read: a written/seeded value, else (in
 /// whole-project mode) the channel's externally-driven enum startup default, else
 /// — in single-function/cone mode — a fail-loud [`EvalError::MissingInput`]. A
-/// non-enum value is a `TypeError` (never a guessed integer).
-fn read_enum_at(canon: &str, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
-    let value = crate::expr::read_symbol(canon, ctx)?;
-    if matches!(value, Value::Enum { .. }) {
-        Ok(value)
-    } else {
-        Err(EvalError::TypeError {
-            detail: format!("value at {canon:?} is not an enum value"),
-        })
+/// typed enum source must already contain that enum. A package-derived source may
+/// contain the generated numeric representation, which is validated and restored
+/// through its catalogue enum id.
+fn read_enum_at(source: &EnumValueSource, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
+    let value = crate::expr::read_symbol(&source.path, ctx)?;
+    if !source.numeric_storage && !matches!(value, Value::Enum { .. }) {
+        return Err(EvalError::TypeError {
+            detail: format!("value at {:?} is not an enum value", source.path),
+        });
     }
+    coerce_for_declared_type(
+        &source.path,
+        value,
+        ValueType::Enum(source.enum_id),
+        ctx.project,
+    )
 }
 
 #[cfg(test)]
@@ -309,6 +367,54 @@ mod tests {
         assert_eq!(
             h.as_int("Root.Demo.Compound").unwrap(),
             Some(Value::m1_integer(0))
+        );
+    }
+
+    #[test]
+    fn sensor_diagnostic_recovers_catalogue_enum_from_package_shape() {
+        let mut h = Harness::new();
+        let diagnostic_id = h
+            .project
+            .symbols()
+            .enum_by_name("Sensor Diagnostic Enumeration")
+            .expect("firmware diagnostic enum is registered");
+        assert_eq!(
+            enum_value_source("Root.Demo.Sensor.Diagnostic", &h.project),
+            Some(EnumValueSource {
+                path: "Root.Demo.Sensor.Diagnostic.Value".to_string(),
+                enum_id: diagnostic_id,
+                numeric_storage: true,
+            })
+        );
+
+        // Package-generated Diagnostic.Value is untyped in the project XML.
+        // Its numeric storage is interpreted through the authoritative enum,
+        // including non-zero members, before AsInteger converts it back.
+        h.env
+            .set("Root.Demo.Sensor.Diagnostic.Value", Value::m1_integer(1));
+        assert_eq!(
+            h.as_int("Sensor.Diagnostic").unwrap(),
+            Some(Value::m1_integer(1))
+        );
+    }
+
+    #[test]
+    fn arbitrary_untyped_diagnostic_group_is_not_an_enum_source() {
+        let h = Harness::new();
+        assert_eq!(
+            enum_value_source("Root.Demo.Service Bits", &h.project),
+            None,
+            "an untyped group must not acquire a diagnostic enum by name alone"
+        );
+    }
+
+    #[test]
+    fn typed_enum_source_does_not_accept_untyped_numeric_storage() {
+        let mut h = Harness::new();
+        h.env.set("Root.Demo.Mode", Value::m1_integer(0));
+        assert!(
+            matches!(h.as_int("Mode"), Err(EvalError::TypeError { .. })),
+            "only the catalogue-backed package source may restore numeric storage"
         );
     }
 

--- a/src/builtins/io_stub.rs
+++ b/src/builtins/io_stub.rs
@@ -133,11 +133,12 @@ fn library_return_type(object: &str, method: &str) -> Option<&'static str> {
 /// - `Integer` → `0`,
 /// - `UnsignedInteger` → `0`,
 /// - `String` → `""`,
+/// - `Handle` → an opaque unsigned-zero handle, matching the M1 storage family
+///   used when scripts pass handles between calls,
 /// - `Void` → the benign unit (`Bool(true)`) the void side-effect writers use,
-/// - anything else (`Handle`, `Bit`, `Enumeration`, an `Integer|FloatingPoint`
-///   union) → the benign unit `Bool(true)`: a transmit/receive handle or a single
-///   bus bit has no determinate numeric offline value, so we return the unit
-///   rather than invent one.
+/// - anything else (`Bit`, `Enumeration`, an `Integer|FloatingPoint` union) →
+///   the benign unit `Bool(true)` because the catalogue does not expose a runtime
+///   representation for it.
 ///
 /// All overloads of a method declare the same return type in the IO objects, so
 /// the first overload's `returns` fixes the default. An empty overload set means
@@ -152,9 +153,13 @@ fn typed_io_default(object: &str, method: &str) -> Option<Value> {
         "Integer" => Value::m1_integer(0),
         "UnsignedInteger" => Value::m1_unsigned(0),
         "String" => Value::Str(String::new()),
-        // `Void` writers and any unmappable return (`Handle`, `Bit`,
-        // `Enumeration`, the `Integer|FloatingPoint` union) collapse to the benign
-        // unit value, matching the void side-effect convention used elsewhere.
+        // Handles are opaque, but M1 scripts store and pass them as unsigned
+        // integers. Zero is the deterministic offline handle and cannot be
+        // mistaken for a live bus resource.
+        "Handle" => Value::m1_unsigned(0),
+        // `Void` writers and any other unmappable return (`Bit`, `Enumeration`,
+        // the `Integer|FloatingPoint` union) collapse to the benign unit value,
+        // matching the void side-effect convention used elsewhere.
         _ => Value::Bool(true),
     })
 }
@@ -172,11 +177,15 @@ fn coerce_hardware_value(
         Some("UnsignedInteger") => {
             coerce_for_scalar_kind(&key, value, M1ScalarKind::UnsignedInteger)
         }
+        // Handles are opaque tokens, represented by the unsigned storage
+        // family at script boundaries. Apply the same rule to adapter/scenario
+        // replies as to the deterministic offline handle.
+        Some("Handle") => coerce_for_scalar_kind(&key, value, M1ScalarKind::UnsignedInteger),
         Some("FloatingPoint") => coerce_for_scalar_kind(&key, value, M1ScalarKind::FloatingPoint),
         Some("FixedPoint7dps") => coerce_for_scalar_kind(&key, value, M1ScalarKind::FixedPoint7dps),
         Some("Boolean") => coerce_for_declared_type(&key, value, ValueType::Boolean, ctx.project),
         Some("String") => coerce_for_declared_type(&key, value, ValueType::String, ctx.project),
-        // Void and opaque handles do not have an M1 scalar family to restore.
+        // Void and remaining catalogue-only types have no scalar family to restore.
         _ => Ok(value),
     }
 }
@@ -716,6 +725,23 @@ mod tests {
                 .unwrap(),
             Value::m1_unsigned(u32::MAX - 1)
         );
+
+        h.env
+            .set_io_override("CanComms.RxOpenStandard", Value::m1_integer(-1));
+        assert_eq!(
+            h.io(
+                "CanComms",
+                "RxOpenStandard",
+                &[
+                    Value::m1_unsigned(0),
+                    Value::m1_unsigned(0),
+                    Value::m1_unsigned(0),
+                    Value::m1_unsigned(0),
+                ],
+            )
+            .unwrap(),
+            Value::m1_unsigned(u32::MAX)
+        );
     }
 
     #[test]
@@ -752,11 +778,11 @@ mod tests {
     }
 
     #[test]
-    fn can_open_handle_returns_unit_external_stub() {
+    fn can_open_handle_returns_unsigned_zero_external_stub() {
         let mut h = Harness::new();
         // `CanComms.RxOpenStandard` declares a `Handle` return — an opaque
-        // receive handle with no determinate offline value — so the typed stub is
-        // the benign unit (`Bool(true)`), externally driven, not a fail-loud abort.
+        // receive handle with no live offline resource. M1 scripts store handles
+        // in unsigned locals, so the typed stub is the opaque zero handle.
         assert_eq!(
             h.io(
                 "CanComms",
@@ -769,7 +795,7 @@ mod tests {
                 ],
             )
             .unwrap(),
-            Value::Bool(true)
+            Value::m1_unsigned(0)
         );
         assert!(h.trace.is_external("CanComms.RxOpenStandard"));
     }
@@ -1245,7 +1271,7 @@ mod tests {
         // The generic fallback maps each registry return type to its zero/unit.
         // `GetFloat` → FloatingPoint, `GetID` → Integer, `BusRxTotal` →
         // UnsignedInteger, `RxMessage` → Boolean, `SetFloat` → Void,
-        // `RxOpenStandard` → Handle (unmappable → unit).
+        // `RxOpenStandard` → Handle (opaque unsigned zero).
         assert_eq!(
             typed_io_default("CanComms", "GetFloat"),
             Some(Value::m1_float(0.0))
@@ -1272,7 +1298,7 @@ mod tests {
         );
         assert_eq!(
             typed_io_default("CanComms", "RxOpenStandard"),
-            Some(Value::Bool(true))
+            Some(Value::m1_unsigned(0))
         );
         // A method not in the registry → None (the caller fails loud).
         assert_eq!(typed_io_default("CanComms", "NotARealMethod"), None);

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1671,6 +1671,17 @@ mod tests {
                 &loaded,
                 Some("Root.Demo"),
                 Some("Root.Demo.Update"),
+                "Sensor.Diagnostic",
+                "AsInteger"
+            ),
+            BuiltinSupport::Direct,
+            "package-generated sensor diagnostics use the catalogue enum"
+        );
+        assert_eq!(
+            support_in(
+                &loaded,
+                Some("Root.Demo"),
+                Some("Root.Demo.Update"),
                 "Drive State.Idle",
                 "AsString"
             ),
@@ -2643,7 +2654,7 @@ mod tests {
         // Logging) handled by the generic typed fallback must classify as
         // Stubbed, so coverage stays consistent with runtime dispatch.
         let cases = [
-            ("CanComms", "RxOpenStandard"),     // Handle -> unit stub
+            ("CanComms", "RxOpenStandard"),     // Handle -> unsigned-zero stub
             ("CanComms", "GetFloat"),           // FloatingPoint -> 0.0
             ("CanComms", "GetUnsignedInteger"), // Integer -> 0
             ("CanComms", "RxMessage"),          // Boolean -> false

--- a/src/calib.rs
+++ b/src/calib.rs
@@ -19,12 +19,14 @@
 //! - A `<Parameter Name="...">` holds a single `<Cell Type="..." Unit="...">`.
 //!   Cell content may be a `<![CDATA[...]]>` block or plain text; `roxmltree`'s
 //!   `Node::text()` returns the CDATA content either way.
-//! - Numbers may be in scientific notation (e.g. `1.0000e-003`). They are parsed
+//! - Numbers may be in scientific notation (e.g. `1.0000e-003`), and unsigned
+//!   cells may use M1 hexadecimal notation (e.g. `0x400`). They are parsed
 //!   according to the cell's declared type and restored to their M1-width scalar
 //!   family. Untyped and historical `f64` cells narrow to M1 binary32.
-//! - `enum` cells carry a non-numeric member name (e.g. `On`), and `bool` cells
-//!   are not numeric calibration values. Both are skipped here (and surface as
-//!   `MissingCalibration` if some script later reads them as a number).
+//! - Scalar `enum` cells usually carry a member name (e.g. `On`) and are skipped.
+//!   Table enum axes instead contain the enum's numeric integer representation;
+//!   those values are retained as M1 integers. Boolean cells are not numeric
+//!   calibration values and are skipped.
 //! - A `<Table Name="...">` has ordered `<X>`/`<Y>`/`<Z>` axis children, each
 //!   wrapping a `<Cells>` of breakpoint `<Cell>`s, plus a `<Body><Cells>` of
 //!   interpolation values.
@@ -69,8 +71,8 @@ impl Calibration {
     /// Parse a `.m1cfg` document's numeric values from its XML text.
     ///
     /// Malformed XML, unsupported numeric types, and values outside their M1
-    /// storage range fail loud. Enum and Boolean cells are skipped because they
-    /// are not numeric calibration values.
+    /// storage range fail loud. Named enum members and Boolean cells are skipped;
+    /// numeric enum representations (used by table axes) are retained.
     pub fn from_m1cfg_str(xml: &str) -> Result<Calibration, EvalError> {
         let doc = roxmltree::Document::parse(xml).map_err(|e| EvalError::MissingCalibration {
             path: format!(".m1cfg parse error: {e}"),
@@ -84,9 +86,9 @@ impl Calibration {
             let Some(cell) = param.children().find(|c| c.has_tag_name("Cell")) else {
                 continue;
             };
-            // Skip non-numeric cells (enum members and booleans) — they are not
-            // calibration *numbers*. A script that later reads such a value as
-            // a number will fail loud at that read, not here.
+            // Skip named enum members and booleans — they are not calibration
+            // numbers. Numeric enum representations remain available to the
+            // table reader and to unusual scalar exports that use that form.
             if let Some(v) = cell_value(cell, cell.attribute("Type"), name)? {
                 params.insert(name.to_string(), v);
             }
@@ -115,8 +117,9 @@ impl Calibration {
 }
 
 /// Parse one calibration cell according to its declared M1 storage type.
-/// Enum and Boolean cells are non-numeric and return `None`. An absent type uses
-/// the historical untyped-cell rule: numeric cells are parsed as binary32.
+/// Named enum members and Boolean cells are non-numeric and return `None`;
+/// numeric enum representations return an integer. An absent type uses the
+/// historical untyped-cell rule: numeric cells are parsed as binary32.
 fn cell_value(
     cell: roxmltree::Node<'_, '_>,
     declared_type: Option<&str>,
@@ -131,7 +134,21 @@ fn cell_value(
     };
 
     let scalar = match ty {
-        "enum" | "bool" => return Ok(None),
+        "bool" => return Ok(None),
+        "enum" => match text.parse::<f64>() {
+            // Named members belong to the project enum model, not this numeric
+            // calibration store. Keep the existing skip behavior for them.
+            Err(_) => return Ok(None),
+            Ok(value)
+                if value.is_finite()
+                    && value.fract() == 0.0
+                    && value >= f64::from(i32::MIN)
+                    && value <= f64::from(i32::MAX) =>
+            {
+                M1Scalar::Integer(value as i32)
+            }
+            Ok(_) => return Err(width_error()),
+        },
         "f32" | "f64" | "untyped-f32" => {
             let narrowed = text.parse::<f32>().map_err(|_| width_error())?;
             if !narrowed.is_finite() {
@@ -144,8 +161,7 @@ fn cell_value(
             .ok()
             .map(M1Scalar::Integer)
             .ok_or_else(width_error)?,
-        "u8" | "u16" | "u32" | "u64" => text
-            .parse::<u32>()
+        "u8" | "u16" | "u32" | "u64" => parse_unsigned_cell(text)
             .ok()
             .map(M1Scalar::UnsignedInteger)
             .ok_or_else(width_error)?,
@@ -159,6 +175,18 @@ fn cell_value(
         }
     };
     Ok(Some(scalar))
+}
+
+/// Parse the unsigned literal forms emitted by M1 configuration exports.
+/// Decimal and `0x` hexadecimal forms share the evaluator's 32-bit storage
+/// limit. A trailing `u` is accepted for parity with script literals.
+fn parse_unsigned_cell(text: &str) -> Result<u32, std::num::ParseIntError> {
+    let lower = text.to_ascii_lowercase();
+    let body = lower.strip_suffix('u').unwrap_or(&lower);
+    match body.strip_prefix("0x") {
+        Some(hex) => u32::from_str_radix(hex, 16),
+        None => body.parse::<u32>(),
+    }
 }
 
 /// Collect the `<Cell>` breakpoint/body values under a `<Cells>` wrapper found
@@ -306,10 +334,36 @@ mod tests {
     }
 
     #[test]
+    fn numeric_enum_table_axis_uses_integer_representation() {
+        let xml = r#"<Configuration>
+          <Table Name="Root.Enum Curve">
+            <X><Cells Type="enum"><Cell>0.0e+00</Cell><Cell>2.0e+00</Cell></Cells></X>
+            <Body><Cells Type="f32"><Cell>5</Cell><Cell>25</Cell></Cells></Body>
+          </Table>
+        </Configuration>"#;
+        let calibration = Calibration::from_m1cfg_str(xml).unwrap();
+        let table = calibration.table("Root.Enum Curve").unwrap();
+        assert_eq!(
+            table.axes[0],
+            vec![M1Scalar::Integer(0), M1Scalar::Integer(2)]
+        );
+
+        let fractional = r#"<Configuration>
+          <Table Name="Root.Bad Enum Curve">
+            <X><Cells Type="enum"><Cell>0.5</Cell></Cells></X>
+          </Table>
+        </Configuration>"#;
+        let error = Calibration::from_m1cfg_str(fractional).unwrap_err();
+        assert!(format!("{error}").contains("enum"), "{error}");
+    }
+
+    #[test]
     fn cell_types_preserve_signedness_and_reject_width_overflow() {
         let xml = r#"<Configuration>
           <Parameter Name="Signed"><Cell Type="s32">-2147483648</Cell></Parameter>
           <Parameter Name="Unsigned"><Cell Type="u32">4294967295</Cell></Parameter>
+          <Parameter Name="Hex"><Cell Type="u32">0x0400</Cell></Parameter>
+          <Parameter Name="Upper Hex"><Cell Type="u32">0XFFu</Cell></Parameter>
           <Parameter Name="Fixed"><Cell Type="FixedPoint7dps">1.2345678</Cell></Parameter>
         </Configuration>"#;
         let calibration = Calibration::from_m1cfg_str(xml).unwrap();
@@ -320,6 +374,14 @@ mod tests {
         assert_eq!(
             calibration.param("Unsigned"),
             Some(M1Scalar::UnsignedInteger(u32::MAX))
+        );
+        assert_eq!(
+            calibration.param("Hex"),
+            Some(M1Scalar::UnsignedInteger(0x400))
+        );
+        assert_eq!(
+            calibration.param("Upper Hex"),
+            Some(M1Scalar::UnsignedInteger(0xff))
         );
         assert_eq!(
             calibration.param("Fixed"),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -419,6 +419,9 @@ fn read_symbol_inner(
                 return coerce_for_channel(canon, v, ctx.project);
             }
             let symbol = symbol.expect("a matched symbol kind has a symbol");
+            if let Some(value) = configured_enum_parameter_value(symbol, ctx.project)? {
+                return Ok(value);
+            }
             let default = typed_io_input_default(
                 symbol.value_type,
                 symbol.declared_type.as_deref(),
@@ -529,6 +532,41 @@ fn read_symbol_inner(
             name: canon.to_string(),
         }),
     }
+}
+
+/// Recover a named enum calibration cell retained by `m1-typecheck` on its
+/// parameter symbol. [`Calibration`] stores numeric M1 scalars and table cells;
+/// a named enum member instead needs the project's concrete enum id. The loaded
+/// symbol model has already associated that member with its declared enum, so
+/// restore the runtime [`Value::Enum`] here and reject corrupt membership.
+fn configured_enum_parameter_value(
+    symbol: &Symbol,
+    project: &Project,
+) -> Result<Option<Value>, EvalError> {
+    let ValueType::Enum(id) = symbol.value_type else {
+        return Ok(None);
+    };
+    let Some(member) = symbol
+        .static_value
+        .as_deref()
+        .map(str::trim)
+        .filter(|member| !member.is_empty())
+    else {
+        return Ok(None);
+    };
+    if project.symbols().enum_has_member(id, member) {
+        return Ok(Some(Value::Enum {
+            id,
+            member: member.to_string(),
+        }));
+    }
+    Err(EvalError::TypeError {
+        detail: format!(
+            "configured member {member:?} for {:?} does not belong to enum {:?}",
+            symbol.path,
+            project.symbols().enum_type(id).name
+        ),
+    })
 }
 
 /// Parse a constant's project-owned `<Props Value>` directly against its target
@@ -1367,6 +1405,21 @@ mod tests {
             }
         }
 
+        fn configured_enums() -> Harness {
+            let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums");
+            let loaded = crate::loader::load(
+                &dir.join("Project.m1prj"),
+                Some(&dir.join("parameters.m1cfg")),
+            )
+            .expect("configured enums fixture loads");
+            Harness {
+                project: loaded.project,
+                calib: loaded.calib,
+                env: Env::new(),
+                state: StateStore::new(),
+            }
+        }
+
         fn ctx(&mut self) -> EvalCtx<'_> {
             EvalCtx {
                 project: &self.project,
@@ -1506,6 +1559,19 @@ mod tests {
             .params
             .insert("Demo.Gain".to_string(), M1Scalar::FloatingPoint(2.5));
         assert_eq!(rhs_value("Gain", &mut h).unwrap(), Value::m1_float(2.5));
+    }
+
+    #[test]
+    fn named_enum_parameter_reads_configured_member() {
+        let mut h = Harness::configured_enums();
+        let enum_id = h.project.symbols().enum_by_name("Drive State").unwrap();
+        assert_eq!(
+            rhs_value("Configured Mode", &mut h).unwrap(),
+            Value::Enum {
+                id: enum_id,
+                member: "Precharging".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/tests/evm1_smoke.rs
+++ b/tests/evm1_smoke.rs
@@ -28,9 +28,9 @@ use std::path::{Path, PathBuf};
 
 use m1_core::{Field, Kind, Node};
 use m1_eval::{
-    AdapterReply, Engine, Env, EvalCtx, EvalError, EvalTime, FixedPoint7dps, HardwareAdapter,
-    HardwareCall, HardwareValueSource, InputKind, InputSeries, Loaded, M1Scalar, Scenario,
-    StateStore, Trace, Value, eval, io_sets, load,
+    AdapterReply, Engine, Env, EvalCtx, EvalError, FixedPoint7dps, HardwareAdapter, HardwareCall,
+    HardwareValueSource, InputKind, InputSeries, Loaded, M1Scalar, Scenario, StateStore, Trace,
+    Value, eval, io_sets, load,
 };
 use m1_typecheck::parsed::ParsedScript;
 use m1_typecheck::symbols::{Symbol, SymbolKind};
@@ -569,8 +569,7 @@ fn evaluate_smoke_expression(
         group,
         fn_symbol,
         script_name: &script.name,
-        time: EvalTime::at_start(0.001),
-        hardware: None,
+        dt: 0.001,
         scripts: &loaded.scripts,
         signature_m1_types: Some(&loaded.signature_m1_types),
         object_rules: Some(&loaded.object_rules),

--- a/tests/evm1_smoke.rs
+++ b/tests/evm1_smoke.rs
@@ -1,18 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-//! Gated EV-M1 acceptance smoke tests (off the default CI path).
+//! Environment-gated EV and AV acceptance smoke tests.
 //!
-//! These load the real (proprietary, NOT committed) UQR EV-M1 project from a
-//! local path given by the `M1_EVAL_EVM1_DIR` environment variable. They are
-//! `#[ignore]`-by-default so a normal `cargo test` run never touches proprietary
-//! data; run them explicitly when validating against the real corpus:
+//! These load real proprietary projects from local paths given by
+//! `M1_EVAL_EVM1_DIR` and `M1_EVAL_AVM1_DIR`. A normal test run executes the
+//! gates, but each gate skips with a message when its corpus variable is absent.
+//! Point either variable at the repository root, version directory, or exact
+//! `Project.m1prj`:
 //!
 //! ```text
-//! M1_EVAL_EVM1_DIR=/path/to/UQR-EV/01.00.0166 \
-//!   cargo test --test evm1_smoke -- --ignored
+//! M1_EVAL_EVM1_DIR=/path/to/EV-M1 \
+//! M1_EVAL_AVM1_DIR=/path/to/av-firmware \
+//!   cargo test --test evm1_smoke -- --nocapture
 //! ```
 //!
-//! The directory must contain a `Project.m1prj` (and optionally a
-//! `parameters.m1cfg` calibration alongside it).
+//! The tests discover the versioned project below that path and the matching
+//! repository-level `parameters.m1cfg`. No corpus files are modified or copied.
 //!
 //! ## Phase-1.5 acceptance gate ([`evm1_phase15_categories_are_closed`])
 //!
@@ -21,32 +23,170 @@
 //! `.AsInteger`, project-object `.Set`/`.Update` methods, or inline user-function
 //! calls. This test asserts exactly that against the real project.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use m1_eval::{Engine, Scenario};
+use m1_core::{Field, Kind, Node};
+use m1_eval::{
+    AdapterReply, Engine, Env, EvalCtx, EvalError, EvalTime, FixedPoint7dps, HardwareAdapter,
+    HardwareCall, HardwareValueSource, InputKind, InputSeries, Loaded, M1Scalar, Scenario,
+    StateStore, Trace, Value, eval, io_sets, load,
+};
+use m1_typecheck::parsed::ParsedScript;
+use m1_typecheck::symbols::{Symbol, SymbolKind};
+use m1_typecheck::types::ValueType;
 
-/// Resolve the EV-M1 project directory from `M1_EVAL_EVM1_DIR`. Returns `None`
-/// (so the test silently passes as a no-op) when the variable is unset — the
-/// gating mechanism for "no proprietary data available".
-fn evm1_dir() -> Option<PathBuf> {
-    std::env::var_os("M1_EVAL_EVM1_DIR").map(PathBuf::from)
+const EV_ENV: &str = "M1_EVAL_EVM1_DIR";
+const AV_ENV: &str = "M1_EVAL_AVM1_DIR";
+
+#[derive(Debug)]
+struct CorpusLayout {
+    project: PathBuf,
+    config: PathBuf,
 }
 
-/// Load the EV-M1 project + optional calibration into an [`Engine`].
-fn load_evm1(dir: &Path) -> Engine {
-    let project = dir.join("Project.m1prj");
-    assert!(
-        project.exists(),
-        "M1_EVAL_EVM1_DIR={} has no Project.m1prj",
-        dir.display()
+/// A corpus-independent offline bus source. A successful receive lets the real
+/// receive scripts consume the evaluator's typed zero-valued signal stubs;
+/// returning `false` would deliberately send those scripts down their
+/// communication-timeout paths, where the projects write NaN sentinels that
+/// later transmit functions correctly refuse to narrow to integers.
+struct SmokeBus;
+
+impl HardwareAdapter for SmokeBus {
+    fn call(&mut self, call: &HardwareCall) -> Result<AdapterReply, EvalError> {
+        Ok(if call.method == "Receive" {
+            Value::Bool(true).into()
+        } else {
+            AdapterReply::Unhandled
+        })
+    }
+}
+
+/// Resolve the EV-M1 corpus hint. `None` makes the test print its explicit
+/// no-corpus skip reason before returning.
+fn evm1_dir() -> Option<PathBuf> {
+    std::env::var_os(EV_ENV).map(PathBuf::from)
+}
+
+fn corpus_dir(variable: &str) -> Option<PathBuf> {
+    std::env::var_os(variable).map(PathBuf::from)
+}
+
+/// Resolve the layouts used by the real repositories. The project sits below a
+/// version directory while `parameters.m1cfg` sits at the repository root.
+/// Callers may point the environment variable at either level.
+fn discover_corpus(path: &Path) -> Result<CorpusLayout, String> {
+    let project = if path.is_file() {
+        if path.file_name().and_then(|name| name.to_str()) != Some("Project.m1prj") {
+            return Err(format!("{} is not a Project.m1prj", path.display()));
+        }
+        path.to_path_buf()
+    } else {
+        let direct = path.join("Project.m1prj");
+        if direct.is_file() {
+            direct
+        } else {
+            let mut projects = Vec::new();
+            collect_named(path, "Project.m1prj", &mut projects)?;
+            projects.sort();
+            match projects.as_slice() {
+                [project] => project.clone(),
+                [] => return Err(format!("{} contains no Project.m1prj", path.display())),
+                _ => {
+                    return Err(format!(
+                        "{} contains {} Project.m1prj files; point the variable at one version",
+                        path.display(),
+                        projects.len()
+                    ));
+                }
+            }
+        }
+    };
+
+    // The checked corpora keep their calibration two levels above the project.
+    // Walk a few ancestors first, then fall back to a unique recursive `.m1cfg`.
+    let mut config = project.parent().and_then(|parent| {
+        parent
+            .ancestors()
+            .take(4)
+            .map(|ancestor| ancestor.join("parameters.m1cfg"))
+            .find(|candidate| candidate.is_file())
+    });
+    if config.is_none() {
+        let search_root = if path.is_file() {
+            path.parent().unwrap_or_else(|| Path::new("."))
+        } else {
+            path
+        };
+        let mut configs = Vec::new();
+        collect_extension(search_root, "m1cfg", &mut configs)?;
+        configs.sort();
+        if let [candidate] = configs.as_slice() {
+            config = Some(candidate.clone());
+        }
+    }
+    let config =
+        config.ok_or_else(|| format!("no unambiguous .m1cfg found for {}", project.display()))?;
+
+    Ok(CorpusLayout { project, config })
+}
+
+fn collect_named(dir: &Path, name: &str, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    collect_files(dir, out, &|path| {
+        path.file_name().and_then(|file| file.to_str()) == Some(name)
+    })
+}
+
+fn collect_extension(dir: &Path, extension: &str, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    collect_files(dir, out, &|path| {
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case(extension))
+    })
+}
+
+fn collect_files(
+    dir: &Path,
+    out: &mut Vec<PathBuf>,
+    matches: &dyn Fn(&Path) -> bool,
+) -> Result<(), String> {
+    let entries = std::fs::read_dir(dir)
+        .map_err(|error| format!("cannot read {}: {error}", dir.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("cannot read {}: {error}", dir.display()))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("cannot inspect {}: {error}", path.display()))?;
+        if file_type.is_dir() {
+            if !matches!(entry.file_name().to_str(), Some(".git" | "target")) {
+                collect_files(&path, out, matches)?;
+            }
+        } else if file_type.is_file() && matches(&path) {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Load one corpus with the configuration discovered from its real layout.
+fn load_corpus(dir: &Path, label: &str) -> Engine {
+    let layout = discover_corpus(dir)
+        .unwrap_or_else(|error| panic!("cannot discover {label} corpus: {error}"));
+    eprintln!(
+        "{label}: project={}, config={}",
+        layout.project.display(),
+        layout.config.display()
     );
-    let cfg = dir.join("parameters.m1cfg");
-    let cfg = cfg.exists().then_some(cfg);
-    Engine::load(&project, cfg.as_deref()).expect("EV-M1 project loads")
+    Engine::load(&layout.project, Some(&layout.config))
+        .unwrap_or_else(|error| panic!("{label} project and configuration load: {error}"))
+}
+
+fn load_evm1(dir: &Path) -> Engine {
+    load_corpus(dir, "EV")
 }
 
 #[test]
-#[ignore = "requires M1_EVAL_EVM1_DIR pointing at the proprietary EV-M1 project"]
 fn evm1_phase15_categories_are_closed() {
     let Some(dir) = evm1_dir() else {
         eprintln!("M1_EVAL_EVM1_DIR unset; skipping EV-M1 Phase-1.5 coverage gate");
@@ -104,7 +244,6 @@ fn evm1_phase15_categories_are_closed() {
 /// must resolve to the effective 200 Hz rate instead of appearing unresolved or
 /// unscheduled.
 #[test]
-#[ignore = "requires M1_EVAL_EVM1_DIR pointing at the proprietary EV-M1 project"]
 fn evm1_parameterized_suspension_triggers_resolve_to_200_hz() {
     let Some(dir) = evm1_dir() else {
         eprintln!("M1_EVAL_EVM1_DIR unset; skipping EV-M1 trigger-resolution gate");
@@ -147,62 +286,337 @@ fn evm1_parameterized_suspension_triggers_resolve_to_200_hz() {
 /// the externally-driven CAN/sensor IO falls back to its documented stubs — all
 /// without a single fail-loud `EvalError`.
 ///
-/// External inputs are driven by the IO stubs (Task 7) plus any scenario
-/// `[[inputs]]`; the schedule's CAN reads stub to documented defaults rather than
-/// aborting, so the run completes offline. We assert the trace is non-empty (a
-/// real tick grid over the duration) and that it carries the scheduled control
-/// channels.
+/// External values use typed IO defaults plus a receive-only adapter that
+/// presents an offline bus frame; otherwise the real timeout branches
+/// deliberately write NaN sentinels which later fail-loud integer conversions
+/// correctly reject. We assert the trace is non-empty and disclose every
+/// ordinary, calibration, and receive substitution.
 #[test]
-#[ignore = "requires M1_EVAL_EVM1_DIR pointing at the proprietary EV-M1 project"]
 fn evm1_whole_project_runs_end_to_end() {
     let Some(dir) = evm1_dir() else {
         eprintln!("M1_EVAL_EVM1_DIR unset; skipping EV-M1 whole-project smoke");
         return;
     };
-    let engine = load_evm1(&dir);
+    run_whole_project_smoke(&dir, "EV", 0.02);
+}
 
-    // A short whole-project run needs no `target`. The base tick is pinned at
-    // 1000 Hz, the least common multiple of the scheduled 500/200/50/10/2 Hz
-    // rates, giving every function an exact integer tick period. 0.02 s = 20
-    // base ticks — enough for the slower loops to fire
-    // at least once.
-    let scenario = Scenario::from_toml_str(
+#[test]
+fn avm1_whole_project_runs_end_to_end() {
+    let Some(dir) = corpus_dir(AV_ENV) else {
+        eprintln!("M1_EVAL_AVM1_DIR unset; skipping AV-M1 whole-project smoke");
+        return;
+    };
+    run_whole_project_smoke(&dir, "AV", 0.02);
+}
+
+fn run_whole_project_smoke(dir: &Path, label: &str, duration_s: f64) -> Trace {
+    let layout = discover_corpus(dir)
+        .unwrap_or_else(|error| panic!("cannot discover {label} corpus: {error}"));
+    let loaded = load(&layout.project, Some(&layout.config))
+        .unwrap_or_else(|error| panic!("{label} project and configuration load: {error}"));
+    let calibration_inputs = neutralize_zero_calibration_denominators(&loaded);
+    let engine = load_corpus(dir, label);
+    let scheduled_rates = engine
+        .coverage()
+        .schedule
+        .into_iter()
+        .filter_map(|(_, rate)| rate)
+        .collect::<Vec<_>>();
+    assert!(!scheduled_rates.is_empty(), "{label}: no periodic schedule");
+
+    // Leave base_rate_hz absent. The runner derives the exact LCM, including the
+    // 200 Hz jobs which a fixed 500 Hz grid cannot represent.
+    let mut scenario = Scenario::from_toml_str(&format!(
         r#"
 mode = "whole-project"
-duration_s = 0.02
-base_rate_hz = 1000.0
-"#,
-    )
-    .expect("whole-project scenario parses");
+duration_s = {duration_s}
+allow_default_inputs = true
+
+[[io]]
+call = "System.FlashSize"
+const = {{ unsigned = 8388608 }}
+
+[[io]]
+call = "System.FlashFree"
+const = {{ unsigned = 2097152 }}
+"#
+    ))
+    .expect("whole-project smoke scenario parses");
+    scenario.inputs.extend(calibration_inputs);
+    eprintln!(
+        "{label}: {} neutralized zero-denominator calibration input(s)",
+        scenario.inputs.len()
+    );
+    for input in &scenario.inputs {
+        eprintln!("  {} = {:?}", input.channel, input.kind);
+    }
+    assert_eq!(
+        scenario.base_rate_hz, 0.0,
+        "the corpus tick must be derived"
+    );
 
     let trace = engine
-        .run(&scenario)
-        .expect("EV-M1 whole-project run completes without an EvalError");
-
-    // 0.02 s at 1000 Hz = 20 base ticks; the trace has a dense time axis.
-    assert_eq!(trace.time.len(), 20, "expected 20 base ticks");
+        .run_with_adapter(&scenario, &mut SmokeBus)
+        .unwrap_or_else(|error| panic!("{label} whole-project run failed: {error}"));
+    assert!(
+        trace.time.len() >= 2,
+        "{label}: smoke produced too few ticks"
+    );
     assert!(
         !trace.channels.is_empty(),
-        "whole-project run produced no channel columns"
+        "{label}: whole-project run produced no channel columns"
     );
-    // Every channel column is dense over the tick grid (zero-order hold fills the
-    // ticks a slow function did not run on).
-    for (name, col) in &trace.channels {
+    for (channel, column) in &trace.channels {
         assert_eq!(
-            col.len(),
+            column.len(),
             trace.time.len(),
-            "channel {name:?} column is not dense over the tick grid"
+            "{label}: channel {channel:?} is not dense over the tick grid"
         );
     }
 
-    // The scheduled control channels must appear in the trace. `Control.Drive
-    // State` is written by the drive-state machine; the inverter torque channels
-    // are written by the torque/slip control helpers. We match by suffix so the
-    // canonical `Root.…` prefix does not have to be spelled out.
-    let has_channel = |needle: &str| trace.channels.keys().any(|k| k.contains(needle));
+    let base_rate = 1.0 / (trace.time[1] - trace.time[0]);
+    for rate in scheduled_rates {
+        let divisor = base_rate / rate;
+        assert!(
+            (divisor - divisor.round()).abs() < 1e-9,
+            "{label}: derived {base_rate} Hz base cannot represent {rate} Hz"
+        );
+    }
+
+    for call in ["System.FlashSize", "System.FlashFree"] {
+        assert!(
+            trace.hardware.iter().any(|item| {
+                item.canonical_call() == call
+                    && item.source == HardwareValueSource::ScenarioWildcard
+            }),
+            "{label}: {call} did not use explicit scenario metadata"
+        );
+    }
+
+    let bus_substitutions = trace
+        .hardware
+        .iter()
+        .filter(|item| item.source == HardwareValueSource::Adapter)
+        .collect::<Vec<_>>();
     assert!(
-        has_channel("Drive State"),
-        "no Drive State control channel in the trace; channels: {:?}",
-        trace.channels.keys().collect::<Vec<_>>()
+        !bus_substitutions.is_empty(),
+        "{label}: the offline bus supplied no receive calls"
+    );
+    eprintln!(
+        "{label}: {} adapter-backed receive substitution(s)",
+        bus_substitutions.len()
+    );
+    for item in bus_substitutions {
+        eprintln!(
+            "  {} at {}:{}",
+            item.canonical_call(),
+            item.site.script(),
+            item.site.offset()
+        );
+    }
+
+    assert!(
+        !trace.defaulted.is_empty(),
+        "{label}: expected the offline smoke to disclose substituted inputs"
+    );
+    eprintln!(
+        "{label}: {} substituted ordinary input(s)",
+        trace.defaulted.len()
+    );
+    for (channel, substitution) in &trace.defaulted {
+        assert!(
+            !channel.is_empty(),
+            "{label}: empty substituted channel name"
+        );
+        assert!(
+            !substitution.first_reader.is_empty(),
+            "{label}: {channel} has no first-reader identity"
+        );
+        eprintln!(
+            "  {channel} = {:?}, first read by {}",
+            substitution.value, substitution.first_reader
+        );
+    }
+
+    trace
+}
+
+/// Supply a neutral, type-correct one for a configured zero parameter only
+/// when that parameter is proven to make a statically evaluable division
+/// denominator non-zero. Some checked-in projects deliberately leave optional
+/// physical models untuned (all-zero coefficients). The compatibility smoke is
+/// not a calibration-validity oracle, so it reports these scenario inputs while
+/// normal evaluator runs retain their fail-loud divide/table behavior.
+fn neutralize_zero_calibration_denominators(loaded: &Loaded) -> Vec<InputSeries> {
+    let mut seeds = BTreeMap::<String, Value>::new();
+    for script in &loaded.scripts {
+        let group = loaded.project.group_for_script(&script.name);
+        let fn_symbol = loaded.project.function_symbol_for_script(&script.name);
+        let candidates = io_sets(script, &loaded.project, group.as_deref())
+            .reads
+            .into_iter()
+            .filter_map(|path| {
+                let symbol = loaded.project.symbols().get(&path)?;
+                if symbol.kind != SymbolKind::Parameter {
+                    return None;
+                }
+                let scalar = loaded.calib.param(&path).or_else(|| {
+                    path.strip_prefix("Root.")
+                        .and_then(|path| loaded.calib.param(path))
+                })?;
+                if scalar.as_f64() != 0.0 {
+                    return None;
+                }
+                safe_nonzero_parameter(symbol).map(|value| (path, value))
+            })
+            .collect::<Vec<_>>();
+        neutralize_script_denominators(
+            loaded,
+            script,
+            group.as_deref(),
+            fn_symbol.as_deref(),
+            &script.cst.root(),
+            &candidates,
+            &mut seeds,
+        );
+    }
+    seeds
+        .into_iter()
+        .map(|(channel, value)| InputSeries {
+            channel,
+            kind: InputKind::Const(value),
+        })
+        .collect()
+}
+
+fn safe_nonzero_parameter(symbol: &Symbol) -> Option<Value> {
+    if symbol.declared_type.as_deref().is_some_and(|declared| {
+        declared.eq_ignore_ascii_case("FixedPoint7dps")
+            || declared.eq_ignore_ascii_case("fixed7dps")
+    }) {
+        return Some(Value::M1(M1Scalar::FixedPoint7dps(
+            FixedPoint7dps::from_raw(FixedPoint7dps::SCALE as i32),
+        )));
+    }
+    match symbol.value_type {
+        ValueType::Integer => Some(Value::m1_integer(1)),
+        ValueType::Unsigned => Some(Value::m1_unsigned(1)),
+        ValueType::Float => Some(Value::m1_float(1.0)),
+        ValueType::Boolean | ValueType::String | ValueType::Enum(_) | ValueType::Unknown => None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn neutralize_script_denominators(
+    loaded: &Loaded,
+    script: &ParsedScript,
+    group: Option<&str>,
+    fn_symbol: Option<&str>,
+    node: &Node,
+    candidates: &[(String, Value)],
+    seeds: &mut BTreeMap<String, Value>,
+) {
+    if node.kind() == Kind::BinaryExpression
+        && node
+            .child_by_field(Field::Operator)
+            .is_some_and(|operator| operator.kind() == Kind::Slash)
+        && let Some(denominator) = node.child_by_field(Field::Right)
+        && evaluate_smoke_expression(loaded, script, group, fn_symbol, &denominator, seeds)
+            .is_some_and(|value| value.m1_scalar().is_ok_and(|scalar| scalar.as_f64() == 0.0))
+    {
+        for (path, probe) in candidates {
+            if seeds.contains_key(path) {
+                continue;
+            }
+            let mut probed = seeds.clone();
+            probed.insert(path.clone(), probe.clone());
+            if evaluate_smoke_expression(loaded, script, group, fn_symbol, &denominator, &probed)
+                .is_some_and(|value| {
+                    value.m1_scalar().is_ok_and(|scalar| {
+                        let scalar = scalar.as_f64();
+                        scalar.is_finite() && scalar != 0.0
+                    })
+                })
+            {
+                seeds.insert(path.clone(), probe.clone());
+                break;
+            }
+        }
+    }
+    for child in node.named_children() {
+        neutralize_script_denominators(loaded, script, group, fn_symbol, &child, candidates, seeds);
+    }
+}
+
+fn evaluate_smoke_expression(
+    loaded: &Loaded,
+    script: &ParsedScript,
+    group: Option<&str>,
+    fn_symbol: Option<&str>,
+    node: &Node,
+    seeds: &BTreeMap<String, Value>,
+) -> Option<Value> {
+    let mut env = Env::new();
+    for (path, value) in seeds {
+        env.set(path.clone(), value.clone());
+    }
+    let mut state = StateStore::new();
+    let mut ctx = EvalCtx {
+        project: &loaded.project,
+        calib: &loaded.calib,
+        env: &mut env,
+        state: &mut state,
+        group,
+        fn_symbol,
+        script_name: &script.name,
+        time: EvalTime::at_start(0.001),
+        hardware: None,
+        scripts: &loaded.scripts,
+        signature_m1_types: Some(&loaded.signature_m1_types),
+        object_rules: Some(&loaded.object_rules),
+        depth: 0,
+        trace: None,
+    };
+    eval(node, &mut ctx).ok()
+}
+
+#[test]
+fn corpus_discovery_finds_versioned_project_and_root_config() {
+    let temp = tempfile::tempdir().expect("temporary corpus root");
+    let version = temp.path().join("UQR-Test/01.00");
+    std::fs::create_dir_all(&version).expect("create synthetic version directory");
+    let project = version.join("Project.m1prj");
+    let config = temp.path().join("parameters.m1cfg");
+    std::fs::write(&project, "synthetic project marker").expect("write synthetic project marker");
+    std::fs::write(&config, "synthetic config marker").expect("write synthetic config marker");
+
+    for entry in [temp.path(), version.as_path(), project.as_path()] {
+        let layout = discover_corpus(entry).expect("synthetic layout is discovered");
+        assert_eq!(layout.project, project);
+        assert_eq!(layout.config, config);
+    }
+}
+
+#[test]
+fn zero_denominator_neutralization_is_structural_and_minimal() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/enums");
+    let loaded = load(
+        &dir.join("Project.m1prj"),
+        Some(&dir.join("parameters.m1cfg")),
+    )
+    .expect("configured enum fixture loads");
+    let inputs = neutralize_zero_calibration_denominators(&loaded);
+    assert_eq!(
+        inputs.len(),
+        1,
+        "one side of a zero sum is enough to make the denominator non-zero"
+    );
+    assert!(
+        matches!(inputs[0].kind, InputKind::Const(Value::M1(_))),
+        "the synthetic float calibration gets a typed numeric scenario value"
+    );
+    assert!(
+        inputs[0].channel.ends_with("Coefficient"),
+        "the helper derives a parameter from the denominator instead of a corpus path"
     );
 }

--- a/tests/fixtures/can_stub/Project.m1prj
+++ b/tests/fixtures/can_stub/Project.m1prj
@@ -5,8 +5,8 @@
 <!-- opens a CAN receive handle and reads a float and an unsigned from  -->
 <!-- the bus, then writes the float to an output channel. Offline there -->
 <!-- is no CAN bus, so each `CanComms.*` call returns its documented,    -->
-<!-- type-correct externally-driven default (a Handle -> the benign      -->
-<!-- unit, a FloatingPoint read -> 0.0, an Integer read -> 0) instead of -->
+<!-- type-correct externally-driven default (a Handle -> unsigned zero,  -->
+<!-- a FloatingPoint read -> 0.0, an Integer read -> 0) instead of       -->
 <!-- failing loud. This is the CI-safe guard for the gated EV-M1 whole-  -->
 <!-- project test: it proves a run whose script reads CAN completes.     -->
 <MoTeCM1BuildSession>

--- a/tests/fixtures/can_stub/Scripts/CanDemo.Read.m1scr
+++ b/tests/fixtures/can_stub/Scripts/CanDemo.Read.m1scr
@@ -1,6 +1,6 @@
 // Synthetic M1 script for m1-eval fixture tests. No proprietary content.
 // Reads from a CAN bus that does not exist offline: each CanComms.* call
 // resolves to its documented externally-driven stub rather than failing loud.
-local handle = CanComms.RxOpenStandard(0, 0, 0, false);
+local <Unsigned Integer> handle = CanComms.RxOpenStandard(0, 0, 0, false);
 local raw = CanComms.GetUnsignedInteger(handle, 0, 8);
 Bus Value = CanComms.GetFloat(handle, 0);

--- a/tests/fixtures/enums/Project.m1prj
+++ b/tests/fixtures/enums/Project.m1prj
@@ -10,6 +10,10 @@
   <ComponentStream><List>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo"/>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Mode"><Props Type="::This.Drive State"/></Component>
+   <Component Classname="BuiltIn.Parameter" Name="Root.Demo.Configured Mode"><Props Type="::This.Drive State"/></Component>
+   <Component Classname="BuiltIn.Parameter" Name="Root.Demo.Left Coefficient"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Parameter" Name="Root.Demo.Right Coefficient"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Ratio"><Props Type="f32"/></Component>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Compound"/>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Compound.Value"><Props Type="::This.Drive State"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Precharge State"><Props Type="u8"/></Component>
@@ -27,6 +31,9 @@
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Calibration Compound.Value"><Props Type="f32"/></Component>
    <Component Classname="BuiltIn.Timer" Name="Root.Demo.Startup Delay"/>
    <Component Classname="MoTeC Input.Sensor" Name="Root.Demo.Typed IO"><Props Type="f32"/></Component>
+   <Component Classname="MoTeC Input.Sensor" Name="Root.Demo.Sensor"/>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Sensor.Diagnostic"/>
+   <Component Classname="BuiltIn.Channel" Name="Root.Demo.Sensor.Diagnostic.Value"/>
    <Component Classname="BuiltIn.GroupCompound" Name="Root.Demo.Service Bits"/>
    <Component Classname="BuiltIn.CAN.Message" Name="Root.Demo.DashVals"/>
    <Component Classname="BuiltIn.CAN.Signal" Name="Root.Demo.DashVals.Aux Switch"/>
@@ -34,6 +41,7 @@
    <Component Classname="BuiltIn.Channel" Name="Root.Demo.Flag"><Props Type="u8"/></Component>
    <Component Classname="BuiltIn.FuncUser" Filename="Demo.Update.m1scr" Name="Root.Demo.Update"/>
    <Component Classname="BuiltIn.FuncUser" Filename="Demo.Report.m1scr" Name="Root.Demo.Report"/>
+   <Component Classname="BuiltIn.FuncUser" Filename="Demo.Ratio.m1scr" Name="Root.Demo.Ratio Update"/>
   </List></ComponentStream>
  </Project>
 </MoTeCM1BuildSession>

--- a/tests/fixtures/enums/Scripts/Demo.Ratio.m1scr
+++ b/tests/fixtures/enums/Scripts/Demo.Ratio.m1scr
@@ -1,0 +1,2 @@
+// Synthetic zero-denominator calibration fixture. No proprietary content.
+Ratio = Left Coefficient / (Left Coefficient + Right Coefficient);

--- a/tests/fixtures/enums/parameters.m1cfg
+++ b/tests/fixtures/enums/parameters.m1cfg
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<Configuration>
+ <Parameter Name="Demo.Configured Mode">
+  <Cell Type="enum">Precharging</Cell>
+ </Parameter>
+ <Parameter Name="Demo.Left Coefficient">
+  <Cell Type="f32">0.0</Cell>
+ </Parameter>
+ <Parameter Name="Demo.Right Coefficient">
+  <Cell Type="f32">0.0</Cell>
+ </Parameter>
+</Configuration>


### PR DESCRIPTION
Closes #47

## What changed

- Discover `Project.m1prj` and its matching configuration from the repository root, a version directory, or an exact project path.
- Derive a schedule-compatible base tick, supply required System flash metadata explicitly, and report ordinary, calibration, and receive substitutions.
- Cover the corpus compatibility paths needed by EV and AV, including Handle typing, Sensor Diagnostic `AsInteger`, enum and numeric configuration parsing, and structural denominator neutralization in the smoke harness.
- Keep the public `EvalCtx` construction contract covered.

## Verification

- `cargo test`: 522 passed.
- `cargo test --all-targets --all-features`: 533 passed, with the existing proprietary `.ld` test ignored.
- `cargo +1.88.0 test --all-targets --all-features`: 533 passed, with the same ignore.
- `cargo clippy --all-targets --all-features -- -D warnings`.
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`.
- `cargo fmt --all -- --check` and commit/worktree diff checks.
- Read-only AV corpus smoke: passed, reporting 28 adapter receive substitutions and 39 ordinary input substitutions. The EV corpus is not present on this machine, so its gate exercised the documented explicit skip path.
- The two-commit range-diff is exact against the reviewed #47 head, and the resulting tree is identical.

## Corpus boundary

The real-corpus tests only read paths supplied through `M1_EVAL_EVM1_DIR` and `M1_EVAL_AVM1_DIR`. They do not copy or modify corpus files. No proprietary project or configuration data is committed.