### PR TITLE
feat: add M1 Sim conformance runner

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Keep synthetic evaluator fixtures byte-stable for SHA-256 manifests.
+tests/fixtures/**/*.m1prj text eol=lf
+tests/fixtures/**/*.m1scr text eol=lf
+tests/fixtures/**/*.m1cfg text eol=lf
+tests/fixtures/conformance/*.toml text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,10 +182,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -211,6 +249,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -303,6 +351,7 @@ dependencies = [
  "roxmltree",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "toml",
 ]
@@ -524,6 +573,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +722,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ld = ["dep:motec-i2"]
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 toml = "1.1"
 roxmltree = "0.21"
 m1-core = { git = "https://github.com/C-Nucifora/m1-core.git", tag = "v0.15.0" }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ do not compare computed channel values with captured M1 results.
 | Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. |
 | `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Assumed / Stubbed** | Each call crosses a typed adapter boundary with its resolved receiver, source call site, arguments, and evaluator time. Exact-site scenario values take precedence over wildcard values and an attached adapter. `System.ElapsedTime` reports the interval since that call site last ran. Its first tick-zero call returns zero, while a site first reached later uses its function step. Tick calls use the deterministic base timeline. `System.FlashSize` and `System.FlashFree` require scenario or adapter data; they never become a dangerous zero. Remaining unhandled calls use documented typed stubs or fail loud. |
 | Scenario parsing, tick grids, trace output, and `--coverage` | **Assumed** | These are deterministic m1-eval contracts tested with synthetic data. A `Supported` coverage entry means implemented, not M1-verified. |
+| Typed conformance fixture parser and runner | **Assumed** | Synthetic fixtures cover typed values, project hashes, initial-state reset, tolerances, and mismatch reporting. No genuine M1 Sim capture is committed yet, so this runner does not make another area Verified by itself. |
 | Single-function and upstream dependency-cone runners | **Assumed** | Selection, ordering, and zero-order hold are tested on synthetic projects. |
 | Whole-project multi-rate scheduling | **Assumed** | Trigger rates come from `Project.m1prj`; same-rate dependency order, fastest-first rate groups, startup order, and cross-rate stale reads are the evaluator's model. |
 | CSV log replay, overrides, downstream-cone recomputation, and diffs | **Assumed** | Synthetic tests cover import, resampling, source precedence, recomputation, and the no-op invariant. They do not establish M1 execution fidelity. |
@@ -246,11 +247,18 @@ cargo run --features ld -- --project Project.m1prj --log run.ld --out trace.csv
 # Static coverage report — what the engine can and cannot evaluate, plus the
 # per-function execution schedule.
 m1-eval --project Project.m1prj --coverage
+
+# Run one or more typed golden-vector fixtures. The committed examples are
+# synthetic runner tests, not M1 compatibility evidence.
+m1-eval \
+  --conformance tests/fixtures/conformance/synthetic-mini.toml \
+  --conformance tests/fixtures/conformance/synthetic-initial-state.toml
 ```
 
 `--project` defaults to the nearest `Project.m1prj` upward (or `$M1_PROJECT`).
-See [`docs/cli.md`](docs/cli.md) for the full flag list, the scenario file
-format, and the exit-code contract.
+See [`docs/cli.md`](docs/cli.md) for the full flag list, scenario format, and
+exit-code contract. [`docs/conformance.md`](docs/conformance.md) defines the
+golden-vector schema and the M1 Sim capture procedure.
 
 The real-project smoke tests remain read-only and keep proprietary files out of
 the repository. Point each variable at a corpus repository root, version

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,8 +2,8 @@
 # m1-eval — CLI reference
 
 `m1-eval` is a thin command-line shell over the evaluator library. It loads a
-project (and optional `.m1cfg` calibration), then either evaluates a scenario
-into a `Trace` or prints the static coverage report.
+project and evaluates a scenario, replays a counterfactual log, reports static
+coverage, or runs typed conformance fixtures.
 
 ```
 m1-eval [--project P] [--config C]
@@ -12,12 +12,16 @@ m1-eval [--project P] [--config C]
         [--log L.csv|L.ld [--override CH=expr]... [--diff diff.json|diff.csv]
                           [--out trace.json|trace.csv]]
         [--coverage]
+m1-eval --conformance FIXTURE [--conformance FIXTURE]...
+        [--require-m1-sim-capture]
 ```
 
 ## Flags
 
 | Flag | Meaning |
 | --- | --- |
+| `--conformance <PATH>` | Run a typed TOML or JSON golden-vector fixture. Repeatable. The fixture supplies its project paths and hashes, so this action conflicts with the ordinary project/run/report flags. |
+| `--require-m1-sim-capture` | Fail a conformance suite that contains no passing fixture with `m1-sim` provenance. Requires `--conformance`. |
 | `--project <PATH>` | The `Project.m1prj`. Defaults to the nearest one upward from the cwd, or `$M1_PROJECT`. |
 | `--config <PATH>` | The calibration file (`.m1cfg`) supplying parameter values and table cells. Required for actual tunable and table values. Without it, parameters use externally-driven type defaults; table reads fail unless whole-project mode opts in to default inputs, which supplies an external `0.0`. |
 | `--scenario <PATH>` | The scenario file (TOML or JSON; parser chosen by extension) describing how to drive the run. |
@@ -33,8 +37,10 @@ m1-eval [--project P] [--config C]
 | `--version`, `-V` | Print the version and exit `0`. |
 | `--help`, `-h` | Print usage and exit `0`. |
 
-A run requires `--scenario` (to evaluate), `--log` (to replay a log), or
-`--coverage` (to report); with none, the invocation is incomplete and exits `2`.
+A normal project action requires `--scenario` (to evaluate), `--log` (to replay
+a log), or `--coverage` (to report). A conformance suite is a separate action
+and carries its own project bundle. With no action, the invocation is incomplete
+and exits `2`.
 `--function` / `--target` / `--whole-project` override the `mode`/`target`
 declared in the scenario file; at most one may be given (combining two is a usage
 error, exit `2`). `--override` and `--diff` require `--log`.
@@ -64,6 +70,12 @@ base_rate_hz = 100.0         # base tick rate; dt = 1 / base_rate_hz. In
 allow_default_inputs = false # whole-project only: opt-in default substitution
                              # for unseeded channel reads (reported; strict
                              # fail-loud when absent/false)
+
+# Seed a channel once before startup code and tick zero. Unlike an input, this
+# is not written back every tick, so a script may advance it.
+[[initial_state]]
+channel = "Root.Engine.Counter"
+value = { integer = 10 }
 
 # Inputs the engine is *given* rather than computes. Each entry is a constant
 # or a (t_seconds, value) time series sampled by zero-order hold.
@@ -110,6 +122,17 @@ const = 1048576
 Identifiers may contain spaces (e.g. `Cooling Fan.Output`); channel names are
 used verbatim and never split on whitespace, only on `.` for path segments.
 
+## Conformance fixtures
+
+Conformance fixtures use a stricter typed wire format than scenarios. They
+record project hashes, provenance, the calculation rate, initial state, every
+tick's input changes, expected outputs, and type-specific tolerances. The runner
+starts with fresh evaluator state for every fixture and reports the first
+meaningful mismatch.
+
+See [`conformance.md`](conformance.md) for the schema, comparison rules, M1 Sim
+capture procedure, synthetic examples, and the optional private-capture gate.
+
 ## Output
 
 - **JSON** (`--out trace.json`, or no `--out`):
@@ -118,10 +141,10 @@ used verbatim and never split on whitespace, only on `.` for path segments.
   script, byte offset, and selected route (`scenario-exact`,
   `scenario-wildcard`, `adapter`, `system-model`, or `generic-stub`). The
   `external` list names channels whose values were externally driven rather than
-  computed, including scenario inputs, Tier-3 stubs, parameter defaults, opt-in
-  table fallbacks, and opt-in defaults for unseeded channels. JSON has no
-  non-finite numeric values, so NaN and positive or negative infinity are written
-  as `null`.
+  computed, including scenario inputs, held initial state, Tier-3 stubs,
+  parameter defaults, opt-in table fallbacks, and opt-in defaults for unseeded
+  channels. JSON has no non-finite numeric values, so NaN and positive or
+  negative infinity are written as `null`.
 - **CSV** (`--out trace.csv`): a `time` header column followed by one column per
   channel in sorted-name order, one row per tick.
 
@@ -133,9 +156,9 @@ These follow the shared toolchain contract (`m1-tools/docs/cli.md`):
 
 | Code | Meaning |
 | --- | --- |
-| `0` | Success — the run produced a trace, or the coverage report printed. |
-| `1` | The engine ran and **has something to report**: a project/calibration that would not load, a scenario that would not parse, or a fail-loud evaluation error (an unsupported builtin, missing hardware metadata, a missing calibration value, an unresolved symbol, or a missing input). |
-| `2` | A **usage error** — an unrecognised flag, no resolvable project, or neither `--scenario` nor `--coverage` given. |
+| `0` | Success. The run produced a trace, the coverage report printed, or every conformance fixture passed. |
+| `1` | The engine has something to report: a load, parse, integrity, evaluation, or conformance mismatch, including missing hardware metadata. |
+| `2` | A usage error: an unrecognised or conflicting flag, no resolvable project for a normal action, or no action. |
 
 So `$? != 0` means "do not trust the output." Unsupported behavior fails loud.
 The documented hardware stubs, parameter defaults, opt-in table fallbacks, and

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,213 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+# Conformance fixtures
+
+A conformance fixture replays captured inputs on a fixed tick grid and compares
+m1-eval's channel values with an independent result. The file carries the
+project paths and SHA-256 hashes needed to reproduce the calculation. Ordinary
+CI can therefore run a capture without installing M1 Sim.
+
+The committed fixtures under `tests/fixtures/conformance` are synthetic. They
+test the fixture parser and runner, but they are not evidence that m1-eval
+matches M1. A fixture counts as M1 Sim evidence only when its provenance says
+`kind = "m1-sim"` and its expected values were actually captured from M1 Sim.
+
+## Running fixtures
+
+Pass `--conformance` once per TOML or JSON file. The runner processes files and
+steps in command-line order and stops at the first error or output mismatch.
+
+```sh
+m1-eval \
+  --conformance tests/fixtures/conformance/synthetic-mini.toml \
+  --conformance tests/fixtures/conformance/synthetic-initial-state.toml
+```
+
+Each fixture carries its own project and optional calibration path, so
+`--conformance` cannot be combined with `--project`, `--config`, scenario,
+counterfactual, trace-output, or coverage flags.
+
+Use the stricter gate when a private or CI-only suite is expected to contain a
+real capture:
+
+```sh
+m1-eval --conformance /secure/captures/filter.toml \
+  --require-m1-sim-capture
+```
+
+The same gate is available to integration tests. Set
+`M1_EVAL_M1_SIM_FIXTURES` to an operating-system path list:
+
+```sh
+M1_EVAL_M1_SIM_FIXTURES=/secure/captures/filter.toml \
+  cargo test --test conformance configured_private_m1_sim_fixtures_form_an_optional_gate
+```
+
+Do not commit licensed projects, calibrations, logs, or customer data. Keep a
+private fixture outside the repository, or reproduce the behavior in a small
+project that you are allowed to publish.
+
+## File layout
+
+This shortened TOML example shows the schema. JSON accepts the same fields.
+
+```toml
+schema_version = 1
+name = "first-order filter capture"
+calculation_rate_hz = 100.0
+
+[project]
+root = "../filter-project"
+project = "Project.m1prj"
+config = "Filter.m1cfg"
+
+# Replace each all-zero example with that file's lowercase SHA-256 digest.
+[[project.files]]
+path = "Project.m1prj"
+sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[[project.files]]
+path = "Scripts/Filter.Update.m1scr"
+sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[[project.files]]
+path = "Filter.m1cfg"
+sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[provenance]
+kind = "m1-sim"
+source = "reduced Filter project, capture session FILTER-2026-08-30"
+procedure = "docs/conformance.md#capturing-from-m1-sim"
+tool_version = "M1 Build and M1 Sim version used for the capture"
+captured_at_utc = "2026-08-30T12:00:00Z"
+notes = "Optional setup details that affect the result."
+
+[run]
+mode = "function" # "function", "cone", or "whole-project"
+target = "Filter.Update"
+
+[[initial_state]]
+channel = "Root.Filter.Output"
+value = { type = "floating-point", value = "0" }
+
+[[steps]]
+time_s = 0.0
+
+[[steps.inputs]]
+channel = "Root.Filter.Input"
+value = { type = "floating-point", value = "1" }
+
+[[steps.expected]]
+channel = "Root.Filter.Output"
+value = { type = "floating-point", value = "0.095162585" }
+tolerance = { type = "floating-point", absolute = "0.000001", relative = "0.000001" }
+
+[[steps]]
+time_s = 0.01
+
+[[steps.expected]]
+channel = "Root.Filter.Output"
+value = { type = "floating-point", value = "0.18126924" }
+tolerance = { type = "floating-point", absolute = "0.000001", relative = "0.000001" }
+```
+
+`project.files` must be the exact evaluator input set: the project descriptor,
+the selected calibration, and every `.m1scr` below the descriptor's directory.
+Paths in that manifest are normalized relative paths below `project.root`.
+Symlinks are rejected because the same fixture must hash the same files on every
+machine. Duplicate `.m1scr` basenames are rejected because the evaluator loader
+identifies scripts by basename and could otherwise depend on directory order.
+
+Initial-state, input, and expected-output paths must be canonical `Channel`
+symbols in the loaded project, not parameters, constants, groups, or functions.
+Their wire families must match the channel storage families;
+the runner rejects a fixture that would rely on an implicit numeric or enum
+conversion at the scenario boundary.
+
+Steps start at zero and include every calculation tick. For step index `i`, the
+runner requires `time_s = i / calculation_rate_hz`. An input change is held
+until its next change. If an input first changes after step zero, its channel
+must have an `initial_state` entry. Initial state is seeded once, before startup
+code and the first tick. It is not pinned on later ticks, so scripts can advance
+captured counters, accumulators, and state channels. Every step declares the
+same expected-channel set, which keeps each captured output dense and aligned
+with the tick grid. An expected channel must be evaluator-computed. A channel
+that only repeats an input, an initial seed, or another external value is
+rejected instead of producing a vacuous conformance pass. Expected channels
+must be disjoint from fixture input channels. A run that consults an external
+stub or source not declared as fixture input or initial state is also rejected.
+
+## Typed values and comparisons
+
+Every value names its M1 family:
+
+| `type` | Fields | Comparison |
+| --- | --- | --- |
+| `boolean` | `value = true` | Exact |
+| `integer` | signed 32-bit `value` | Exact |
+| `unsigned-integer` | unsigned 32-bit `value` | Exact |
+| `floating-point` | binary32 decimal string in `value` | Declared absolute or relative tolerance |
+| `fixed-point-7dps` | signed 32-bit `raw` storage | Declared `raw` tolerance |
+| `enum` | `enum_type` and `member` | Exact type and member |
+| `string` | `value` | Exact |
+
+Floating-point strings may use `NaN`, `Infinity`, or `-Infinity`. NaN matches
+only NaN. Infinity matches only infinity with the same sign. A finite expected
+value never matches a non-finite actual value, regardless of tolerance.
+
+For finite floating-point values, the allowed error is:
+
+```text
+max(absolute, relative * max(abs(expected), abs(actual)))
+```
+
+At least one floating bound must be present. Omitted bounds act as zero.
+Fixed-point values compare their signed raw storage and use an integer raw-unit
+tolerance. A tolerance on Boolean, integer, unsigned integer, enum, or string
+data is an error rather than a silent approximation.
+
+## Capturing from M1 Sim
+
+1. Use a project and calibration you may inspect and share. Reduce it to the
+   calculation under test when the original contains private material.
+2. Record the exact M1 Build and M1 Sim version, UTC time, project purpose,
+   calculation rate, selected function or whole-project schedule, and any setup
+   that changes the result.
+3. Hash the project descriptor, selected calibration, and all loaded scripts.
+   On systems with `sha256sum`, run it on each manifest file and copy the
+   lowercase digest into `project.files`.
+4. Reset M1 Sim before the capture so filters, integrals, timers, static locals,
+   and other hidden operator state start fresh, like the runner's state store.
+   If the calculation needs a warm-up, include those warm-up ticks in the
+   fixture. `initial_state` seeds channel storage only; it cannot restore hidden
+   operator state from a running session.
+5. Set the simulator's initial channel state before tick zero. For each tick,
+   apply that step's input changes before executing the calculation, then capture
+   expected outputs after the calculation completes. Capture tick zero and every
+   following calculation tick at the declared rate. Use M1 Sim's logging or
+   export facility from the licensed installation. Do not derive the expected
+   column with m1-eval.
+6. Preserve the source types. Record signed and unsigned integers without
+   widening, Boolean values as Boolean, fixed-point values as signed raw storage,
+   and floating-point values as binary32 round-trip decimal strings. Declare
+   tolerances from the capture's precision and the behavior under test.
+7. Run the fixture without the strict flag first. Resolve hash, schema, or value
+   errors. Then run it with `--require-m1-sim-capture`.
+8. Review the fixture for private names and values before committing it. If it
+   cannot be published, keep it in the private gate described above.
+
+The runner reloads the project and creates a fresh evaluator state for each
+fixture, including repeated paths in one suite. A failure reports the first
+expected channel that differs, with its step index, time, typed expected value,
+tolerance, and typed actual value.
+
+## Synthetic runner fixtures
+
+The committed mini fixture checks calibrated arithmetic, typed floating-point
+input, tolerances, and bundle hashes. The typed-value fixture carries Boolean,
+signed, unsigned, binary32, fixed-point, enum, and string values through the
+full parser, evaluator, and comparator. The initial-state fixture starts two
+scheduled counters at non-zero values and runs the same fixture twice in one
+test. It catches state leakage and accidental per-tick reseeding.
+
+These files use `kind = "synthetic"` and cannot satisfy
+`--require-m1-sim-capture`.

--- a/src/bin/m1_eval.rs
+++ b/src/bin/m1_eval.rs
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //! The `m1-eval` command-line interface: a thin shell over the [`Engine`].
 //!
-//! Loads a project (and optional `.m1cfg` calibration), then either evaluates a
-//! scenario into a [`Trace`] (written to `--out` as JSON or CSV, or to stdout) or
-//! prints the static `--coverage` report. The heavy lifting lives in the library;
-//! this binary only parses arguments, wires them to the engine, and maps results
-//! onto the shared toolchain exit-code contract.
+//! Loads a project and evaluates a scenario, replays a log, prints static
+//! coverage, or runs one or more self-contained conformance fixtures. The heavy
+//! lifting lives in the library. This binary parses arguments, wires them to the
+//! engine or conformance runner, and maps results onto the shared toolchain
+//! exit-code contract.
 //!
 //! ## Exit codes (shared toolchain contract, see `m1-tools/docs/cli.md`)
 //!
-//! - `0` — success: the run produced a trace, or the coverage report printed.
-//! - `1` — the engine ran and has something to report: a project that would not
-//!   load, a scenario that would not parse, or an evaluation error (a fail-loud
-//!   `EvalError`).
-//! - `2` — a usage error: an unrecognised flag, or arguments that do not name a
-//!   runnable action (no resolvable project, or neither `--scenario` nor
-//!   `--coverage`).
+//! - `0`: success; the run produced a trace, the coverage report printed, or
+//!   every conformance fixture passed.
+//! - `1`: the engine ran and has something to report; a project that would not
+//!   load, a scenario or fixture that would not parse, a fixture integrity or
+//!   comparison failure, or an evaluation error (a fail-loud `EvalError`).
+//! - `2`: a usage error; an unrecognised flag, or arguments that do not name a
+//!   runnable action (no resolvable project, or no scenario, log, coverage, or
+//!   conformance action).
 //!
 //! Counterfactual replay is supported: `--log` attaches a recorded MoTeC log
 //! (CSV, or `.ld` with `--features ld`) as ground truth, `--override CH=expr`
@@ -23,7 +24,7 @@
 //! `--diff` writes the per-channel logged-vs-counterfactual delta.
 
 use clap::{ArgGroup, Parser};
-use m1_eval::{Engine, RunMode, Scenario};
+use m1_eval::{ConformanceOptions, Engine, RunMode, Scenario, run_conformance_suite};
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -45,6 +46,33 @@ use std::process;
         .multiple(false)
 ))]
 struct Args {
+    /// Run a typed conformance fixture. Repeat to run a suite. Each fixture
+    /// carries its own project paths, hashes, tick grid, and expected values.
+    #[arg(
+        long,
+        value_name = "FIXTURE",
+        conflicts_with_all = [
+            "project",
+            "config",
+            "scenario",
+            "function",
+            "target",
+            "whole_project",
+            "allow_default_inputs",
+            "out",
+            "coverage",
+            "log",
+            "overrides",
+            "diff"
+        ]
+    )]
+    conformance: Vec<PathBuf>,
+
+    /// Fail a conformance suite that contains no passing M1 Sim capture.
+    /// Ordinary CI omits this flag and runs the committed synthetic fixtures.
+    #[arg(long, requires = "conformance")]
+    require_m1_sim_capture: bool,
+
     /// Project.m1prj (defaults to the nearest one upward, or $M1_PROJECT).
     #[arg(long)]
     project: Option<PathBuf>,
@@ -182,6 +210,31 @@ fn apply_mode_override(
 
 fn main() {
     let args = Args::parse();
+
+    if !args.conformance.is_empty() {
+        let options = ConformanceOptions {
+            require_m1_sim_capture: args.require_m1_sim_capture,
+        };
+        match run_conformance_suite(&args.conformance, options) {
+            Ok(reports) => {
+                for report in &reports {
+                    println!(
+                        "PASS {} ({} steps, {} assertions, {})",
+                        report.name,
+                        report.steps_checked,
+                        report.assertions_checked,
+                        report.provenance
+                    );
+                }
+                println!("conformance: {} fixture(s) passed", reports.len());
+            }
+            Err(error) => {
+                eprintln!("m1-eval: {error}");
+                process::exit(1);
+            }
+        }
+        return;
+    }
 
     // Resolve the project; no project at all is a usage error (exit 2).
     let Some(project_path) = resolve_project(args.project) else {

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -1,0 +1,1633 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Typed golden-vector fixtures for M1 Sim conformance evidence.
+//!
+//! A fixture binds its expected values to an exact project bundle through
+//! SHA-256 hashes. It records an explicit tick grid, one-time initial channel
+//! state, zero-order-held inputs, expected outputs, tolerances, and provenance.
+//! Running a fixture always loads a new project and starts a new evaluator run,
+//! so stateful operators cannot leak state between fixtures in a suite.
+
+use crate::error::EvalError;
+use crate::loader::{Loaded, load};
+use crate::runner;
+use crate::scenario::{InitialValue, InputKind, InputSeries, RunMode, Scenario};
+use crate::trace::Trace;
+use crate::value::{FixedPoint7dps, M1Scalar, Value};
+use m1_typecheck::Project;
+use m1_typecheck::symbols::SymbolKind;
+use m1_typecheck::types::ValueType;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+/// The fixture schema version understood by this release.
+pub const CONFORMANCE_SCHEMA_VERSION: u32 = 1;
+
+/// A parsed conformance fixture and the path it was loaded from.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConformanceFixture {
+    /// Schema version. It must equal [`CONFORMANCE_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Short name printed in reports and mismatch messages.
+    pub name: String,
+    /// Exact project files used for the captured calculation.
+    pub project: ProjectBundle,
+    /// Where the expected values came from.
+    pub provenance: FixtureProvenance,
+    /// Evaluator mode and target used to replay the capture.
+    pub run: FixtureRun,
+    /// Tick-grid rate. Every step must be at `index / calculation_rate_hz`.
+    pub calculation_rate_hz: f64,
+    /// Values placed in the channel store once, before startup and tick zero.
+    #[serde(default)]
+    pub initial_state: Vec<FixtureChannelValue>,
+    /// One record per tick, starting at `time_s = 0`.
+    pub steps: Vec<FixtureStep>,
+    /// Absolute path of the parsed document. This is not part of the wire data.
+    #[serde(skip)]
+    source_path: PathBuf,
+}
+
+/// Paths and hashes for every evaluator-consumed project file.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectBundle {
+    /// Bundle directory, relative to the fixture file unless absolute.
+    pub root: PathBuf,
+    /// Project descriptor path, relative to [`ProjectBundle::root`].
+    pub project: PathBuf,
+    /// Optional calibration path, relative to [`ProjectBundle::root`].
+    #[serde(default)]
+    pub config: Option<PathBuf>,
+    /// Exact manifest of the descriptor, calibration, and discovered scripts.
+    pub files: Vec<ProjectFileHash>,
+}
+
+/// One SHA-256 entry in a project bundle manifest.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectFileHash {
+    /// File path relative to the bundle root.
+    pub path: PathBuf,
+    /// Lowercase hexadecimal SHA-256 digest.
+    pub sha256: String,
+}
+
+/// How a fixture's expected values were produced.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureProvenance {
+    /// Whether this is synthetic data or a real M1 Sim capture.
+    pub kind: ProvenanceKind,
+    /// Concrete origin, such as a test-project name or simulator session ID.
+    pub source: String,
+    /// Capture procedure or a link to the procedure used.
+    pub procedure: String,
+    /// M1 Build or M1 Sim version for a genuine capture.
+    #[serde(default)]
+    pub tool_version: Option<String>,
+    /// UTC capture time for a genuine capture.
+    #[serde(default)]
+    pub captured_at_utc: Option<String>,
+    /// Optional free-form facts needed to reproduce the capture.
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+/// Evidence classification carried by each fixture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProvenanceKind {
+    /// Hand-derived expected values used to test the runner itself.
+    Synthetic,
+    /// Values captured from M1 Sim.
+    M1Sim,
+}
+
+impl fmt::Display for ProvenanceKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Synthetic => formatter.write_str("synthetic"),
+            Self::M1Sim => formatter.write_str("m1-sim"),
+        }
+    }
+}
+
+/// Evaluator mode recorded by a conformance fixture.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureRun {
+    /// Runner mode.
+    pub mode: FixtureRunMode,
+    /// Function name or cone channel. Whole-project mode must omit it.
+    #[serde(default)]
+    pub target: Option<String>,
+}
+
+/// Supported conformance-run modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FixtureRunMode {
+    /// Run one function on every fixture tick.
+    Function,
+    /// Run the dependency cone for one output channel.
+    Cone,
+    /// Run the project's periodic schedule on the fixture base grid.
+    WholeProject,
+}
+
+/// One typed channel value used as initial state or a step input.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureChannelValue {
+    /// Canonical project channel path.
+    pub channel: String,
+    /// Typed value on the fixture wire.
+    pub value: WireValue,
+}
+
+/// One captured tick.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureStep {
+    /// Tick time in seconds. Step `i` must use `i / calculation_rate_hz`.
+    pub time_s: f64,
+    /// Input changes applied at this tick and held until the next change.
+    #[serde(default)]
+    pub inputs: Vec<FixtureChannelValue>,
+    /// Expected channel values after this tick executes.
+    pub expected: Vec<ExpectedChannelValue>,
+}
+
+/// One expected output and its comparison rule.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectedChannelValue {
+    /// Canonical trace channel path.
+    pub channel: String,
+    /// Typed expected value.
+    pub value: WireValue,
+    /// Required for floating-point and fixed-point values, forbidden otherwise.
+    #[serde(default)]
+    pub tolerance: Option<ValueTolerance>,
+}
+
+/// A value with its M1 runtime family written explicitly.
+///
+/// Floating-point values use strings so JSON can carry `NaN`, `Infinity`, and
+/// `-Infinity`, and so a capture does not pass through a host-width JSON number.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum WireValue {
+    /// M1 Boolean.
+    Boolean { value: bool },
+    /// M1 binary32, written as a decimal string or an explicit non-finite token.
+    FloatingPoint { value: String },
+    /// M1 signed 32-bit integer.
+    Integer { value: i32 },
+    /// M1 unsigned 32-bit integer.
+    UnsignedInteger { value: u32 },
+    /// M1 signed fixed-point storage, scaled by 10^-7.
+    #[serde(rename = "fixed-point-7dps")]
+    FixedPoint7dps { raw: i32 },
+    /// Enum member with its declared type name.
+    Enum {
+        /// Project enum type name.
+        enum_type: String,
+        /// Declared member name.
+        member: String,
+    },
+    /// M1 string.
+    String { value: String },
+}
+
+/// Tolerance declaration for an approximate numeric family.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum ValueTolerance {
+    /// Binary32 comparison. At least one bound must be present.
+    FloatingPoint {
+        /// Absolute error bound, as a finite non-negative decimal string.
+        #[serde(default)]
+        absolute: Option<String>,
+        /// Relative error bound, as a finite non-negative decimal string.
+        #[serde(default)]
+        relative: Option<String>,
+    },
+    /// Fixed-point comparison in exact raw storage units.
+    #[serde(rename = "fixed-point-7dps")]
+    FixedPoint7dps {
+        /// Maximum absolute difference between the two signed raw values.
+        raw: u32,
+    },
+}
+
+/// Successful result for one fixture.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformanceReport {
+    /// Fixture name.
+    pub name: String,
+    /// Fixture file path.
+    pub path: PathBuf,
+    /// Evidence classification declared by the fixture.
+    pub provenance: ProvenanceKind,
+    /// Number of tick records checked.
+    pub steps_checked: usize,
+    /// Number of expected channel values checked.
+    pub assertions_checked: usize,
+}
+
+/// Options for a multi-fixture conformance run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ConformanceOptions {
+    /// Fail unless at least one passing fixture declares M1 Sim provenance.
+    pub require_m1_sim_capture: bool,
+}
+
+/// The first output mismatch found while walking a fixture in file order.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConformanceMismatch {
+    /// Fixture name.
+    pub fixture: String,
+    /// Zero-based step index.
+    pub step: usize,
+    /// Captured tick time.
+    pub time_s: f64,
+    /// Expected channel path.
+    pub channel: String,
+    /// Human-readable expected value and tolerance.
+    pub expected: String,
+    /// Actual runtime value, or `None` if no aligned trace value existed.
+    pub actual: Option<Value>,
+    /// Specific comparison failure.
+    pub detail: String,
+}
+
+impl fmt::Display for ConformanceMismatch {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "fixture {:?} step {} at t = {} s, channel {:?}: {}; expected {}, got {}",
+            self.fixture,
+            self.step,
+            self.time_s,
+            self.channel,
+            self.detail,
+            self.expected,
+            self.actual
+                .as_ref()
+                .map(runtime_value_text)
+                .unwrap_or_else(|| "no value".to_string())
+        )
+    }
+}
+
+/// Fixture parsing, integrity, evaluation, or comparison failure.
+#[derive(Debug)]
+pub enum ConformanceError {
+    /// A fixture or project file could not be read.
+    Io {
+        /// File involved.
+        path: PathBuf,
+        /// Operating-system error.
+        source: std::io::Error,
+    },
+    /// TOML or JSON did not match the fixture schema.
+    Parse {
+        /// Fixture file involved.
+        path: PathBuf,
+        /// Parser detail.
+        detail: String,
+    },
+    /// The document is syntactically valid but violates a fixture invariant.
+    InvalidFixture {
+        /// Fixture name or path.
+        fixture: String,
+        /// Failed invariant.
+        detail: String,
+    },
+    /// A project file did not match its declared SHA-256 digest.
+    HashMismatch {
+        /// Project file involved.
+        path: PathBuf,
+        /// Digest in the fixture.
+        expected: String,
+        /// Digest calculated by the runner.
+        actual: String,
+    },
+    /// Project loading or script evaluation failed.
+    Evaluation {
+        /// Fixture name.
+        fixture: String,
+        /// Evaluator error.
+        source: EvalError,
+    },
+    /// First expected-output mismatch.
+    Mismatch(Box<ConformanceMismatch>),
+    /// A suite requested real capture evidence but contained only synthetic data.
+    MissingM1SimCapture,
+}
+
+impl fmt::Display for ConformanceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, source } => write!(formatter, "{}: {source}", path.display()),
+            Self::Parse { path, detail } => {
+                write!(
+                    formatter,
+                    "{}: conformance fixture parse error: {detail}",
+                    path.display()
+                )
+            }
+            Self::InvalidFixture { fixture, detail } => {
+                write!(formatter, "fixture {fixture:?}: {detail}")
+            }
+            Self::HashMismatch {
+                path,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "{}: SHA-256 mismatch, fixture has {expected}, file has {actual}",
+                path.display()
+            ),
+            Self::Evaluation { fixture, source } => {
+                write!(formatter, "fixture {fixture:?}: {source}")
+            }
+            Self::Mismatch(mismatch) => mismatch.fmt(formatter),
+            Self::MissingM1SimCapture => formatter
+                .write_str("conformance suite passed, but no fixture declared `m1-sim` provenance"),
+        }
+    }
+}
+
+impl std::error::Error for ConformanceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::Evaluation { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl ConformanceFixture {
+    /// Read a TOML or JSON fixture. The extension selects the parser.
+    pub fn from_path(path: &Path) -> Result<Self, ConformanceError> {
+        let source_path = fs::canonicalize(path).map_err(|source| ConformanceError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let body = fs::read_to_string(&source_path).map_err(|source| ConformanceError::Io {
+            path: source_path.clone(),
+            source,
+        })?;
+        let extension = source_path
+            .extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default();
+        let mut fixture: Self = if extension.eq_ignore_ascii_case("json") {
+            serde_json::from_str(&body).map_err(|error| ConformanceError::Parse {
+                path: source_path.clone(),
+                detail: error.to_string(),
+            })?
+        } else if extension.eq_ignore_ascii_case("toml") {
+            toml::from_str(&body).map_err(|error| ConformanceError::Parse {
+                path: source_path.clone(),
+                detail: error.to_string(),
+            })?
+        } else {
+            return Err(ConformanceError::Parse {
+                path: source_path,
+                detail: "expected a `.toml` or `.json` fixture".to_string(),
+            });
+        };
+        fixture.source_path = source_path;
+        fixture.validate_document()?;
+        Ok(fixture)
+    }
+
+    fn invalid(&self, detail: impl Into<String>) -> ConformanceError {
+        ConformanceError::InvalidFixture {
+            fixture: if self.name.trim().is_empty() {
+                self.source_path.display().to_string()
+            } else {
+                self.name.clone()
+            },
+            detail: detail.into(),
+        }
+    }
+
+    fn validate_document(&self) -> Result<(), ConformanceError> {
+        if self.schema_version != CONFORMANCE_SCHEMA_VERSION {
+            return Err(self.invalid(format!(
+                "unsupported schema_version {}, expected {}",
+                self.schema_version, CONFORMANCE_SCHEMA_VERSION
+            )));
+        }
+        if self.name.trim().is_empty() {
+            return Err(self.invalid("`name` must not be empty"));
+        }
+        if !self.calculation_rate_hz.is_finite() || self.calculation_rate_hz <= 0.0 {
+            return Err(self.invalid(format!(
+                "calculation_rate_hz must be finite and positive, got {}",
+                self.calculation_rate_hz
+            )));
+        }
+        match self.run.mode {
+            FixtureRunMode::Function | FixtureRunMode::Cone => {
+                if self
+                    .run
+                    .target
+                    .as_deref()
+                    .is_none_or(|target| target.trim().is_empty())
+                {
+                    return Err(self.invalid("function and cone modes require a non-empty target"));
+                }
+            }
+            FixtureRunMode::WholeProject if self.run.target.is_some() => {
+                return Err(self.invalid("whole-project mode must not declare a target"));
+            }
+            FixtureRunMode::WholeProject => {}
+        }
+        if self.provenance.source.trim().is_empty() || self.provenance.procedure.trim().is_empty() {
+            return Err(self.invalid("provenance source and procedure must not be empty"));
+        }
+        if self.provenance.kind == ProvenanceKind::M1Sim {
+            for (name, value) in [
+                ("tool_version", self.provenance.tool_version.as_deref()),
+                (
+                    "captured_at_utc",
+                    self.provenance.captured_at_utc.as_deref(),
+                ),
+            ] {
+                if value.is_none_or(|text| text.trim().is_empty()) {
+                    return Err(
+                        self.invalid(format!("m1-sim provenance requires a non-empty {name}"))
+                    );
+                }
+            }
+        }
+        if self.steps.is_empty() {
+            return Err(self.invalid("at least one step is required"));
+        }
+
+        let mut initial_channels = BTreeSet::new();
+        for initial in &self.initial_state {
+            validate_channel_name(self, &initial.channel, "initial-state")?;
+            if !initial_channels.insert(initial.channel.as_str()) {
+                return Err(self.invalid(format!(
+                    "initial state declares channel {:?} more than once",
+                    initial.channel
+                )));
+            }
+            initial.value.validate(self)?;
+        }
+
+        let mut first_input_step: BTreeMap<&str, usize> = BTreeMap::new();
+        let mut output_channels: Option<BTreeSet<&str>> = None;
+        for (index, step) in self.steps.iter().enumerate() {
+            let expected_time = index as f64 / self.calculation_rate_hz;
+            if !step.time_s.is_finite()
+                || (step.time_s - expected_time).abs() > 1e-12_f64.max(expected_time.abs() * 1e-12)
+            {
+                return Err(self.invalid(format!(
+                    "step {index} time_s {} is off the {} Hz grid; expected {expected_time}",
+                    step.time_s, self.calculation_rate_hz
+                )));
+            }
+            if step.expected.is_empty() {
+                return Err(self.invalid(format!(
+                    "step {index} must declare at least one expected output"
+                )));
+            }
+
+            let mut input_channels = BTreeSet::new();
+            for input in &step.inputs {
+                validate_channel_name(self, &input.channel, "input")?;
+                if !input_channels.insert(input.channel.as_str()) {
+                    return Err(self.invalid(format!(
+                        "step {index} declares input channel {:?} more than once",
+                        input.channel
+                    )));
+                }
+                first_input_step.entry(&input.channel).or_insert(index);
+                input.value.validate(self)?;
+            }
+
+            let mut expected_channels = BTreeSet::new();
+            for expected in &step.expected {
+                validate_channel_name(self, &expected.channel, "expected output")?;
+                if !expected_channels.insert(expected.channel.as_str()) {
+                    return Err(self.invalid(format!(
+                        "step {index} declares expected channel {:?} more than once",
+                        expected.channel
+                    )));
+                }
+                expected.value.validate(self)?;
+                validate_tolerance(self, index, expected)?;
+            }
+            if let Some(first) = &output_channels {
+                if &expected_channels != first {
+                    return Err(self.invalid(format!(
+                        "step {index} expected-channel set differs from step 0"
+                    )));
+                }
+            } else {
+                output_channels = Some(expected_channels);
+            }
+        }
+        for (&channel, &first_step) in &first_input_step {
+            if first_step != 0 && !initial_channels.contains(channel) {
+                return Err(self.invalid(format!(
+                    "input channel {channel:?} first changes at step {first_step}; seed it in initial_state or step 0"
+                )));
+            }
+        }
+        if let Some(outputs) = output_channels {
+            for channel in first_input_step.keys() {
+                if outputs.contains(channel) {
+                    return Err(self.invalid(format!(
+                        "expected channel {channel:?} is also a fixture input; expected outputs must be disjoint from externally driven inputs"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn resolved_mode(&self) -> RunMode {
+        match self.run.mode {
+            FixtureRunMode::Function => {
+                RunMode::Function(self.run.target.clone().expect("target validated"))
+            }
+            FixtureRunMode::Cone => {
+                RunMode::Cone(self.run.target.clone().expect("target validated"))
+            }
+            FixtureRunMode::WholeProject => RunMode::WholeProject,
+        }
+    }
+}
+
+impl WireValue {
+    fn validate(&self, fixture: &ConformanceFixture) -> Result<(), ConformanceError> {
+        match self {
+            Self::FloatingPoint { value } => parse_wire_float(value)
+                .map(|_| ())
+                .map_err(|detail| fixture.invalid(detail)),
+            Self::Enum { enum_type, member }
+                if enum_type.trim().is_empty() || member.trim().is_empty() =>
+            {
+                Err(fixture.invalid("enum type and member names must not be empty"))
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn to_value(
+        &self,
+        fixture: &ConformanceFixture,
+        project: &Project,
+    ) -> Result<Value, ConformanceError> {
+        match self {
+            Self::Boolean { value } => Ok(Value::Bool(*value)),
+            Self::FloatingPoint { value } => parse_wire_float(value)
+                .map(Value::m1_float)
+                .map_err(|detail| fixture.invalid(detail)),
+            Self::Integer { value } => Ok(Value::m1_integer(*value)),
+            Self::UnsignedInteger { value } => Ok(Value::m1_unsigned(*value)),
+            Self::FixedPoint7dps { raw } => Ok(Value::M1(M1Scalar::FixedPoint7dps(
+                FixedPoint7dps::from_raw(*raw),
+            ))),
+            Self::Enum { enum_type, member } => {
+                let id = project.symbols().enum_by_name(enum_type).ok_or_else(|| {
+                    fixture.invalid(format!("project has no enum type {enum_type:?}"))
+                })?;
+                let declared = project
+                    .symbols()
+                    .enum_type(id)
+                    .members
+                    .iter()
+                    .any(|(name, _)| name == member);
+                if !declared {
+                    return Err(fixture
+                        .invalid(format!("enum type {enum_type:?} has no member {member:?}")));
+                }
+                Ok(Value::Enum {
+                    id,
+                    member: member.clone(),
+                })
+            }
+            Self::String { value } => Ok(Value::Str(value.clone())),
+        }
+    }
+
+    fn describe(&self) -> String {
+        match self {
+            Self::Boolean { value } => format!("boolean({value})"),
+            Self::FloatingPoint { value } => format!("floating-point({value})"),
+            Self::Integer { value } => format!("integer({value})"),
+            Self::UnsignedInteger { value } => format!("unsigned-integer({value})"),
+            Self::FixedPoint7dps { raw } => format!("fixed-point-7dps(raw={raw})"),
+            Self::Enum { enum_type, member } => format!("enum({enum_type}.{member})"),
+            Self::String { value } => format!("string({value:?})"),
+        }
+    }
+}
+
+/// Run one fixture from disk.
+pub fn run_conformance_fixture(path: &Path) -> Result<ConformanceReport, ConformanceError> {
+    let fixture = ConformanceFixture::from_path(path)?;
+    run_parsed_fixture(&fixture)
+}
+
+/// Run fixtures in the supplied order, stopping at the first failure.
+///
+/// Each path goes through [`run_conformance_fixture`], which reloads the project
+/// and creates a new evaluator environment and state store. Repeating a fixture
+/// in the same suite is therefore a useful state-reset check.
+pub fn run_conformance_suite(
+    paths: &[PathBuf],
+    options: ConformanceOptions,
+) -> Result<Vec<ConformanceReport>, ConformanceError> {
+    if paths.is_empty() {
+        return Err(ConformanceError::InvalidFixture {
+            fixture: "suite".to_string(),
+            detail: "at least one fixture path is required".to_string(),
+        });
+    }
+    let mut reports = Vec::with_capacity(paths.len());
+    for path in paths {
+        reports.push(run_conformance_fixture(path)?);
+    }
+    if options.require_m1_sim_capture
+        && !reports
+            .iter()
+            .any(|report| report.provenance == ProvenanceKind::M1Sim)
+    {
+        return Err(ConformanceError::MissingM1SimCapture);
+    }
+    Ok(reports)
+}
+
+fn run_parsed_fixture(fixture: &ConformanceFixture) -> Result<ConformanceReport, ConformanceError> {
+    let bundle = resolve_and_verify_bundle(fixture)?;
+    let loaded = load(&bundle.project, bundle.config.as_deref()).map_err(|source| {
+        ConformanceError::Evaluation {
+            fixture: fixture.name.clone(),
+            source,
+        }
+    })?;
+    validate_project_bindings(fixture, &loaded.project)?;
+    let scenario = fixture_scenario(fixture, &loaded)?;
+    let trace = runner::run(&loaded, &scenario).map_err(|source| ConformanceError::Evaluation {
+        fixture: fixture.name.clone(),
+        source,
+    })?;
+    compare_trace(fixture, &loaded.project, &trace)?;
+
+    Ok(ConformanceReport {
+        name: fixture.name.clone(),
+        path: fixture.source_path.clone(),
+        provenance: fixture.provenance.kind,
+        steps_checked: fixture.steps.len(),
+        assertions_checked: fixture.steps.iter().map(|step| step.expected.len()).sum(),
+    })
+}
+
+fn validate_project_bindings(
+    fixture: &ConformanceFixture,
+    project: &Project,
+) -> Result<(), ConformanceError> {
+    for initial in &fixture.initial_state {
+        validate_project_value(
+            fixture,
+            project,
+            "initial-state",
+            &initial.channel,
+            &initial.value,
+        )?;
+    }
+    for (index, step) in fixture.steps.iter().enumerate() {
+        for input in &step.inputs {
+            validate_project_value(
+                fixture,
+                project,
+                &format!("step {index} input"),
+                &input.channel,
+                &input.value,
+            )?;
+        }
+        for expected in &step.expected {
+            validate_project_value(
+                fixture,
+                project,
+                &format!("step {index} expected output"),
+                &expected.channel,
+                &expected.value,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_project_value(
+    fixture: &ConformanceFixture,
+    project: &Project,
+    role: &str,
+    channel: &str,
+    wire: &WireValue,
+) -> Result<(), ConformanceError> {
+    let Some(symbol) = project.symbols().get(channel) else {
+        return Err(fixture.invalid(format!(
+            "{role} channel {channel:?} is not a project symbol; use its canonical project path"
+        )));
+    };
+    if symbol.kind != SymbolKind::Channel {
+        return Err(fixture.invalid(format!(
+            "{role} path {channel:?} resolves to {:?}, not a project Channel",
+            symbol.kind
+        )));
+    }
+    let value = wire.to_value(fixture, project)?;
+    let declared = runtime_family(&value);
+    if let Some(stored) = project_runtime_family(symbol.value_type, symbol.declared_type.as_deref())
+        && declared != stored
+    {
+        return Err(fixture.invalid(format!(
+            "{role} channel {channel:?} declares {}, but the project stores {}",
+            declared.name(),
+            stored.name()
+        )));
+    }
+    let coerced =
+        crate::expr::coerce_for_channel(channel, value.clone(), project).map_err(|source| {
+            fixture.invalid(format!(
+                "{role} channel {channel:?} has an incompatible typed value: {source}"
+            ))
+        })?;
+    if declared != runtime_family(&coerced) {
+        return Err(fixture.invalid(format!(
+            "{role} channel {channel:?} declares {}, but the project stores {}",
+            declared.name(),
+            runtime_family(&coerced).name()
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeFamily {
+    Boolean,
+    FloatingPoint,
+    Integer,
+    UnsignedInteger,
+    FixedPoint7dps,
+    Enum(usize),
+    String,
+}
+
+impl RuntimeFamily {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Boolean => "Boolean",
+            Self::FloatingPoint => "FloatingPoint",
+            Self::Integer => "Integer",
+            Self::UnsignedInteger => "UnsignedInteger",
+            Self::FixedPoint7dps => "FixedPoint7dps",
+            Self::Enum(_) => "Enumeration",
+            Self::String => "String",
+        }
+    }
+}
+
+fn runtime_family(value: &Value) -> RuntimeFamily {
+    match value {
+        Value::Bool(_) => RuntimeFamily::Boolean,
+        Value::M1(scalar) => match scalar.kind() {
+            crate::value::M1ScalarKind::FloatingPoint => RuntimeFamily::FloatingPoint,
+            crate::value::M1ScalarKind::Integer => RuntimeFamily::Integer,
+            crate::value::M1ScalarKind::UnsignedInteger => RuntimeFamily::UnsignedInteger,
+            crate::value::M1ScalarKind::FixedPoint7dps => RuntimeFamily::FixedPoint7dps,
+        },
+        Value::Enum { id, .. } => RuntimeFamily::Enum(*id),
+        Value::Str(_) => RuntimeFamily::String,
+    }
+}
+
+fn project_runtime_family(
+    value_type: ValueType,
+    declared_type: Option<&str>,
+) -> Option<RuntimeFamily> {
+    if let Some(declared) = declared_type {
+        let normalized = declared.to_ascii_lowercase().replace([' ', '_', '-'], "");
+        let family = match normalized.as_str() {
+            "bool" | "boolean" => Some(RuntimeFamily::Boolean),
+            "f32" | "f64" | "float" | "floatingpoint" => Some(RuntimeFamily::FloatingPoint),
+            "s8" | "s16" | "s32" | "s64" | "integer" => Some(RuntimeFamily::Integer),
+            "u8" | "u16" | "u32" | "u64" | "unsigned" | "unsignedinteger" => {
+                Some(RuntimeFamily::UnsignedInteger)
+            }
+            "fixedpoint7dps" | "fixed7dps" => Some(RuntimeFamily::FixedPoint7dps),
+            "str" | "string" => Some(RuntimeFamily::String),
+            _ => None,
+        };
+        if family.is_some() {
+            return family;
+        }
+    }
+    match value_type {
+        ValueType::Boolean => Some(RuntimeFamily::Boolean),
+        ValueType::Integer => Some(RuntimeFamily::Integer),
+        ValueType::Unsigned => Some(RuntimeFamily::UnsignedInteger),
+        ValueType::Float => Some(RuntimeFamily::FloatingPoint),
+        ValueType::String => Some(RuntimeFamily::String),
+        ValueType::Enum(id) => Some(RuntimeFamily::Enum(id)),
+        ValueType::Unknown => None,
+    }
+}
+
+struct ResolvedBundle {
+    project: PathBuf,
+    config: Option<PathBuf>,
+}
+
+fn resolve_and_verify_bundle(
+    fixture: &ConformanceFixture,
+) -> Result<ResolvedBundle, ConformanceError> {
+    let fixture_dir = fixture
+        .source_path
+        .parent()
+        .expect("a canonical fixture path has a parent");
+    let root_path = if fixture.project.root.is_absolute() {
+        fixture.project.root.clone()
+    } else {
+        fixture_dir.join(&fixture.project.root)
+    };
+    let root = fs::canonicalize(&root_path).map_err(|source| ConformanceError::Io {
+        path: root_path,
+        source,
+    })?;
+    if !root.is_dir() {
+        return Err(fixture.invalid(format!(
+            "project bundle root {} is not a directory",
+            root.display()
+        )));
+    }
+
+    validate_relative_path(fixture, &fixture.project.project, "project")?;
+    if let Some(config) = &fixture.project.config {
+        validate_relative_path(fixture, config, "config")?;
+    }
+    let project = resolve_bundle_file(fixture, &root, &fixture.project.project)?;
+    let config = fixture
+        .project
+        .config
+        .as_ref()
+        .map(|path| resolve_bundle_file(fixture, &root, path))
+        .transpose()?;
+
+    let mut expected_paths = BTreeSet::new();
+    expected_paths.insert(fixture.project.project.clone());
+    if let Some(config) = &fixture.project.config {
+        expected_paths.insert(config.clone());
+    }
+    let project_dir = fixture
+        .project
+        .project
+        .parent()
+        .unwrap_or_else(|| Path::new(""));
+    collect_script_paths(fixture, &root, project_dir, &mut expected_paths)?;
+    let mut script_basenames = BTreeMap::new();
+    for path in expected_paths
+        .iter()
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("m1scr"))
+    {
+        let basename = path
+            .file_name()
+            .expect("a normalized script path has a basename")
+            .to_os_string();
+        if let Some(first) = script_basenames.insert(basename, path) {
+            return Err(fixture.invalid(format!(
+                "project bundle contains duplicate script basename {:?}: {} and {}; evaluator loading would be filesystem-order dependent",
+                path.file_name().expect("script path has a basename"),
+                first.display(),
+                path.display()
+            )));
+        }
+    }
+
+    let mut manifest = BTreeMap::new();
+    for entry in &fixture.project.files {
+        validate_relative_path(fixture, &entry.path, "manifest")?;
+        if entry.sha256.len() != 64
+            || !entry
+                .sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(fixture.invalid(format!(
+                "manifest entry {} has an invalid SHA-256 digest",
+                entry.path.display()
+            )));
+        }
+        if manifest
+            .insert(entry.path.clone(), entry.sha256.clone())
+            .is_some()
+        {
+            return Err(fixture.invalid(format!(
+                "manifest declares {} more than once",
+                entry.path.display()
+            )));
+        }
+    }
+    let manifest_paths: BTreeSet<PathBuf> = manifest.keys().cloned().collect();
+    if manifest_paths != expected_paths {
+        let missing = expected_paths
+            .difference(&manifest_paths)
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>();
+        let extra = manifest_paths
+            .difference(&expected_paths)
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>();
+        return Err(fixture.invalid(format!(
+            "project manifest does not match evaluator inputs; missing [{}], extra [{}]",
+            missing.join(", "),
+            extra.join(", ")
+        )));
+    }
+
+    for (relative, declared_hash) in manifest {
+        let path = resolve_bundle_file(fixture, &root, &relative)?;
+        let bytes = fs::read(&path).map_err(|source| ConformanceError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        let actual = format!("{:x}", Sha256::digest(bytes));
+        if !actual.eq_ignore_ascii_case(&declared_hash) {
+            return Err(ConformanceError::HashMismatch {
+                path,
+                expected: declared_hash,
+                actual,
+            });
+        }
+    }
+
+    Ok(ResolvedBundle { project, config })
+}
+
+fn validate_relative_path(
+    fixture: &ConformanceFixture,
+    path: &Path,
+    label: &str,
+) -> Result<(), ConformanceError> {
+    if path.as_os_str().is_empty()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(fixture.invalid(format!(
+            "{label} path {:?} must be a normalized path relative to the project bundle root",
+            path.display().to_string()
+        )));
+    }
+    Ok(())
+}
+
+fn resolve_bundle_file(
+    fixture: &ConformanceFixture,
+    root: &Path,
+    relative: &Path,
+) -> Result<PathBuf, ConformanceError> {
+    let mut joined = root.to_path_buf();
+    let components = relative.components().collect::<Vec<_>>();
+    for (index, component) in components.iter().enumerate() {
+        let Component::Normal(name) = component else {
+            unreachable!("bundle paths were validated before resolution");
+        };
+        joined.push(name);
+        let metadata = fs::symlink_metadata(&joined).map_err(|source| ConformanceError::Io {
+            path: joined.clone(),
+            source,
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(fixture.invalid(format!(
+                "project bundle path {} must not contain a symlink",
+                joined.display()
+            )));
+        }
+        let is_last = index + 1 == components.len();
+        if (is_last && !metadata.is_file()) || (!is_last && !metadata.is_dir()) {
+            return Err(fixture.invalid(format!(
+                "project bundle path {} is not a {}",
+                joined.display(),
+                if is_last { "regular file" } else { "directory" }
+            )));
+        }
+    }
+    Ok(joined)
+}
+
+fn collect_script_paths(
+    fixture: &ConformanceFixture,
+    root: &Path,
+    relative_dir: &Path,
+    out: &mut BTreeSet<PathBuf>,
+) -> Result<(), ConformanceError> {
+    let dir = root.join(relative_dir);
+    let dir_metadata = fs::symlink_metadata(&dir).map_err(|source| ConformanceError::Io {
+        path: dir.clone(),
+        source,
+    })?;
+    if dir_metadata.file_type().is_symlink() {
+        return Err(fixture.invalid(format!(
+            "project bundle contains symlink {}, which cannot be hashed portably",
+            relative_dir.display()
+        )));
+    }
+    if !dir_metadata.is_dir() {
+        return Err(fixture.invalid(format!(
+            "project script root {} is not a directory",
+            relative_dir.display()
+        )));
+    }
+    let mut entries = fs::read_dir(&dir)
+        .map_err(|source| ConformanceError::Io {
+            path: dir.clone(),
+            source,
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| ConformanceError::Io {
+            path: dir.clone(),
+            source,
+        })?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let file_type = entry.file_type().map_err(|source| ConformanceError::Io {
+            path: entry.path(),
+            source,
+        })?;
+        let relative = relative_dir.join(entry.file_name());
+        if file_type.is_symlink() {
+            return Err(fixture.invalid(format!(
+                "project bundle contains symlink {}, which cannot be hashed portably",
+                relative.display()
+            )));
+        }
+        if file_type.is_dir() {
+            collect_script_paths(fixture, root, &relative, out)?;
+        } else if file_type.is_file()
+            && entry.path().extension().and_then(|value| value.to_str()) == Some("m1scr")
+        {
+            out.insert(relative);
+        }
+    }
+    Ok(())
+}
+
+fn fixture_scenario(
+    fixture: &ConformanceFixture,
+    loaded: &Loaded,
+) -> Result<Scenario, ConformanceError> {
+    let mut initial_by_channel = BTreeMap::new();
+    let mut initial_state = Vec::with_capacity(fixture.initial_state.len());
+    for initial in &fixture.initial_state {
+        let value = initial.value.to_value(fixture, &loaded.project)?;
+        initial_by_channel.insert(initial.channel.clone(), value.clone());
+        initial_state.push(InitialValue {
+            channel: initial.channel.clone(),
+            value,
+        });
+    }
+
+    let mut updates: BTreeMap<String, Vec<(f64, Value)>> = BTreeMap::new();
+    for (index, step) in fixture.steps.iter().enumerate() {
+        let grid_time = index as f64 / fixture.calculation_rate_hz;
+        for input in &step.inputs {
+            updates
+                .entry(input.channel.clone())
+                .or_default()
+                .push((grid_time, input.value.to_value(fixture, &loaded.project)?));
+        }
+    }
+    for (channel, points) in &mut updates {
+        if points.first().is_some_and(|(time, _)| *time > 0.0) {
+            let initial = initial_by_channel
+                .get(channel)
+                .expect("late input was required to have initial state");
+            points.insert(0, (0.0, initial.clone()));
+        }
+    }
+    let inputs = updates
+        .into_iter()
+        .map(|(channel, points)| InputSeries {
+            channel,
+            kind: InputKind::Series(points),
+        })
+        .collect();
+    let duration_s = fixture.steps.len() as f64 / fixture.calculation_rate_hz;
+    if !duration_s.is_finite() || duration_s <= 0.0 {
+        return Err(fixture.invalid("fixture tick grid produces an invalid duration"));
+    }
+    Ok(Scenario {
+        mode: fixture.resolved_mode(),
+        initial_state,
+        inputs,
+        duration_s,
+        base_rate_hz: fixture.calculation_rate_hz,
+        overrides: Vec::new(),
+        io: Vec::new(),
+        allow_default_inputs: false,
+    })
+}
+
+fn compare_trace(
+    fixture: &ConformanceFixture,
+    project: &Project,
+    trace: &Trace,
+) -> Result<(), ConformanceError> {
+    if trace.time.len() != fixture.steps.len() {
+        return Err(fixture.invalid(format!(
+            "runner produced {} ticks for {} fixture steps",
+            trace.time.len(),
+            fixture.steps.len()
+        )));
+    }
+    let declared_sources: BTreeSet<&str> = fixture
+        .initial_state
+        .iter()
+        .map(|value| value.channel.as_str())
+        .chain(
+            fixture
+                .steps
+                .iter()
+                .flat_map(|step| step.inputs.iter().map(|input| input.channel.as_str())),
+        )
+        .collect();
+    if let Some(source) = trace
+        .external
+        .iter()
+        .find(|source| !declared_sources.contains(source.as_str()))
+    {
+        return Err(fixture.invalid(format!(
+            "evaluation used undeclared external source {source:?}; every external source must be an explicit fixture input or initial-state channel"
+        )));
+    }
+    for (index, step) in fixture.steps.iter().enumerate() {
+        if (trace.time[index] - step.time_s).abs() > 1e-12_f64.max(step.time_s.abs() * 1e-12) {
+            return Err(fixture.invalid(format!(
+                "runner tick {index} was at {} s, fixture records {} s",
+                trace.time[index], step.time_s
+            )));
+        }
+        for expected in &step.expected {
+            if trace.channel_is_external_at_tick(&expected.channel, index) {
+                return Err(fixture.invalid(format!(
+                    "step {index} expected channel {:?} is externally supplied rather than evaluator-computed at that tick",
+                    expected.channel
+                )));
+            }
+            let actual = trace
+                .channel_value_at_tick(&expected.channel, index)
+                .cloned();
+            let alignment_error = actual.is_none().then(|| {
+                if trace.channels.contains_key(&expected.channel) {
+                    "trace channel has no value aligned to this tick".to_string()
+                } else {
+                    "trace has no channel with this path".to_string()
+                }
+            });
+            let expected_value = expected.value.to_value(fixture, project)?;
+            let result = match (actual.as_ref(), alignment_error) {
+                (Some(actual), None) => {
+                    compare_value(&expected_value, actual, expected.tolerance.as_ref())
+                }
+                (_, Some(detail)) => Err(detail),
+                (None, None) => Err("trace has no aligned value for this channel".to_string()),
+            };
+            if let Err(detail) = result {
+                return Err(ConformanceError::Mismatch(Box::new(ConformanceMismatch {
+                    fixture: fixture.name.clone(),
+                    step: index,
+                    time_s: step.time_s,
+                    channel: expected.channel.clone(),
+                    expected: expected_text(expected),
+                    actual,
+                    detail,
+                })));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_channel_name(
+    fixture: &ConformanceFixture,
+    channel: &str,
+    label: &str,
+) -> Result<(), ConformanceError> {
+    if channel.trim().is_empty() {
+        Err(fixture.invalid(format!("{label} channel must not be empty")))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_tolerance(
+    fixture: &ConformanceFixture,
+    step: usize,
+    expected: &ExpectedChannelValue,
+) -> Result<(), ConformanceError> {
+    match (&expected.value, &expected.tolerance) {
+        (
+            WireValue::FloatingPoint { .. },
+            Some(ValueTolerance::FloatingPoint { absolute, relative }),
+        ) => {
+            if absolute.is_none() && relative.is_none() {
+                return Err(fixture.invalid(format!(
+                    "step {step} channel {:?} needs an absolute or relative floating-point tolerance",
+                    expected.channel
+                )));
+            }
+            for (name, bound) in [("absolute", absolute), ("relative", relative)] {
+                if let Some(bound) = bound {
+                    parse_tolerance(bound).map_err(|detail| {
+                        fixture.invalid(format!(
+                            "step {step} channel {:?} has invalid {name} tolerance: {detail}",
+                            expected.channel
+                        ))
+                    })?;
+                }
+            }
+            Ok(())
+        }
+        (WireValue::FloatingPoint { .. }, _) => Err(fixture.invalid(format!(
+            "step {step} channel {:?} needs a floating-point tolerance",
+            expected.channel
+        ))),
+        (WireValue::FixedPoint7dps { .. }, Some(ValueTolerance::FixedPoint7dps { .. })) => Ok(()),
+        (WireValue::FixedPoint7dps { .. }, _) => Err(fixture.invalid(format!(
+            "step {step} channel {:?} needs a fixed-point raw tolerance",
+            expected.channel
+        ))),
+        (_, None) => Ok(()),
+        (_, Some(_)) => Err(fixture.invalid(format!(
+            "step {step} channel {:?} has a tolerance, but its type compares exactly",
+            expected.channel
+        ))),
+    }
+}
+
+fn compare_value(
+    expected: &Value,
+    actual: &Value,
+    tolerance: Option<&ValueTolerance>,
+) -> Result<(), String> {
+    match (expected, actual) {
+        (Value::Bool(expected), Value::Bool(actual)) => exact(*expected == *actual),
+        (Value::M1(M1Scalar::Integer(expected)), Value::M1(M1Scalar::Integer(actual))) => {
+            exact(expected == actual)
+        }
+        (
+            Value::M1(M1Scalar::UnsignedInteger(expected)),
+            Value::M1(M1Scalar::UnsignedInteger(actual)),
+        ) => exact(expected == actual),
+        (
+            Value::M1(M1Scalar::FixedPoint7dps(expected)),
+            Value::M1(M1Scalar::FixedPoint7dps(actual)),
+        ) => {
+            let Some(ValueTolerance::FixedPoint7dps { raw }) = tolerance else {
+                return Err("missing fixed-point tolerance".to_string());
+            };
+            let delta = (i64::from(expected.raw()) - i64::from(actual.raw())).unsigned_abs();
+            if delta <= u64::from(*raw) {
+                Ok(())
+            } else {
+                Err(format!("raw delta {delta} exceeds tolerance {raw}"))
+            }
+        }
+        (
+            Value::M1(M1Scalar::FloatingPoint(expected)),
+            Value::M1(M1Scalar::FloatingPoint(actual)),
+        ) => compare_float(*expected, *actual, tolerance),
+        (
+            Value::Enum {
+                id: expected_id,
+                member: expected_member,
+            },
+            Value::Enum {
+                id: actual_id,
+                member: actual_member,
+            },
+        ) => exact(expected_id == actual_id && expected_member == actual_member),
+        (Value::Str(expected), Value::Str(actual)) => exact(expected == actual),
+        _ => Err(format!(
+            "runtime type differs, expected {}, got {}",
+            runtime_value_text(expected),
+            runtime_value_text(actual)
+        )),
+    }
+}
+
+fn exact(matches: bool) -> Result<(), String> {
+    if matches {
+        Ok(())
+    } else {
+        Err("values differ under exact comparison".to_string())
+    }
+}
+
+fn compare_float(
+    expected: f32,
+    actual: f32,
+    tolerance: Option<&ValueTolerance>,
+) -> Result<(), String> {
+    if expected.is_nan() {
+        return exact(actual.is_nan())
+            .map_err(|_| "expected NaN, but the actual value is not NaN".to_string());
+    }
+    if expected.is_infinite() {
+        return exact(actual == expected).map_err(|_| {
+            format!(
+                "expected {}, got {}",
+                float_text(expected),
+                float_text(actual)
+            )
+        });
+    }
+    if !actual.is_finite() {
+        return Err(format!(
+            "expected a finite value, got {}",
+            float_text(actual)
+        ));
+    }
+    let Some(ValueTolerance::FloatingPoint { absolute, relative }) = tolerance else {
+        return Err("missing floating-point tolerance".to_string());
+    };
+    let absolute = absolute
+        .as_deref()
+        .map(parse_tolerance)
+        .transpose()
+        .map_err(|detail| format!("invalid absolute tolerance: {detail}"))?
+        .unwrap_or(0.0);
+    let relative = relative
+        .as_deref()
+        .map(parse_tolerance)
+        .transpose()
+        .map_err(|detail| format!("invalid relative tolerance: {detail}"))?
+        .unwrap_or(0.0);
+    let expected = f64::from(expected);
+    let actual = f64::from(actual);
+    let delta = (actual - expected).abs();
+    let allowed = absolute.max(relative * expected.abs().max(actual.abs()));
+    if delta <= allowed {
+        Ok(())
+    } else {
+        Err(format!(
+            "absolute delta {delta} exceeds allowed error {allowed}"
+        ))
+    }
+}
+
+fn parse_wire_float(text: &str) -> Result<f32, String> {
+    let trimmed = text.trim();
+    let explicit = match trimmed.to_ascii_lowercase().as_str() {
+        "nan" | "+nan" | "-nan" => Some(f32::NAN),
+        "inf" | "+inf" | "infinity" | "+infinity" => Some(f32::INFINITY),
+        "-inf" | "-infinity" => Some(f32::NEG_INFINITY),
+        _ => None,
+    };
+    if let Some(value) = explicit {
+        return Ok(value);
+    }
+    let value = trimmed
+        .parse::<f32>()
+        .map_err(|_| format!("floating-point value {text:?} is not a binary32 decimal"))?;
+    if value.is_infinite() {
+        Err(format!(
+            "finite decimal {text:?} is outside the binary32 range"
+        ))
+    } else {
+        Ok(value)
+    }
+}
+
+fn parse_tolerance(text: &str) -> Result<f64, String> {
+    let value = text
+        .trim()
+        .parse::<f64>()
+        .map_err(|_| format!("{text:?} is not a decimal number"))?;
+    if !value.is_finite() || value < 0.0 {
+        Err(format!("{text:?} must be finite and non-negative"))
+    } else {
+        Ok(value)
+    }
+}
+
+fn expected_text(expected: &ExpectedChannelValue) -> String {
+    let value = expected.value.describe();
+    match &expected.tolerance {
+        None => format!("{value} exactly"),
+        Some(ValueTolerance::FixedPoint7dps { raw }) => {
+            format!("{value} within {raw} raw unit(s)")
+        }
+        Some(ValueTolerance::FloatingPoint { absolute, relative }) => format!(
+            "{value} with absolute={} relative={}",
+            absolute.as_deref().unwrap_or("unset"),
+            relative.as_deref().unwrap_or("unset")
+        ),
+    }
+}
+
+fn runtime_value_text(value: &Value) -> String {
+    match value {
+        Value::Bool(value) => format!("boolean({value})"),
+        Value::M1(M1Scalar::FloatingPoint(value)) => {
+            format!("floating-point({})", float_text(*value))
+        }
+        Value::M1(M1Scalar::Integer(value)) => format!("integer({value})"),
+        Value::M1(M1Scalar::UnsignedInteger(value)) => {
+            format!("unsigned-integer({value})")
+        }
+        Value::M1(M1Scalar::FixedPoint7dps(value)) => {
+            format!("fixed-point-7dps(raw={})", value.raw())
+        }
+        Value::Enum { id, member } => format!("enum(id={id}, member={member:?})"),
+        Value::Str(value) => format!("string({value:?})"),
+    }
+}
+
+fn float_text(value: f32) -> String {
+    if value.is_nan() {
+        "NaN".to_string()
+    } else if value == f32::INFINITY {
+        "Infinity".to_string()
+    } else if value == f32::NEG_INFINITY {
+        "-Infinity".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comparison_rules_are_family_specific() {
+        let float_tolerance = ValueTolerance::FloatingPoint {
+            absolute: Some("0.01".to_string()),
+            relative: None,
+        };
+        assert!(
+            compare_value(
+                &Value::m1_float(1.0),
+                &Value::m1_float(1.005),
+                Some(&float_tolerance),
+            )
+            .is_ok()
+        );
+        assert!(
+            compare_value(
+                &Value::m1_float(1.0),
+                &Value::m1_float(1.02),
+                Some(&float_tolerance),
+            )
+            .is_err()
+        );
+        assert!(compare_value(&Value::Bool(true), &Value::Bool(false), None).is_err());
+        assert!(compare_value(&Value::m1_integer(1), &Value::m1_integer(2), None).is_err());
+        assert!(compare_value(&Value::m1_unsigned(1), &Value::m1_integer(1), None,).is_err());
+
+        let fixed_tolerance = ValueTolerance::FixedPoint7dps { raw: 2 };
+        let fixed = |raw| Value::M1(M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(raw)));
+        assert!(compare_value(&fixed(100), &fixed(102), Some(&fixed_tolerance)).is_ok());
+        assert!(compare_value(&fixed(100), &fixed(103), Some(&fixed_tolerance)).is_err());
+
+        let relative_tolerance = ValueTolerance::FloatingPoint {
+            absolute: None,
+            relative: Some("0.01".to_string()),
+        };
+        assert!(
+            compare_value(
+                &Value::m1_float(100.0),
+                &Value::m1_float(101.0),
+                Some(&relative_tolerance),
+            )
+            .is_ok()
+        );
+        assert!(
+            compare_value(
+                &Value::m1_float(100.0),
+                &Value::m1_float(102.0),
+                Some(&relative_tolerance),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn non_finite_floats_follow_explicit_rules() {
+        let tolerance = ValueTolerance::FloatingPoint {
+            absolute: Some("1000".to_string()),
+            relative: Some("1000".to_string()),
+        };
+        assert!(
+            compare_value(
+                &Value::m1_float(f32::NAN),
+                &Value::m1_float(f32::NAN),
+                Some(&tolerance),
+            )
+            .is_ok()
+        );
+        assert!(
+            compare_value(
+                &Value::m1_float(f32::INFINITY),
+                &Value::m1_float(f32::NEG_INFINITY),
+                Some(&tolerance),
+            )
+            .is_err()
+        );
+        assert!(
+            compare_value(
+                &Value::m1_float(1.0),
+                &Value::m1_float(f32::NAN),
+                Some(&tolerance),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn finite_overflow_is_not_an_infinity_spelling() {
+        assert!(parse_wire_float("Infinity").unwrap().is_infinite());
+        assert!(parse_wire_float("1e9999").is_err());
+        assert_eq!(
+            parse_wire_float("-0").unwrap().to_bits(),
+            (-0.0_f32).to_bits()
+        );
+    }
+
+    #[test]
+    fn m1_sim_provenance_spelling_is_stable() {
+        let provenance: FixtureProvenance = toml::from_str(
+            r#"
+kind = "m1-sim"
+source = "capture session"
+procedure = "documented procedure"
+tool_version = "1.2.3"
+captured_at_utc = "2026-08-30T12:00:00Z"
+"#,
+        )
+        .expect("m1-sim provenance parses");
+        assert_eq!(provenance.kind, ProvenanceKind::M1Sim);
+    }
+
+    #[test]
+    fn sparse_trace_column_is_not_shifted_onto_the_first_tick() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/conformance/synthetic-mini.toml");
+        let fixture = ConformanceFixture::from_path(&path).expect("fixture parses");
+        let bundle = resolve_and_verify_bundle(&fixture).expect("bundle verifies");
+        let loaded = load(&bundle.project, bundle.config.as_deref()).expect("project loads");
+        let mut trace = Trace::new();
+        trace.push_tick(fixture.steps[0].time_s);
+        trace.push_tick(fixture.steps[1].time_s);
+        trace.record_channel("Root.Demo.Output", Value::m1_float(50.0));
+        trace.record_channel("Root.Demo.Output", Value::m1_float(50.0));
+        trace.push_tick(fixture.steps[2].time_s);
+        trace.record_channel("Root.Demo.Output", Value::m1_float(50.0));
+
+        let error = compare_trace(&fixture, &loaded.project, &trace)
+            .expect_err("same-tick writes must not fill an earlier sparse tick");
+        let ConformanceError::Mismatch(mismatch) = error else {
+            panic!("expected mismatch, got {error}");
+        };
+        assert_eq!(mismatch.step, 0);
+        assert_eq!(mismatch.actual, None);
+        assert!(mismatch.detail.contains("no value aligned to this tick"));
+    }
+
+    #[test]
+    fn comparison_uses_the_final_channel_assignment_on_each_tick() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/conformance/synthetic-mini.toml");
+        let fixture = ConformanceFixture::from_path(&path).expect("fixture parses");
+        let bundle = resolve_and_verify_bundle(&fixture).expect("bundle verifies");
+        let loaded = load(&bundle.project, bundle.config.as_deref()).expect("project loads");
+        let mut trace = Trace::new();
+        for step in &fixture.steps {
+            trace.push_tick(step.time_s);
+            trace.record_channel("Root.Demo.Output", Value::m1_float(-1.0));
+            trace.record_channel("Root.Demo.Output", Value::m1_float(50.0));
+        }
+
+        compare_trace(&fixture, &loaded.project, &trace)
+            .expect("the final assignment on every tick matches");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub mod stmt;
 pub use stmt::{exec, exec_script};
 
 pub mod scenario;
-pub use scenario::{InputKind, InputSeries, IoSeries, RunMode, Scenario};
+pub use scenario::{InitialValue, InputKind, InputSeries, IoSeries, RunMode, Scenario};
 
 pub mod log;
 pub use log::{Log, LogMeta};
@@ -65,3 +65,11 @@ pub use coverage::{CoverageItem, CoverageReport, ItemKind, UnresolvedTrigger};
 
 pub mod engine;
 pub use engine::Engine;
+
+pub mod conformance;
+pub use conformance::{
+    CONFORMANCE_SCHEMA_VERSION, ConformanceError, ConformanceFixture, ConformanceMismatch,
+    ConformanceOptions, ConformanceReport, ExpectedChannelValue, FixtureChannelValue,
+    FixtureProvenance, FixtureRun, FixtureRunMode, FixtureStep, ProjectBundle, ProjectFileHash,
+    ProvenanceKind, ValueTolerance, WireValue, run_conformance_fixture, run_conformance_suite,
+};

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -48,7 +48,7 @@ use crate::hardware::{EvalTime, HardwareAdapter};
 use crate::ident::{Target, classify};
 use crate::loader::Loaded;
 use crate::log::Log;
-use crate::scenario::{InputSeries, IoSeries, RunMode, Scenario};
+use crate::scenario::{InitialValue, InputSeries, IoSeries, RunMode, Scenario};
 use crate::stmt::exec_script_with_runtime;
 use crate::summary::io_sets;
 use crate::trace::Trace;
@@ -489,6 +489,17 @@ fn tick_loop(
     let scope_fn = schedule.first().and_then(|s| s.sched.fn_symbol.as_deref());
     let inputs = canonicalise(&scenario.inputs, loaded, scope_group, scope_fn);
     let overrides = canonicalise(&scenario.overrides, loaded, scope_group, scope_fn);
+    let initial_state =
+        canonicalise_initial(&scenario.initial_state, loaded, scope_group, scope_fn);
+
+    // Initial state is a one-time seed. It is present for On-Startup code and
+    // the first periodic tick, but unlike a scenario input it is not written
+    // back on every tick. Scripts may therefore advance a captured accumulator
+    // or counter from this value.
+    for (path, initial) in &initial_state {
+        let value = crate::expr::coerce_for_channel(path, initial.value.clone(), &loaded.project)?;
+        env.set(path.clone(), value);
+    }
 
     // Run every On-Startup function exactly once, before the periodic grid —
     // the ECU's initialisation pass. Inputs/overrides are seeded at t = 0 first
@@ -496,6 +507,7 @@ fn tick_loop(
     // shared env (no trace tick is open yet) and surface via the zero-order
     // hold from tick 0 on. dt is the base period — startup code has no rate of
     // its own, and its stateful operators see one nominal step.
+    let mut startup_written = BTreeSet::new();
     if !startup.is_empty() {
         // Startup has no time-axis row. Capture hardware metadata separately so
         // its provenance survives while startup channel/expression samples do
@@ -525,6 +537,9 @@ fn tick_loop(
                 signature_m1_types: Some(&loaded.signature_m1_types),
                 object_rules: Some(&loaded.object_rules),
                 depth: 0,
+                // A throwaway startup sink captures which assignments actually
+                // executed. Their values surface on the real tick-0 trace
+                // through the zero-order hold below.
                 trace: Some(&mut startup_trace),
             };
             let mut runtime = EvalRuntime {
@@ -537,6 +552,7 @@ fn tick_loop(
             exec_script_with_runtime(&root, &mut ctx, &mut runtime)
                 .map_err(|e| e.in_script(&sched.script.name, None))?;
         }
+        startup_written.extend(startup_trace.channels.keys().cloned());
         trace.external.extend(startup_trace.external);
         trace.hardware.extend(startup_trace.hardware);
     }
@@ -601,31 +617,41 @@ fn tick_loop(
                 .map_err(|e| e.in_script(&sched.script.name, Some(t)))?;
         }
 
-        // 4. Record any channel a scheduled function *holds* this tick (it did not
-        //    run, so the executor wrote nothing) by repeating its current env
-        //    value, plus the seeded inputs/overrides. This keeps every column
-        //    aligned to the time axis with the zero-order-hold value. Two passes:
-        //    the static scheduled-write set, then every channel that already has a
-        //    trace column — the latter catches channels written only by *inline*
-        //    user-function callees (e.g. a `Service Bits.Update` push, whose backing
-        //    function carries no schedule rate), which are not in the static set but
-        //    must still hold dense once they have appeared.
-        hold_unwritten_channels(&scheduled_writes, &env, &mut trace);
-        hold_trace_channels(&env, &mut trace);
+        // 4. Preserve value provenance before filling scheduled zero-order holds.
+        //    A statically known assignment may be conditional and may not have run
+        //    on this tick. In that case an input or as-yet-uncomputed initial seed
+        //    remains external even though the channel appears in `scheduled_writes`.
         for (path, series) in inputs.iter().chain(overrides.iter()) {
             // Only record if the executor did not already record this channel this
             // tick (assignment targets are recorded by the statement executor).
-            let already = trace
-                .channels
-                .get(path)
-                .map(|c| c.len() == trace.time.len())
-                .unwrap_or(false);
+            let already = trace.has_channel_value_at_current_tick(path);
             if !already {
                 let v = env.get(path).cloned().unwrap_or_else(|| series.sample(t));
-                trace.record_channel(path.clone(), v);
-                trace.mark_external(path.clone());
+                trace.record_external_channel(path.clone(), v);
             }
         }
+        // Initial state is only external until the evaluator first computes the
+        // channel. Later non-running ticks hold that computed value rather than
+        // reverting its provenance to the one-time seed.
+        for (path, _) in &initial_state {
+            if !trace.has_channel_value_at_current_tick(path)
+                && let Some(value) = env.get(path).cloned()
+            {
+                if i == 0 && startup_written.contains(path) {
+                    trace.record_channel(path.clone(), value);
+                } else if i > 0 && trace.channel_value_at_tick(path, i - 1).is_some() {
+                    trace.record_held_channel(path.clone(), value);
+                } else {
+                    trace.record_external_channel(path.clone(), value);
+                }
+            }
+        }
+
+        // 5. Record any channel a scheduled function *holds* this tick (it did not
+        //    run, so the executor wrote nothing) by repeating its current env
+        //    value. Two passes keep static scheduled writes and inline callees dense.
+        hold_unwritten_channels(&scheduled_writes, &env, &mut trace);
+        hold_trace_channels(&env, &mut trace);
     }
 
     Ok(trace)
@@ -708,16 +734,12 @@ fn schedule_writes(loaded: &Loaded, schedule: &[ScheduledRated]) -> BTreeSet<Str
 /// (never written) is skipped — it simply has no column until first written.
 fn hold_unwritten_channels(writes: &BTreeSet<String>, env: &Env, trace: &mut Trace) {
     for path in writes {
-        let already = trace
-            .channels
-            .get(path)
-            .map(|c| c.len() == trace.time.len())
-            .unwrap_or(false);
+        let already = trace.has_channel_value_at_current_tick(path);
         if already {
             continue;
         }
         if let Some(v) = env.get(path).cloned() {
-            trace.record_channel(path.clone(), v);
+            trace.record_held_channel(path.clone(), v);
         }
     }
 }
@@ -729,18 +751,17 @@ fn hold_unwritten_channels(writes: &BTreeSet<String>, env: &Env, trace: &mut Tra
 /// functions carry no schedule rate, so they are not in the static set — once they
 /// have first appeared, keeping every column dense over the tick grid.
 fn hold_trace_channels(env: &Env, trace: &mut Trace) {
-    let len = trace.time.len();
     // Collect the lagging channels first to avoid borrowing `trace.channels` while
     // recording into it.
     let lagging: Vec<String> = trace
         .channels
         .iter()
-        .filter(|(_, col)| col.len() < len)
+        .filter(|(path, _)| !trace.has_channel_value_at_current_tick(path))
         .map(|(path, _)| path.clone())
         .collect();
     for path in lagging {
         if let Some(v) = env.get(&path).cloned() {
-            trace.record_channel(path, v);
+            trace.record_held_channel(path, v);
         }
     }
 }
@@ -768,13 +789,41 @@ fn canonicalise<'a>(
     series
         .iter()
         .map(|s| {
-            let canon = match classify(&s.channel, group, fn_symbol, &loaded.project, &no_locals) {
-                Target::Symbol(p) => p,
-                _ => s.channel.clone(),
-            };
+            let canon = canonical_channel(&s.channel, loaded, group, fn_symbol, &no_locals);
             (canon, s)
         })
         .collect()
+}
+
+/// Canonicalise one-time initial-state entries with the same path rules used by
+/// continuously-driven inputs.
+fn canonicalise_initial<'a>(
+    values: &'a [InitialValue],
+    loaded: &Loaded,
+    group: Option<&str>,
+    fn_symbol: Option<&str>,
+) -> Vec<(String, &'a InitialValue)> {
+    let no_locals = HashMap::new();
+    values
+        .iter()
+        .map(|value| {
+            let canon = canonical_channel(&value.channel, loaded, group, fn_symbol, &no_locals);
+            (canon, value)
+        })
+        .collect()
+}
+
+fn canonical_channel(
+    channel: &str,
+    loaded: &Loaded,
+    group: Option<&str>,
+    fn_symbol: Option<&str>,
+    no_locals: &HashMap<String, Value>,
+) -> String {
+    match classify(channel, group, fn_symbol, &loaded.project, no_locals) {
+        Target::Symbol(path) => path,
+        _ => channel.to_string(),
+    }
 }
 
 /// Resolve a function-mode target name to its scheduled function. The name may be
@@ -1291,32 +1340,22 @@ fn run_counterfactual_inner(
         //    the logged channels and the overrides — so the trace is a dense grid
         //    with the logged value on every pass-through channel and the recomputed
         //    value on every cone channel.
-        hold_unwritten_channels(&scheduled_writes, &env, &mut trace);
-        hold_trace_channels(&env, &mut trace);
         for (path, series) in &log_inputs {
-            let already = trace
-                .channels
-                .get(path)
-                .map(|c| c.len() == trace.time.len())
-                .unwrap_or(false);
+            let already = trace.has_channel_value_at_current_tick(path);
             if !already {
                 let v = env.get(path).cloned().unwrap_or_else(|| series.sample(t));
-                trace.record_channel(path.clone(), v);
-                trace.mark_external(path.clone());
+                trace.record_external_channel(path.clone(), v);
             }
         }
         for ov in &prepared {
             let path = ov.channel();
-            let already = trace
-                .channels
-                .get(path)
-                .map(|c| c.len() == trace.time.len())
-                .unwrap_or(false);
+            let already = trace.has_channel_value_at_current_tick(path);
             if !already && let Some(v) = env.get(path).cloned() {
-                trace.record_channel(path.to_string(), v);
-                trace.mark_external(path.to_string());
+                trace.record_external_channel(path.to_string(), v);
             }
         }
+        hold_unwritten_channels(&scheduled_writes, &env, &mut trace);
+        hold_trace_channels(&env, &mut trace);
     }
 
     Ok(trace)
@@ -1493,6 +1532,7 @@ mod tests {
         let loaded = load(&dir.join("Project.m1prj"), None).expect("enums fixture loads");
         let scenario = Scenario {
             mode: RunMode::Function("Demo.Report".to_string()),
+            initial_state: vec![],
             duration_s: 0.02,
             base_rate_hz: 100.0,
             inputs: vec![InputSeries {
@@ -1521,6 +1561,7 @@ mod tests {
         let loaded = mini();
         let scenario = Scenario {
             mode: RunMode::Function("Demo.Update".to_string()),
+            initial_state: vec![],
             duration_s: 1.0,
             base_rate_hz: 10.0,
             inputs: vec![InputSeries {
@@ -1550,6 +1591,7 @@ mod tests {
         let loaded = mini();
         let scenario = Scenario {
             mode: RunMode::Function("Demo.Update".to_string()),
+            initial_state: vec![],
             duration_s: 0.02,
             base_rate_hz: 100.0,
             inputs: vec![],
@@ -1748,6 +1790,10 @@ mode = "whole-project"
 duration_s = 0.05
 base_rate_hz = 100.0
 
+[[initial_state]]
+channel = "Root.MR.Started"
+value = { floating_point = 99.0 }
+
 [[inputs]]
 channel = "Root.MR.Seed"
 const = 3.0
@@ -1765,7 +1811,63 @@ const = 6.0
         assert_eq!(started.len(), 5, "held across every tick");
         assert!(
             started.iter().all(|v| *v == Value::m1_float(1.0)),
-            "startup ran once and its output holds: {started:?}"
+            "startup overwrote the seed once and its output holds: {started:?}"
+        );
+        assert!(
+            (0..trace.time.len())
+                .all(|tick| !trace.channel_is_external_at_tick("Root.MR.Started", tick)),
+            "startup-written values retain computed provenance"
+        );
+    }
+
+    #[test]
+    fn startup_external_hardware_sources_are_retained_on_the_real_trace() {
+        let temp = tempfile::tempdir().expect("temp project");
+        let scripts = temp.path().join("Scripts");
+        std::fs::create_dir(&scripts).expect("create scripts directory");
+        std::fs::write(
+            temp.path().join("Project.m1prj"),
+            r#"<?xml version="1.0"?>
+<MoTeCM1BuildSession>
+ <Project Name="Startup External" TargetHardware="ecu120">
+  <ComponentStream><List>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.T"/>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Events"/>
+   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On Startup"/>
+   <Component Classname="BuiltIn.Channel" Name="Root.T.Started"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="T.Init.m1scr" Name="Root.T.Init">
+    <Props SelectedTrigger="Root.Events.On Startup"/>
+   </Component>
+  </List></ComponentStream>
+ </Project>
+</MoTeCM1BuildSession>
+"#,
+        )
+        .expect("write project");
+        std::fs::write(
+            scripts.join("T.Init.m1scr"),
+            "Started = CanComms.GetFloat(1u, 2);\n",
+        )
+        .expect("write startup script");
+        let loaded = load(&temp.path().join("Project.m1prj"), None).expect("project loads");
+        let scenario = Scenario::from_toml_str(
+            r#"
+mode = "whole-project"
+duration_s = 0.01
+base_rate_hz = 100.0
+"#,
+        )
+        .expect("scenario parses");
+
+        let trace = run(&loaded, &scenario).expect("startup run succeeds");
+        assert!(trace.external.contains("CanComms.GetFloat"));
+        assert!(trace.hardware.iter().any(|item| {
+            item.source_call == "CanComms.GetFloat"
+                && item.source == crate::hardware::HardwareValueSource::GenericStub
+        }));
+        assert_eq!(
+            trace.channel_value_at_tick("Root.T.Started", 0),
+            Some(&Value::m1_float(0.0))
         );
     }
 

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -91,6 +91,20 @@ pub struct InputSeries {
     pub kind: InputKind,
 }
 
+/// One value present in the evaluator's channel store before startup code or
+/// the first periodic tick runs.
+///
+/// Unlike an [`InputSeries`], this value is seeded once. It can initialise a
+/// channel that the evaluated scripts later update without pinning that channel
+/// back to the captured value on every tick.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InitialValue {
+    /// The channel path to seed.
+    pub channel: String,
+    /// Its typed initial value.
+    pub value: Value,
+}
+
 /// A constant value or a `(t, value)` time series.
 #[derive(Debug, Clone, PartialEq)]
 pub enum InputKind {
@@ -175,6 +189,10 @@ fn sample_series(points: &[(f64, Value)], t: f64) -> Value {
 pub struct Scenario {
     /// Which runner and target.
     pub mode: RunMode,
+    /// Values seeded once before startup code and the first tick. These model a
+    /// captured evaluator state, while [`Scenario::inputs`] model values driven
+    /// throughout the run.
+    pub initial_state: Vec<InitialValue>,
     /// Externally-driven input sources (constants + series).
     pub inputs: Vec<InputSeries>,
     /// Total run duration in seconds. Ticks span `[0, duration_s)`.
@@ -479,6 +497,8 @@ struct RawScenario {
     #[serde(default)]
     base_rate_hz: f64,
     #[serde(default)]
+    initial_state: Vec<RawInitialValue>,
+    #[serde(default)]
     inputs: Vec<RawInput>,
     #[serde(default)]
     overrides: Vec<RawInput>,
@@ -488,6 +508,13 @@ struct RawScenario {
     /// fail-loud when absent/false).
     #[serde(default)]
     allow_default_inputs: bool,
+}
+
+/// A raw one-time channel seed.
+#[derive(Debug, Deserialize)]
+struct RawInitialValue {
+    channel: String,
+    value: RawValue,
 }
 
 /// A raw input/override entry: a channel plus exactly one of `const`/`series`.
@@ -673,6 +700,16 @@ impl RawScenario {
             .into_iter()
             .map(RawInput::into_input)
             .collect::<Result<Vec<_>, _>>()?;
+        let initial_state = self
+            .initial_state
+            .into_iter()
+            .map(|initial| {
+                initial.value.into_value().map(|value| InitialValue {
+                    channel: initial.channel,
+                    value,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         let overrides = self
             .overrides
             .into_iter()
@@ -703,6 +740,7 @@ impl RawScenario {
         }
         Ok(Scenario {
             mode,
+            initial_state,
             inputs,
             duration_s: self.duration_s,
             base_rate_hz: self.base_rate_hz,
@@ -1227,6 +1265,30 @@ const = { fixed_raw = 12345678 }
                 12_345_678
             )))
         );
+    }
+
+    #[test]
+    fn initial_state_is_typed_and_kept_separate_from_inputs() {
+        let scenario = Scenario::from_toml_str(
+            r#"
+mode = "whole-project"
+duration_s = 0.1
+
+[[initial_state]]
+channel = "Counter"
+value = { integer = 10 }
+
+[[inputs]]
+channel = "Sensor"
+const = { unsigned = 20 }
+"#,
+        )
+        .expect("scenario with initial state parses");
+        assert_eq!(scenario.initial_state.len(), 1);
+        assert_eq!(scenario.initial_state[0].channel, "Counter");
+        assert_eq!(scenario.initial_state[0].value, Value::m1_integer(10));
+        assert_eq!(scenario.inputs.len(), 1);
+        assert_eq!(scenario.inputs[0].sample(0.0), Value::m1_unsigned(20));
     }
 
     #[test]

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -3,10 +3,12 @@
 //! time axis, plus a per-expression value sink for introspection.
 //!
 //! A `Trace` is column-oriented. One shared [`Trace::time`] axis (`Vec<f64>`)
-//! gives the tick instants; each channel and each recorded expression keeps a
-//! `Vec<Value>` aligned to that axis. The runner calls [`Trace::push_tick`] once
-//! per tick to extend the time axis, then [`Trace::record_channel`] /
-//! [`Trace::record_expr`] for every value produced during that tick.
+//! gives the tick instants; channel and expression values use compatibility
+//! `Vec<Value>` columns. The runner calls [`Trace::push_tick`] once per tick to
+//! extend the time axis, then [`Trace::record_channel`] /
+//! [`Trace::record_expr`] for every value produced during that tick. Channel
+//! records also retain an internal tick index and value provenance so consumers
+//! that require exact alignment do not have to infer it from column length.
 //!
 //! ## Per-expression sink
 //!
@@ -17,10 +19,11 @@
 //!
 //! ## Externally-driven channels
 //!
-//! Scenario values, adapters, and hardware stubs produce values the engine did
-//! not compute. Those call names are flagged in [`Trace::external`].
-//! [`Trace::hardware`] adds the resolved receiver, exact call site, and selected
-//! route. Deterministic `System` calls have provenance but are not external.
+//! Scenario inputs, held initial state, adapters, and hardware stubs produce
+//! values the engine did not compute. Those channel or call names are flagged in
+//! [`Trace::external`]. [`Trace::hardware`] adds the resolved receiver, exact
+//! call site, and selected route. Deterministic `System` calls have provenance
+//! but are not external.
 //!
 //! Internal channel and expression columns retain their M1 scalar family. The
 //! established JSON and CSV formats are untyped compatibility outputs, so they
@@ -37,8 +40,11 @@ use std::collections::{BTreeMap, BTreeSet};
 pub struct Trace {
     /// The shared tick time axis, in seconds. One entry per tick.
     pub time: Vec<f64>,
-    /// Channel value columns, keyed by canonical path. Each column is aligned to
-    /// [`Trace::time`]. A `BTreeMap` keeps channel order deterministic.
+    /// Channel value columns, keyed by canonical path. Runner-held columns are
+    /// dense after their first value; a channel first written mid-run cannot
+    /// represent its empty prefix in this compatibility shape. A `BTreeMap`
+    /// keeps channel order deterministic, while internal tick metadata retains
+    /// exact alignment.
     pub channels: BTreeMap<String, Vec<Value>>,
     /// Per-expression value columns, keyed by `(script_name, byte_offset)`. Used
     /// by the value overlay; sparse (only expressions the sink recorded appear).
@@ -56,6 +62,16 @@ pub struct Trace {
     /// Structured source records for hardware-backed call sites. A set keeps
     /// repeated ticks compact while retaining every route a site used.
     pub hardware: BTreeSet<HardwareProvenance>,
+    /// Final channel value and provenance for each tick that recorded one.
+    /// Kept separately from the compatibility columns, whose public shape
+    /// cannot represent a missing value before a channel first appears.
+    channel_ticks: BTreeMap<String, BTreeMap<usize, ChannelTick>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ChannelTick {
+    value: Value,
+    external: bool,
 }
 
 /// One reported default substitution: what value was substituted and which
@@ -80,12 +96,95 @@ impl Trace {
         self.time.push(t);
     }
 
-    /// Record a channel value for the current (most recent) tick. A channel seen
-    /// for the first time mid-run is back-filled so its column stays aligned to
-    /// the time axis: earlier ticks get no entry, so we left-pad nothing and
-    /// simply append; callers that need dense columns record every tick.
+    /// Record an evaluator-computed channel value for the current tick. Multiple
+    /// assignments on one tick replace that tick's prior value, leaving the
+    /// final assignment as the observable end-of-tick value. A channel first
+    /// seen mid-run remains sparse in the public compatibility column; exact
+    /// consumers use the retained tick index through the crate-private accessors.
     pub fn record_channel(&mut self, path: impl Into<String>, value: Value) {
-        self.channels.entry(path.into()).or_default().push(value);
+        self.record_channel_tick(path.into(), value, false);
+    }
+
+    /// Record an externally supplied channel value for the current tick.
+    pub(crate) fn record_external_channel(&mut self, path: impl Into<String>, value: Value) {
+        let path = path.into();
+        self.record_channel_tick(path.clone(), value, true);
+        self.mark_external(path);
+    }
+
+    /// Record a zero-order hold, preserving the most recent value's provenance.
+    /// With no prior sample, the value came from an executed startup function:
+    /// scenario inputs and initial state are recorded explicitly before holds.
+    pub(crate) fn record_held_channel(&mut self, path: impl Into<String>, value: Value) {
+        let path = path.into();
+        let tick = self.time.len().checked_sub(1);
+        let external = tick
+            .and_then(|tick| {
+                self.channel_ticks
+                    .get(&path)
+                    .and_then(|samples| samples.range(..tick).next_back())
+                    .map(|(_, sample)| sample.external)
+            })
+            .unwrap_or_else(|| self.external.contains(&path));
+        self.record_channel_tick(path, value, external);
+    }
+
+    fn record_channel_tick(&mut self, path: String, value: Value, external: bool) {
+        let Some(tick) = self.time.len().checked_sub(1) else {
+            // Direct evaluator unit harnesses can record without opening a tick.
+            self.channels.entry(path).or_default().push(value);
+            return;
+        };
+        let replaced = self
+            .channel_ticks
+            .entry(path.clone())
+            .or_default()
+            .insert(
+                tick,
+                ChannelTick {
+                    value: value.clone(),
+                    external,
+                },
+            )
+            .is_some();
+        let column = self.channels.entry(path).or_default();
+        if replaced && let Some(previous) = column.last_mut() {
+            *previous = value;
+        } else {
+            column.push(value);
+        }
+    }
+
+    /// Whether the channel already has a final value for the open tick.
+    pub(crate) fn has_channel_value_at_current_tick(&self, path: &str) -> bool {
+        self.time.len().checked_sub(1).is_some_and(|tick| {
+            self.channel_ticks
+                .get(path)
+                .is_some_and(|samples| samples.contains_key(&tick))
+        })
+    }
+
+    /// The final channel value recorded at one exact tick.
+    pub(crate) fn channel_value_at_tick(&self, path: &str, tick: usize) -> Option<&Value> {
+        self.channel_ticks
+            .get(path)
+            .and_then(|samples| samples.get(&tick))
+            .map(|sample| &sample.value)
+            .or_else(|| {
+                self.channels
+                    .get(path)
+                    .filter(|column| column.len() == self.time.len())
+                    .and_then(|column| column.get(tick))
+            })
+    }
+
+    /// Whether the exact tick value came from an external source.
+    pub(crate) fn channel_is_external_at_tick(&self, path: &str, tick: usize) -> bool {
+        self.channel_ticks
+            .get(path)
+            .and_then(|samples| samples.get(&tick))
+            .map(|sample| sample.external)
+            .unwrap_or_else(|| self.external.contains(path))
     }
 
     /// Record the value of one expression occurrence (keyed by its
@@ -107,7 +206,16 @@ impl Trace {
 
     /// Flag a channel or hardware call name as externally driven.
     pub fn mark_external(&mut self, path: impl Into<String>) {
-        self.external.insert(path.into());
+        let path = path.into();
+        self.external.insert(path.clone());
+        if let Some(tick) = self.time.len().checked_sub(1)
+            && let Some(sample) = self
+                .channel_ticks
+                .get_mut(&path)
+                .and_then(|samples| samples.get_mut(&tick))
+        {
+            sample.external = true;
+        }
     }
 
     /// Whether a channel is flagged externally driven.

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! End-to-end checks for the reusable conformance fixture API and CLI.
+
+use assert_cmd::Command;
+use m1_eval::{
+    ConformanceError, ConformanceOptions, ProvenanceKind, run_conformance_fixture,
+    run_conformance_suite,
+};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/conformance")
+        .join(name)
+}
+
+fn project_fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn edited_mini_fixture(edit: impl FnOnce(String) -> String) -> (tempfile::TempDir, PathBuf) {
+    let template = fixture("synthetic-mini.toml");
+    let body = std::fs::read_to_string(template).expect("read template fixture");
+    let root = project_fixture("mini")
+        .canonicalize()
+        .expect("canonical mini fixture");
+    let body = body.replace(
+        "root = \"../mini\"",
+        &format!("root = {:?}", root.to_string_lossy()),
+    );
+    let body = edit(body);
+    let temp = tempfile::tempdir().expect("temp fixture directory");
+    let path = temp.path().join("fixture.toml");
+    std::fs::write(&path, body).expect("write edited fixture");
+    (temp, path)
+}
+
+fn edited_types_fixture(edit: impl FnOnce(String) -> String) -> (tempfile::TempDir, PathBuf) {
+    let template = fixture("synthetic-types.toml");
+    let body = std::fs::read_to_string(template).expect("read template fixture");
+    let root = project_fixture("conformance-types")
+        .canonicalize()
+        .expect("canonical typed fixture");
+    let body = body.replace(
+        "root = \"../conformance-types\"",
+        &format!("root = {:?}", root.to_string_lossy()),
+    );
+    let body = edit(body);
+    let temp = tempfile::tempdir().expect("temp fixture directory");
+    let path = temp.path().join("fixture.toml");
+    std::fs::write(&path, body).expect("write edited fixture");
+    (temp, path)
+}
+
+fn copy_mini_bundle(temp: &tempfile::TempDir) -> PathBuf {
+    let source_root = project_fixture("mini");
+    let root = temp.path().join("project");
+    std::fs::create_dir_all(root.join("Scripts")).expect("create temp project");
+    std::fs::copy(
+        source_root.join("Project.m1prj"),
+        root.join("Project.m1prj"),
+    )
+    .expect("copy project descriptor");
+    std::fs::copy(
+        source_root.join("parameters.m1cfg"),
+        root.join("parameters.m1cfg"),
+    )
+    .expect("copy calibration");
+    std::fs::copy(
+        source_root.join("Scripts/Demo.Update.m1scr"),
+        root.join("Scripts/Demo.Update.m1scr"),
+    )
+    .expect("copy script");
+    root
+}
+
+#[test]
+fn committed_synthetic_fixtures_pass_without_claiming_capture_evidence() {
+    let paths = vec![
+        fixture("synthetic-mini.toml"),
+        fixture("synthetic-initial-state.toml"),
+        fixture("synthetic-types.toml"),
+    ];
+    let reports = run_conformance_suite(&paths, ConformanceOptions::default())
+        .expect("synthetic conformance fixtures pass");
+    assert_eq!(reports.len(), 3);
+    assert!(
+        reports
+            .iter()
+            .all(|report| report.provenance == ProvenanceKind::Synthetic)
+    );
+}
+
+#[test]
+fn json_fixture_uses_the_same_schema_and_runner() {
+    let template = fixture("synthetic-mini.toml");
+    let body = std::fs::read_to_string(template).expect("read template fixture");
+    let root = project_fixture("mini")
+        .canonicalize()
+        .expect("canonical mini fixture");
+    let body = body.replace(
+        "root = \"../mini\"",
+        &format!("root = {:?}", root.to_string_lossy()),
+    );
+    let document: toml::Value = toml::from_str(&body).expect("parse TOML fixture as a value");
+    let json = serde_json::to_string_pretty(&document).expect("encode equivalent JSON fixture");
+    let temp = tempfile::tempdir().expect("temp fixture directory");
+    let path = temp.path().join("fixture.json");
+    std::fs::write(&path, json).expect("write JSON fixture");
+
+    let report = run_conformance_fixture(&path).expect("equivalent JSON fixture passes");
+    assert_eq!(report.name, "synthetic mini calculation");
+    assert_eq!(report.steps_checked, 3);
+}
+
+#[test]
+fn rounded_step_times_are_normalized_before_input_sampling() {
+    let (_temp, path) = edited_mini_fixture(|body| {
+        let marker = "[[steps]]\ntime_s = 0.01\n\n[[steps.expected]]";
+        let replacement = r#"[[steps]]
+time_s = 0.0100000000001
+
+[[steps.inputs]]
+channel = "Root.Demo.Speed"
+value = { type = "floating-point", value = "40" }
+
+[[steps.expected]]"#;
+        let body = body.replacen(marker, replacement, 1);
+        let later_start = body
+            .find("time_s = 0.0100000000001")
+            .expect("edited second step exists");
+        let (first_step, later_steps) = body.split_at(later_start);
+        let later_steps = later_steps.replace(
+            "value = { type = \"floating-point\", value = \"50\" }",
+            "value = { type = \"floating-point\", value = \"100\" }",
+        );
+        format!("{first_step}{later_steps}")
+    });
+
+    run_conformance_fixture(&path).expect("accepted rounded time uses its exact grid tick");
+}
+
+#[test]
+fn fixture_input_type_must_match_the_project_channel_family() {
+    let (_temp, path) = edited_mini_fixture(|body| {
+        body.replacen(
+            "value = { type = \"floating-point\", value = \"20\" }",
+            "value = { type = \"integer\", value = 20 }",
+            1,
+        )
+    });
+    let error = run_conformance_fixture(&path).expect_err("typed mismatch must not be coerced");
+    let ConformanceError::InvalidFixture { detail, .. } = error else {
+        panic!("expected invalid fixture, got {error}");
+    };
+    assert!(detail.contains("declares Integer, but the project stores FloatingPoint"));
+}
+
+#[test]
+fn fixture_string_type_must_match_the_raw_project_channel_family() {
+    let (_temp, path) = edited_types_fixture(|body| {
+        body.replacen(
+            "value = { type = \"string\", value = \"tick zero\" }",
+            "value = { type = \"integer\", value = 1 }",
+            1,
+        )
+    });
+    let error = run_conformance_fixture(&path).expect_err("typed mismatch must not be coerced");
+    let ConformanceError::InvalidFixture { detail, .. } = error else {
+        panic!("expected invalid fixture, got {error}");
+    };
+    assert!(detail.contains("declares Integer, but the project stores String"));
+}
+
+#[test]
+fn fixture_inputs_must_be_canonical_project_symbols() {
+    let (_temp, path) = edited_mini_fixture(|body| {
+        let input = r#"[[steps.inputs]]
+channel = "Root.Demo.Speed"
+value = { type = "floating-point", value = "20" }"#;
+        let extra = r#"[[steps.inputs]]
+channel = "Root.Not A Project Channel"
+value = { type = "floating-point", value = "1" }"#;
+        body.replacen(input, &format!("{input}\n\n{extra}"), 1)
+    });
+    let error = run_conformance_fixture(&path).expect_err("unknown input must not be ignored");
+    let ConformanceError::InvalidFixture { detail, .. } = error else {
+        panic!("expected invalid fixture, got {error}");
+    };
+    assert!(detail.contains("is not a project symbol"));
+}
+
+#[test]
+fn fixture_inputs_must_name_project_channels() {
+    let (_temp, path) = edited_mini_fixture(|body| {
+        body.replacen(
+            "channel = \"Root.Demo.Speed\"",
+            "channel = \"Root.Demo.Gain\"",
+            1,
+        )
+    });
+    let error = run_conformance_fixture(&path).expect_err("parameters are not scenario channels");
+    let ConformanceError::InvalidFixture { detail, .. } = error else {
+        panic!("expected invalid fixture, got {error}");
+    };
+    assert!(detail.contains("Parameter, not a project Channel"));
+}
+
+#[test]
+fn fixture_inputs_cannot_also_be_expected_outputs() {
+    let (_temp, path) = edited_mini_fixture(|body| {
+        body.replace(
+            "channel = \"Root.Demo.Output\"",
+            "channel = \"Root.Demo.Speed\"",
+        )
+        .replace(
+            "value = { type = \"floating-point\", value = \"50\" }",
+            "value = { type = \"floating-point\", value = \"20\" }",
+        )
+    });
+    let error = run_conformance_fixture(&path).expect_err("an input is not a computed output");
+    let ConformanceError::InvalidFixture { detail, .. } = error else {
+        panic!("expected invalid fixture, got {error}");
+    };
+    assert!(
+        detail.contains("expected outputs must be disjoint"),
+        "unexpected detail: {detail}"
+    );
+}
+
+#[test]
+fn conditional_static_write_does_not_hide_an_external_initial_seed() {
+    let temp = tempfile::tempdir().expect("temp fixture directory");
+    let root = copy_mini_bundle(&temp);
+    let script = std::fs::read_to_string(root.join("Scripts/Demo.Update.m1scr"))
+        .expect("read script")
+        .replace("Output = scaled;", "if (false)\n{\n\tOutput = scaled;\n}");
+    std::fs::write(root.join("Scripts/Demo.Update.m1scr"), &script)
+        .expect("write conditional script");
+    let script_hash = format!("{:x}", Sha256::digest(script.as_bytes()));
+
+    let template =
+        std::fs::read_to_string(fixture("synthetic-mini.toml")).expect("read template fixture");
+    let body = template
+        .replace(
+            "root = \"../mini\"",
+            &format!("root = {:?}", root.to_string_lossy()),
+        )
+        .replace(
+            "687fb0e0ac83f5a0c689a9769d82fbf97de4f3250216ea2e5947a4c18b936f09",
+            &script_hash,
+        )
+        .replacen(
+            "[[steps]]\ntime_s = 0.0",
+            "[[initial_state]]\nchannel = \"Root.Demo.Output\"\nvalue = { type = \"floating-point\", value = \"50\" }\n\n[[steps]]\ntime_s = 0.0",
+            1,
+        );
+    let path = temp.path().join("fixture.toml");
+    std::fs::write(&path, body).expect("write conditional fixture");
+
+    let error = run_conformance_fixture(&path)
+        .expect_err("an unexecuted static write must not validate the initial seed");
+    let ConformanceError::InvalidFixture { detail, .. } = error else {
+        panic!("expected invalid fixture, got {error}");
+    };
+    assert!(
+        detail.contains("externally supplied rather than evaluator-computed"),
+        "unexpected detail: {detail}"
+    );
+}
+
+#[test]
+fn undeclared_io_stubs_cannot_supply_conformance_outputs() {
+    let temp = tempfile::tempdir().expect("temp fixture directory");
+    let root = copy_mini_bundle(&temp);
+    let script = std::fs::read_to_string(root.join("Scripts/Demo.Update.m1scr"))
+        .expect("read script")
+        .replace("Output = scaled;", "Output = CanComms.GetFloat(1u, 2);");
+    std::fs::write(root.join("Scripts/Demo.Update.m1scr"), &script)
+        .expect("write IO-backed script");
+    let script_hash = format!("{:x}", Sha256::digest(script.as_bytes()));
+
+    let template =
+        std::fs::read_to_string(fixture("synthetic-mini.toml")).expect("read template fixture");
+    let body = template
+        .replace(
+            "root = \"../mini\"",
+            &format!("root = {:?}", root.to_string_lossy()),
+        )
+        .replace(
+            "687fb0e0ac83f5a0c689a9769d82fbf97de4f3250216ea2e5947a4c18b936f09",
+            &script_hash,
+        );
+    let path = temp.path().join("fixture.toml");
+    std::fs::write(&path, body).expect("write IO-backed fixture");
+
+    let error = run_conformance_fixture(&path).expect_err("hidden IO source must not pass");
+    let ConformanceError::InvalidFixture { detail, .. } = error else {
+        panic!("expected invalid fixture, got {error}");
+    };
+    assert!(detail.contains("undeclared external source \"CanComms.GetFloat\""));
+}
+
+#[test]
+fn suite_reloads_state_for_every_fixture() {
+    let stateful = fixture("synthetic-initial-state.toml");
+    let reports =
+        run_conformance_suite(&[stateful.clone(), stateful], ConformanceOptions::default())
+            .expect("both runs start from the fixture's initial state");
+    assert_eq!(reports.len(), 2);
+    assert_eq!(reports[0].assertions_checked, reports[1].assertions_checked);
+}
+
+#[test]
+fn first_output_mismatch_names_step_time_channel_and_values() {
+    let (_temp, path) = edited_mini_fixture(|body| {
+        body.replacen(
+            "value = { type = \"floating-point\", value = \"50\" }",
+            "value = { type = \"floating-point\", value = \"51\" }",
+            1,
+        )
+    });
+    let error = run_conformance_fixture(&path).expect_err("edited expectation must fail");
+    let ConformanceError::Mismatch(mismatch) = error else {
+        panic!("expected output mismatch, got {error}");
+    };
+    assert_eq!(mismatch.step, 0);
+    assert_eq!(mismatch.time_s, 0.0);
+    assert_eq!(mismatch.channel, "Root.Demo.Output");
+    assert!(mismatch.expected.contains("51"));
+    assert!(mismatch.actual.as_ref().is_some_and(|value| {
+        value
+            .m1_scalar()
+            .is_ok_and(|scalar| scalar.as_f64() == 50.0)
+    }));
+}
+
+#[test]
+fn project_hash_mismatch_fails_before_evaluation() {
+    let (_temp, path) = edited_mini_fixture(|body| {
+        body.replacen(
+            "9e9dcd16bd3f11a2347b8d273ee1932fd02aa78e54e57ce312b11e605e2f6607",
+            "0e9dcd16bd3f11a2347b8d273ee1932fd02aa78e54e57ce312b11e605e2f6607",
+            1,
+        )
+    });
+    assert!(matches!(
+        run_conformance_fixture(&path),
+        Err(ConformanceError::HashMismatch { .. })
+    ));
+}
+
+#[test]
+fn duplicate_script_basenames_are_rejected_as_nondeterministic() {
+    let temp = tempfile::tempdir().expect("temp fixture directory");
+    let root = copy_mini_bundle(&temp);
+    std::fs::create_dir_all(root.join("Duplicate")).expect("create duplicate script directory");
+    std::fs::copy(
+        root.join("Scripts/Demo.Update.m1scr"),
+        root.join("Duplicate/Demo.Update.m1scr"),
+    )
+    .expect("copy duplicate script");
+
+    let template =
+        std::fs::read_to_string(fixture("synthetic-mini.toml")).expect("read template fixture");
+    let script_manifest = r#"[[project.files]]
+path = "Scripts/Demo.Update.m1scr"
+sha256 = "687fb0e0ac83f5a0c689a9769d82fbf97de4f3250216ea2e5947a4c18b936f09""#;
+    let duplicate_manifest = r#"[[project.files]]
+path = "Duplicate/Demo.Update.m1scr"
+sha256 = "687fb0e0ac83f5a0c689a9769d82fbf97de4f3250216ea2e5947a4c18b936f09""#;
+    let body = template
+        .replace(
+            "root = \"../mini\"",
+            &format!("root = {:?}", root.to_string_lossy()),
+        )
+        .replacen(
+            script_manifest,
+            &format!("{script_manifest}\n\n{duplicate_manifest}"),
+            1,
+        );
+    let path = temp.path().join("fixture.toml");
+    std::fs::write(&path, body).expect("write duplicate fixture");
+
+    let error = run_conformance_fixture(&path).expect_err("duplicate basenames must fail");
+    let ConformanceError::InvalidFixture { detail, .. } = error else {
+        panic!("expected invalid fixture, got {error}");
+    };
+    assert!(detail.contains("duplicate script basename"));
+}
+
+#[test]
+fn cli_runs_a_repeatable_fixture_suite() {
+    let assert = Command::cargo_bin("m1-eval")
+        .unwrap()
+        .arg("--conformance")
+        .arg(fixture("synthetic-mini.toml"))
+        .arg("--conformance")
+        .arg(fixture("synthetic-initial-state.toml"))
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("PASS synthetic mini calculation"));
+    assert!(stdout.contains("PASS synthetic initial-state counters"));
+    assert!(stdout.contains("conformance: 2 fixture(s) passed"));
+}
+
+#[test]
+fn cli_rejects_conformance_mixed_with_a_normal_project_action() {
+    Command::cargo_bin("m1-eval")
+        .unwrap()
+        .arg("--conformance")
+        .arg(fixture("synthetic-mini.toml"))
+        .arg("--project")
+        .arg(project_fixture("mini/Project.m1prj"))
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn real_capture_gate_rejects_a_synthetic_only_suite() {
+    let assert = Command::cargo_bin("m1-eval")
+        .unwrap()
+        .arg("--conformance")
+        .arg(fixture("synthetic-mini.toml"))
+        .arg("--require-m1-sim-capture")
+        .assert()
+        .code(1);
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(stderr.contains("no fixture declared `m1-sim` provenance"));
+}
+
+#[test]
+fn configured_private_m1_sim_fixtures_form_an_optional_gate() {
+    let Some(paths) = std::env::var_os("M1_EVAL_M1_SIM_FIXTURES") else {
+        return;
+    };
+    let paths: Vec<PathBuf> = std::env::split_paths(&paths).collect();
+    assert!(
+        !paths.is_empty(),
+        "M1_EVAL_M1_SIM_FIXTURES was set but contained no paths"
+    );
+    run_conformance_suite(
+        &paths,
+        ConformanceOptions {
+            require_m1_sim_capture: true,
+        },
+    )
+    .expect("configured M1 Sim captures pass conformance");
+}

--- a/tests/fixtures/conformance-types/Project.m1prj
+++ b/tests/fixtures/conformance-types/Project.m1prj
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!-- Synthetic type-preservation project for conformance runner tests. -->
+<MoTeCM1BuildSession>
+ <Project Name="ConformanceTypes" TargetHardware="ecu120">
+  <DataTypes>
+   <Type Storage="enum" Name="Test State" Default="Idle">
+    <Enum Name="Idle" ContainerOrder="0"/>
+    <Enum Name="Active" ContainerOrder="1"/>
+   </Type>
+  </DataTypes>
+  <ComponentStream><List>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Types"/>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Bool In"><Props Type="bool"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Bool Out"><Props Type="bool"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Signed In"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Signed Out"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Unsigned In"><Props Type="u32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Unsigned Out"><Props Type="u32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Float In"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Float Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Fixed In"><Props Type="FixedPoint7dps"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Fixed Out"><Props Type="FixedPoint7dps"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Enum In"><Props Type="::This.Test State"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.Enum Out"><Props Type="::This.Test State"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.String In"><Props Type="string"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Types.String Out"><Props Type="string"/></Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Types.Update.m1scr" Name="Root.Types.Update"/>
+  </List></ComponentStream>
+ </Project>
+</MoTeCM1BuildSession>

--- a/tests/fixtures/conformance-types/Scripts/Types.Update.m1scr
+++ b/tests/fixtures/conformance-types/Scripts/Types.Update.m1scr
@@ -1,0 +1,8 @@
+// Synthetic conformance runner fixture. No proprietary content.
+Bool Out = Bool In;
+Signed Out = Signed In;
+Unsigned Out = Unsigned In;
+Float Out = Float In;
+Fixed Out = Fixed In;
+Enum Out = Enum In;
+String Out = String In;

--- a/tests/fixtures/conformance/synthetic-initial-state.toml
+++ b/tests/fixtures/conformance/synthetic-initial-state.toml
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Hand-derived fixture for initial-state and scheduler tests. Not M1 Sim evidence.
+schema_version = 1
+name = "synthetic initial-state counters"
+calculation_rate_hz = 1000.0
+
+[project]
+root = "../ratemix"
+project = "Project.m1prj"
+
+[[project.files]]
+path = "Project.m1prj"
+sha256 = "c111e89d023ac75a29dcbe7324a2b48f8b3e2f1000bd39282046ed35b5656521"
+
+[[project.files]]
+path = "Scripts/RX.Fast Counter.m1scr"
+sha256 = "c8a17f4ee666506236a82cbee625f9ba533bfd24b5eb0ed64e968eae921eb262"
+
+[[project.files]]
+path = "Scripts/RX.Mid Counter.m1scr"
+sha256 = "c24ec37f34eb727f2349b41b934f5e25f1246887422f8f7738e9c7e6a6c7ec57"
+
+[provenance]
+kind = "synthetic"
+source = "tests/fixtures/ratemix, counters seeded at non-zero values"
+procedure = "docs/conformance.md#synthetic-runner-fixtures"
+notes = "Expected values test one-time state seeding and do not establish M1 compatibility."
+
+[run]
+mode = "whole-project"
+
+[[initial_state]]
+channel = "Root.RX.Fast Count"
+value = { type = "floating-point", value = "10" }
+
+[[initial_state]]
+channel = "Root.RX.Mid Count"
+value = { type = "floating-point", value = "20" }
+
+[[initial_state]]
+channel = "Root.RX.Seed"
+value = { type = "floating-point", value = "2" }
+
+[[steps]]
+time_s = 0.0
+
+[[steps.expected]]
+channel = "Root.RX.Fast Count"
+value = { type = "floating-point", value = "11" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Count"
+value = { type = "floating-point", value = "21" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Total"
+value = { type = "floating-point", value = "0" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps]]
+time_s = 0.001
+
+[[steps.expected]]
+channel = "Root.RX.Fast Count"
+value = { type = "floating-point", value = "11" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Count"
+value = { type = "floating-point", value = "21" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Total"
+value = { type = "floating-point", value = "0" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps]]
+time_s = 0.002
+
+[[steps.expected]]
+channel = "Root.RX.Fast Count"
+value = { type = "floating-point", value = "12" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Count"
+value = { type = "floating-point", value = "21" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Total"
+value = { type = "floating-point", value = "0" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps]]
+time_s = 0.003
+
+[[steps.expected]]
+channel = "Root.RX.Fast Count"
+value = { type = "floating-point", value = "12" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Count"
+value = { type = "floating-point", value = "21" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Total"
+value = { type = "floating-point", value = "0" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps]]
+time_s = 0.004
+
+[[steps.expected]]
+channel = "Root.RX.Fast Count"
+value = { type = "floating-point", value = "13" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Count"
+value = { type = "floating-point", value = "21" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Total"
+value = { type = "floating-point", value = "0" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps]]
+time_s = 0.005
+
+[[steps.expected]]
+channel = "Root.RX.Fast Count"
+value = { type = "floating-point", value = "13" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Count"
+value = { type = "floating-point", value = "22" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.RX.Mid Total"
+value = { type = "floating-point", value = "0.01" }
+tolerance = { type = "floating-point", absolute = "0.0000001" }

--- a/tests/fixtures/conformance/synthetic-mini.toml
+++ b/tests/fixtures/conformance/synthetic-mini.toml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Hand-derived fixture for runner tests. This is not M1 Sim evidence.
+schema_version = 1
+name = "synthetic mini calculation"
+calculation_rate_hz = 100.0
+
+[project]
+root = "../mini"
+project = "Project.m1prj"
+config = "parameters.m1cfg"
+
+[[project.files]]
+path = "Project.m1prj"
+sha256 = "9e9dcd16bd3f11a2347b8d273ee1932fd02aa78e54e57ce312b11e605e2f6607"
+
+[[project.files]]
+path = "Scripts/Demo.Update.m1scr"
+sha256 = "687fb0e0ac83f5a0c689a9769d82fbf97de4f3250216ea2e5947a4c18b936f09"
+
+[[project.files]]
+path = "parameters.m1cfg"
+sha256 = "d81ad7d8f6df9ae33b199425a663e2f08a428e0e60433d3e1dc3f6a945d5c664"
+
+[provenance]
+kind = "synthetic"
+source = "tests/fixtures/mini, Output = Speed * calibrated Gain"
+procedure = "docs/conformance.md#synthetic-runner-fixtures"
+notes = "Expected values are hand-derived and do not establish M1 compatibility."
+
+[run]
+mode = "function"
+target = "Demo.Update"
+
+[[steps]]
+time_s = 0.0
+
+[[steps.inputs]]
+channel = "Root.Demo.Speed"
+value = { type = "floating-point", value = "20" }
+
+[[steps.expected]]
+channel = "Root.Demo.Output"
+value = { type = "floating-point", value = "50" }
+tolerance = { type = "floating-point", absolute = "0", relative = "0" }
+
+[[steps]]
+time_s = 0.01
+
+[[steps.expected]]
+channel = "Root.Demo.Output"
+value = { type = "floating-point", value = "50" }
+tolerance = { type = "floating-point", absolute = "0", relative = "0" }
+
+[[steps]]
+time_s = 0.02
+
+[[steps.expected]]
+channel = "Root.Demo.Output"
+value = { type = "floating-point", value = "50" }
+tolerance = { type = "floating-point", absolute = "0", relative = "0" }

--- a/tests/fixtures/conformance/synthetic-types.toml
+++ b/tests/fixtures/conformance/synthetic-types.toml
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Hand-derived typed-value fixture. This is not M1 Sim evidence.
+schema_version = 1
+name = "synthetic typed scalar round trip"
+calculation_rate_hz = 10.0
+
+[project]
+root = "../conformance-types"
+project = "Project.m1prj"
+
+[[project.files]]
+path = "Project.m1prj"
+sha256 = "f22426477608d06a7f508236b20de5a19176b42316973d9718812ee4f0fa07f4"
+
+[[project.files]]
+path = "Scripts/Types.Update.m1scr"
+sha256 = "92fbc654654c8a77d1dde4e11488347c1fa08c6720cdff64819a44602d217aa4"
+
+[provenance]
+kind = "synthetic"
+source = "tests/fixtures/conformance-types, direct typed channel copies"
+procedure = "docs/conformance.md#synthetic-runner-fixtures"
+notes = "Expected values test the wire and comparison rules, not M1 compatibility."
+
+[run]
+mode = "function"
+target = "Types.Update"
+
+[[steps]]
+time_s = 0.0
+
+[[steps.inputs]]
+channel = "Root.Types.Bool In"
+value = { type = "boolean", value = true }
+
+[[steps.inputs]]
+channel = "Root.Types.Signed In"
+value = { type = "integer", value = -2147483648 }
+
+[[steps.inputs]]
+channel = "Root.Types.Unsigned In"
+value = { type = "unsigned-integer", value = 4294967295 }
+
+[[steps.inputs]]
+channel = "Root.Types.Float In"
+value = { type = "floating-point", value = "-0" }
+
+[[steps.inputs]]
+channel = "Root.Types.Fixed In"
+value = { type = "fixed-point-7dps", raw = -2147483648 }
+
+[[steps.inputs]]
+channel = "Root.Types.Enum In"
+value = { type = "enum", enum_type = "Test State", member = "Idle" }
+
+[[steps.inputs]]
+channel = "Root.Types.String In"
+value = { type = "string", value = "tick zero" }
+
+[[steps.expected]]
+channel = "Root.Types.Bool Out"
+value = { type = "boolean", value = true }
+
+[[steps.expected]]
+channel = "Root.Types.Signed Out"
+value = { type = "integer", value = -2147483648 }
+
+[[steps.expected]]
+channel = "Root.Types.Unsigned Out"
+value = { type = "unsigned-integer", value = 4294967295 }
+
+[[steps.expected]]
+channel = "Root.Types.Float Out"
+value = { type = "floating-point", value = "-0" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.Types.Fixed Out"
+value = { type = "fixed-point-7dps", raw = -2147483648 }
+tolerance = { type = "fixed-point-7dps", raw = 0 }
+
+[[steps.expected]]
+channel = "Root.Types.Enum Out"
+value = { type = "enum", enum_type = "Test State", member = "Idle" }
+
+[[steps.expected]]
+channel = "Root.Types.String Out"
+value = { type = "string", value = "tick zero" }
+
+[[steps]]
+time_s = 0.1
+
+[[steps.inputs]]
+channel = "Root.Types.Bool In"
+value = { type = "boolean", value = false }
+
+[[steps.inputs]]
+channel = "Root.Types.Signed In"
+value = { type = "integer", value = 2147483647 }
+
+[[steps.inputs]]
+channel = "Root.Types.Unsigned In"
+value = { type = "unsigned-integer", value = 0 }
+
+[[steps.inputs]]
+channel = "Root.Types.Float In"
+value = { type = "floating-point", value = "NaN" }
+
+[[steps.inputs]]
+channel = "Root.Types.Fixed In"
+value = { type = "fixed-point-7dps", raw = 2147483647 }
+
+[[steps.inputs]]
+channel = "Root.Types.Enum In"
+value = { type = "enum", enum_type = "Test State", member = "Active" }
+
+[[steps.inputs]]
+channel = "Root.Types.String In"
+value = { type = "string", value = "tick one" }
+
+[[steps.expected]]
+channel = "Root.Types.Bool Out"
+value = { type = "boolean", value = false }
+
+[[steps.expected]]
+channel = "Root.Types.Signed Out"
+value = { type = "integer", value = 2147483647 }
+
+[[steps.expected]]
+channel = "Root.Types.Unsigned Out"
+value = { type = "unsigned-integer", value = 0 }
+
+[[steps.expected]]
+channel = "Root.Types.Float Out"
+value = { type = "floating-point", value = "NaN" }
+tolerance = { type = "floating-point", absolute = "0" }
+
+[[steps.expected]]
+channel = "Root.Types.Fixed Out"
+value = { type = "fixed-point-7dps", raw = 2147483647 }
+tolerance = { type = "fixed-point-7dps", raw = 0 }
+
+[[steps.expected]]
+channel = "Root.Types.Enum Out"
+value = { type = "enum", enum_type = "Test State", member = "Active" }
+
+[[steps.expected]]
+channel = "Root.Types.String Out"
+value = { type = "string", value = "tick one" }

--- a/tests/snapshots/snapshot__whole_project_trace.snap
+++ b/tests/snapshots/snapshot__whole_project_trace.snap
@@ -3,4 +3,4 @@ source: tests/snapshot.rs
 assertion_line: 115
 expression: trace.to_json()
 ---
-{"time":[0,0.01,0.02,0.03,0.04,0.05],"channels":{"Root.MR.Fast Out":[50,50,50,50,50,50],"Root.MR.Fast Shared":[5,5,5,5,5,5],"Root.MR.Seed":[2,2,2,2,2,2],"Root.MR.Slow Echo":[4,4,4,4,4,4],"Root.MR.Slow Out":[4,4,4,4,4,4],"Root.MR.Slow Total":[0,0,0.04,0.04,0.08,0.08],"Root.MR.Started":[1,1,1,1,1,1]},"external":["Root.MR.Seed"],"hardware":[]}
+{"time":[0,0.01,0.02,0.03,0.04,0.05],"channels":{"Root.MR.Fast Out":[50,50,50,50,50,50],"Root.MR.Fast Shared":[5,5,5,5,5,5],"Root.MR.Seed":[2,2,2,2,2,2],"Root.MR.Slow Echo":[4,4,4,4,4,4],"Root.MR.Slow Out":[4,4,4,4,4,4],"Root.MR.Slow Total":[0,0,0.04,0.04,0.08,0.08],"Root.MR.Started":[1,1,1,1,1,1]},"external":["Root.MR.Seed","Root.MR.Slow Out"],"hardware":[]}


### PR DESCRIPTION
Refs #42

## What changed

- Add a typed conformance fixture schema for inputs, initial state, expected outputs, calculation rate, and per-channel comparison rules.
- Bind each fixture to a hash-locked project bundle and record provenance without committing licensed or customer data.
- Reset evaluator state for every fixture, preserve exact tick alignment and write provenance, reject hidden external sources, and report the first meaningful mismatch.
- Add exact integer and Boolean comparison, declared floating and fixed-point tolerances, explicit nonfinite rules, a strict CLI gate, and three synthetic fixture bundles.
- Document the capture procedure and the optional private-suite environment gate.

## Verification

- `cargo test`: 548 passed.
- `cargo test --all-targets --all-features`: 559 passed, with the existing proprietary `.ld` test ignored.
- `cargo +1.88.0 test --all-targets --all-features`: 559 passed, with the same ignore.
- `cargo test --test conformance -- --nocapture`: 18 passed.
- `cargo clippy --all-targets --all-features -- -D warnings`.
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`.
- `cargo fmt --all -- --check` and commit/worktree diff checks.
- Replay range-diff against the reviewed #42 commit changes only adjacent README context added by #47.

## Remaining acceptance gate

This PR does not close #42. Every committed conformance fixture is explicitly synthetic. No genuine M1 Sim capture or proprietary project data is included, so the issue acceptance item requiring a captured M1 Sim fixture remains open.

A person with access to a licensed M1 Sim installation must follow `docs/conformance.md`, capture expected values from a reset simulator, and run the fixture through `--require-m1-sim-capture`. Private evidence can stay outside the repository through `M1_EVAL_M1_SIM_FIXTURES`.