### PR TITLE
fix: make Timer use the evaluator timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ do not compare computed channel values with captured M1 results.
 | Expressions, statements, enums, and inline user functions | **Assumed** | Covered by unit and synthetic-project tests. M1 evaluation results have not been captured for comparison. |
 | `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | Parsing, interpolation, and edge clamping use synthetic fixtures. Use the matching calibration file for actual values. Without it, parameters use typed external defaults. Table `.Lookup()` and `.Get()` fail in strict modes; whole-project mode may opt in to an external `0.0` fallback. |
 | `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, core value-object methods, and table methods | **Assumed** | Implemented methods have hand-derived tests. `AsString`, `Validate`, `Constrain`, `GetUnscheduled`, and `Set` resolve against eligible receiver classes; channel `Set` applies its project validation range before writing. `--coverage` remains authoritative for the methods a project uses. |
-| Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. |
+| Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. Timer countdowns use absolute evaluator time: `Remaining` is a read-only observation, while `Start`, `Stop`, and `Reset` are the only state transitions. |
 | `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Assumed / Stubbed** | Each call crosses a typed adapter boundary with its resolved receiver, source call site, arguments, and evaluator time. Exact-site scenario values take precedence over wildcard values and an attached adapter. `System.ElapsedTime` reports the interval since that call site last ran. Its first tick-zero call returns zero, while a site first reached later uses its function step. Tick calls use the deterministic base timeline. `System.FlashSize` and `System.FlashFree` require scenario or adapter data; they never become a dangerous zero. Remaining unhandled calls use documented typed stubs or fail loud. |
 | Scenario parsing, tick grids, trace output, and `--coverage` | **Assumed** | These are deterministic m1-eval contracts tested with synthetic data. A `Supported` coverage entry means implemented, not M1-verified. |
 | Typed conformance fixture parser and runner | **Assumed** | Synthetic fixtures cover typed values, project hashes, initial-state reset, tolerances, and mismatch reporting. No genuine M1 Sim capture is committed yet, so this runner does not make another area Verified by itself. |
@@ -127,10 +127,12 @@ The multi-rate model:
   the fastest rate) is **rejected loudly** rather than rounded. Each function
   then runs every `base_rate_hz / rate_hz` ticks: a 100 Hz function on a 100 Hz
   base runs every tick, a 50 Hz function every other tick.
-- **Rate-correct `dt`.** A function's stateful operators (`Integral.Normal`,
-  filters, derivatives, timers) are stepped by *its own* period
+- **Rate-correct `dt`.** A function's sampled stateful operators
+  (`Integral.Normal`, filters, derivatives) are stepped by *its own* period
   (`1 / rate_hz`) — a 50 Hz integrator accumulates with `dt = 0.02`, not the
-  base `dt`, so time-domain operators use the configured function period.
+  base `dt`. Timer objects instead retain an absolute deadline on the same
+  evaluator timeline, so `Remaining` observes elapsed time without advancing
+  the timer merely because it was read.
 - **Zero-order hold between ticks.** A channel a function did not write this
   tick keeps its last value (the shared value store carries it forward), so a
   slow channel holds steady between its updates while fast channels move every

--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ The multi-rate model:
   (`1 / rate_hz`) — a 50 Hz integrator accumulates with `dt = 0.02`, not the
   base `dt`. Timer objects instead retain an absolute deadline on the same
   evaluator timeline, so `Remaining` observes elapsed time without advancing
-  the timer merely because it was read.
+  the timer merely because it was read. Direct library users can carry that
+  timeline through `eval_at_time`, `exec_at_time`, `exec_script_at_time`,
+  `builtins::dispatch_at_time`, or `builtins::userfn::call_at_time`; the older
+  entry points remain tick-zero compatibility wrappers.
 - **Zero-order hold between ticks.** A channel a function did not write this
   tick keeps its last value (the shared value store carries it forward), so a
   slow channel holds steady between its updates while fast channels move every

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -60,6 +60,22 @@ pub fn dispatch(
     dispatch_with_runtime(object, method, args, site, ctx, &mut runtime)
 }
 
+/// Dispatch one builtin call at an explicit deterministic evaluator time.
+///
+/// This preserves the public [`dispatch`] API while giving direct callers a
+/// way to advance timer and hardware-model time without using the runner.
+pub fn dispatch_at_time(
+    object: &str,
+    method: &str,
+    args: &[Value],
+    site: CallSite,
+    ctx: &mut EvalCtx,
+    time: crate::hardware::EvalTime,
+) -> Result<Value, EvalError> {
+    let mut runtime = EvalRuntime::from_time(time);
+    dispatch_with_runtime(object, method, args, site, ctx, &mut runtime)
+}
+
 /// Internal dispatch path carrying the runner's evaluator timeline and adapter.
 pub(crate) fn dispatch_with_runtime(
     object: &str,
@@ -172,7 +188,7 @@ pub(crate) fn dispatch_with_runtime(
         CallRoute::Timer => {
             validate_object_arity(object, method, args.len())?;
             let object_key = timer_object_key(object, ctx);
-            match stateful::timer(method, args, object_key, runtime.time, ctx)? {
+            match stateful::timer_at(method, args, object_key, runtime.time, ctx)? {
                 Some(value) => Ok(value),
                 None => Err(unsupported(object, method)),
             }
@@ -1798,6 +1814,32 @@ mod tests {
             self.call_with_adapter(object, method, args, None)
         }
 
+        fn call_at_time(
+            &mut self,
+            object: &str,
+            method: &str,
+            args: &[Value],
+            time: crate::hardware::EvalTime,
+        ) -> Result<Value, EvalError> {
+            let site = CallSite::new("Demo.Update.m1scr", 0);
+            let mut ctx = EvalCtx {
+                project: &self.project,
+                calib: &self.calib,
+                env: &mut self.env,
+                state: &mut self.state,
+                group: Some("Root.Demo"),
+                fn_symbol: Some("Root.Demo.Update"),
+                script_name: "Demo.Update.m1scr",
+                dt: 0.01,
+                scripts: &[],
+                signature_m1_types: None,
+                object_rules: Some(&self.object_rules),
+                depth: 0,
+                trace: Some(&mut self.trace),
+            };
+            dispatch_at_time(object, method, args, site, &mut ctx, time)
+        }
+
         fn call_with_adapter(
             &mut self,
             object: &str,
@@ -2223,6 +2265,31 @@ mod tests {
             Err(EvalError::UnsupportedBuiltin { .. }) => {}
             other => panic!("expected channel.Start to be unsupported, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn public_timed_dispatch_advances_a_timer_on_the_supplied_timeline() {
+        let mut h = ProjectObjHarness::new();
+        h.call_at_time(
+            "Startup Delay",
+            "Start",
+            &[Value::m1_float(0.25)],
+            crate::hardware::EvalTime::periodic(500, 5.0, 0.01, 0.01),
+        )
+        .unwrap();
+
+        let remaining = h
+            .call_at_time(
+                "Startup Delay",
+                "Remaining",
+                &[],
+                crate::hardware::EvalTime::periodic(510, 5.1, 0.01, 0.01),
+            )
+            .unwrap()
+            .m1_scalar()
+            .unwrap()
+            .as_f64();
+        assert!((remaining - 0.15).abs() < 1e-6);
     }
 
     #[test]

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -172,7 +172,7 @@ pub(crate) fn dispatch_with_runtime(
         CallRoute::Timer => {
             validate_object_arity(object, method, args.len())?;
             let object_key = timer_object_key(object, ctx);
-            match stateful::timer(method, args, object_key, ctx)? {
+            match stateful::timer(method, args, object_key, runtime.time, ctx)? {
                 Some(value) => Ok(value),
                 None => Err(unsupported(object, method)),
             }
@@ -2218,7 +2218,7 @@ mod tests {
             .m1_scalar()
             .unwrap()
             .as_f64();
-        assert!((remaining - 0.02).abs() < 1e-7);
+        assert!((remaining - 0.03).abs() < 1e-7);
         match h.call("Precharge State", "Start", &[Value::m1_float(0.03)]) {
             Err(EvalError::UnsupportedBuiltin { .. }) => {}
             other => panic!("expected channel.Start to be unsupported, got {other:?}"),

--- a/src/builtins/stateful.rs
+++ b/src/builtins/stateful.rs
@@ -35,6 +35,7 @@
 use crate::env::{CallSite, OpState};
 use crate::error::EvalError;
 use crate::expr::EvalCtx;
+use crate::hardware::EvalTime;
 use crate::value::{M1Scalar, Value};
 use m1_typecheck::types::{ValueType, numeric_join};
 use std::cmp::Ordering;
@@ -194,10 +195,6 @@ fn advance_time(current: f64, dt: f64) -> f64 {
     current + dt
 }
 
-fn reduce_time(current: f64, dt: f64) -> f64 {
-    (current - dt).max(0.0)
-}
-
 /// Evaluate a `Timer` object method (`Start`/`Stop`/`Reset`/`Remaining`).
 /// Returns `Ok(None)` for a non-Timer method so the caller fails loud.
 ///
@@ -205,24 +202,27 @@ fn reduce_time(current: f64, dt: f64) -> f64 {
 /// share one countdown. We therefore key the state by the **object path**
 /// (`object_key`, a [`CallSite`] with the object path in the script slot and a
 /// zero offset) rather than the individual call site — `Start`/`Remaining`/… on
-/// one Timer all address the same state. The countdown advances by `ctx.dt` each
-/// time `Remaining` is read (the documented Phase-1 model: a
-/// Timer is read once per tick, so reading advances it one tick), clamped at
-/// zero. `Start(period)` (re)loads the period and runs; `Stop` halts without
-/// clearing; `Reset` clears to zero and halts.
+/// one Timer all address the same state. `Start(period)` records an absolute
+/// deadline on the evaluator timeline. `Remaining` observes `deadline - now`
+/// without modifying state, so two reads at one instant are identical and a
+/// timer continues to elapse even on ticks where no script reads it. `Stop`
+/// freezes the duration at the current evaluator time; `Reset` clears it.
 pub fn timer(
     method: &str,
     args: &[Value],
     object_key: CallSite,
+    time: EvalTime,
     ctx: &mut EvalCtx,
 ) -> Result<Option<Value>, EvalError> {
     // Only the Timer object methods are handled; anything else is not a timer.
     if !matches!(method, "Start" | "Stop" | "Reset" | "Remaining") {
         return Ok(None);
     }
-    let dt = ctx.dt;
+    let now = time.elapsed_s;
     let slot = ctx.state.entry(object_key);
-    // Read the current countdown (default: stopped at zero).
+    // Read the current countdown (default: stopped at zero). While running,
+    // `remaining` stores the absolute deadline; when stopped it stores the
+    // frozen duration. This preserves the established public OpState shape.
     let (mut remaining, mut running) = match slot {
         OpState::Timer { remaining, running } => (*remaining, *running),
         _ => (0.0, false),
@@ -231,11 +231,15 @@ pub fn timer(
     let result = match method {
         "Start" => {
             // Start (or restart) counting down from `period`.
-            remaining = seconds(&args[0])?.max(0.0);
+            let period = seconds(&args[0])?.max(0.0);
+            remaining = now + period;
             running = true;
             Value::Bool(true) // Void in M1; we return a benign value.
         }
         "Stop" => {
+            if running {
+                remaining = (remaining - now).max(0.0);
+            }
             running = false;
             Value::Bool(true)
         }
@@ -245,18 +249,20 @@ pub fn timer(
             Value::Bool(true)
         }
         "Remaining" => {
-            // Advance the countdown one tick on read, clamped at zero.
-            if running {
-                remaining = reduce_time(remaining, dt);
-                if remaining == 0.0 {
-                    running = false;
-                }
-            }
-            Value::m1_float(remaining as f32)
+            let observed = if running {
+                (remaining - now).max(0.0)
+            } else {
+                remaining
+            };
+            Value::m1_float(observed as f32)
         }
         _ => unreachable!("guarded above"),
     };
-    *slot = OpState::Timer { remaining, running };
+    // A read must not advance, decrement, stop, or otherwise rewrite the timer.
+    // Start/Stop/Reset are the only state transitions.
+    if method != "Remaining" {
+        *slot = OpState::Timer { remaining, running };
+    }
     Ok(Some(result))
 }
 
@@ -1926,10 +1932,10 @@ mod tests {
     // ---- Task 18: Timer object ----
 
     #[test]
-    fn timer_counts_down_on_read_and_stops_at_zero() {
+    fn timer_remaining_observes_the_evaluator_timeline_without_mutating_state() {
         let mut h = Harness::new(0.1);
         let key = CallSite::new("Root.Demo.MyTimer", 0);
-        let run = |h: &mut Harness, method: &str, args: &[Value]| -> Value {
+        let run = |h: &mut Harness, at: f64, method: &str, args: &[Value]| -> Value {
             let mut ctx = EvalCtx {
                 project: &h.project,
                 calib: &h.calib,
@@ -1945,33 +1951,52 @@ mod tests {
                 depth: 0,
                 trace: None,
             };
-            timer(method, args, key.clone(), &mut ctx).unwrap().unwrap()
+            let time = EvalTime::periodic(0, at, h.dt, h.dt);
+            timer(method, args, key.clone(), time, &mut ctx)
+                .unwrap()
+                .unwrap()
         };
-        // Start counting down from 0.25.
-        run(&mut h, "Start", &[n(0.25)]);
+        // Start after the run is already five seconds old. The deadline must be
+        // relative to this execution, not to tick zero.
+        run(&mut h, 5.0, "Start", &[n(0.25)]);
         approx(
-            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
+            run(&mut h, 5.0, "Remaining", &[])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
+            0.25,
+        );
+        let before_reads = h.state.get(&key).cloned();
+        approx(
+            run(&mut h, 5.1, "Remaining", &[])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             0.15,
         );
         approx(
-            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
-            0.05,
+            run(&mut h, 5.1, "Remaining", &[])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
+            0.15,
         );
+        assert_eq!(h.state.get(&key).cloned(), before_reads);
         approx(
-            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
+            run(&mut h, 5.25, "Remaining", &[])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             0.0,
-        ); // clamps
-        approx(
-            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
-            0.0,
-        ); // stays
+        );
+        assert_eq!(h.state.get(&key).cloned(), before_reads);
     }
 
     #[test]
     fn timer_progresses_when_dt_is_smaller_than_a_binary32_ulp() {
         let mut h = Harness::new(0.01);
         let key = CallSite::new("Root.Demo.LargeTimer", 0);
-        let run = |h: &mut Harness, method: &str, args: &[Value]| -> Value {
+        let run = |h: &mut Harness, at: f64, method: &str, args: &[Value]| -> Value {
             let mut ctx = EvalCtx {
                 project: &h.project,
                 calib: &h.calib,
@@ -1987,19 +2012,41 @@ mod tests {
                 depth: 0,
                 trace: None,
             };
-            timer(method, args, key.clone(), &mut ctx).unwrap().unwrap()
+            let time = EvalTime::periodic(0, at, h.dt, h.dt);
+            timer(method, args, key.clone(), time, &mut ctx)
+                .unwrap()
+                .unwrap()
         };
 
         let initial = f64::from(1_000_000_000_f32);
-        run(&mut h, "Start", &[n(initial)]);
-        run(&mut h, "Remaining", &[]);
+        run(&mut h, 0.0, "Start", &[n(initial)]);
+        let before_read = h.state.get(&key).cloned();
+        let observed = run(&mut h, 0.01, "Remaining", &[])
+            .m1_scalar()
+            .unwrap()
+            .as_f64();
+        // The public M1 result narrows back to binary32, whose ULP is larger
+        // than 10 ms here. The host-width deadline nevertheless retains the
+        // exact elapsed interval without a read-driven state update.
+        assert_eq!(observed, initial);
+        assert_eq!(h.state.get(&key).cloned(), before_read);
         match h.state.0.get(&key) {
             Some(OpState::Timer { remaining, running }) => {
                 assert!(*running);
-                assert!(*remaining < initial, "large timer did not advance");
-                assert!((initial - remaining - 0.01).abs() < 1e-6);
+                assert_eq!(*remaining, initial);
             }
             other => panic!("expected running timer state, got {other:?}"),
+        }
+        run(&mut h, 0.01, "Stop", &[]);
+        match h.state.0.get(&key) {
+            Some(OpState::Timer {
+                remaining, running, ..
+            }) => {
+                assert!(!running);
+                assert!(*remaining < initial, "large timer did not elapse");
+                assert!((initial - remaining - 0.01).abs() < 1e-6);
+            }
+            other => panic!("expected stopped timer state, got {other:?}"),
         }
     }
 
@@ -2007,7 +2054,7 @@ mod tests {
     fn timer_stop_and_reset() {
         let mut h = Harness::new(0.1);
         let key = CallSite::new("Root.Demo.MyTimer", 0);
-        let run = |h: &mut Harness, method: &str, args: &[Value]| -> Value {
+        let run = |h: &mut Harness, at: f64, method: &str, args: &[Value]| -> Value {
             let mut ctx = EvalCtx {
                 project: &h.project,
                 calib: &h.calib,
@@ -2023,19 +2070,75 @@ mod tests {
                 depth: 0,
                 trace: None,
             };
-            timer(method, args, key.clone(), &mut ctx).unwrap().unwrap()
+            let time = EvalTime::periodic(0, at, h.dt, h.dt);
+            timer(method, args, key.clone(), time, &mut ctx)
+                .unwrap()
+                .unwrap()
         };
-        run(&mut h, "Start", &[n(1.0)]);
-        run(&mut h, "Stop", &[]);
-        // Stopped: reading does not decrement.
+        run(&mut h, 0.0, "Start", &[n(1.0)]);
+        run(&mut h, 0.3, "Stop", &[]);
+        // Stopped at 0.3 s: later reads hold the frozen 0.7 s.
         approx(
-            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
-            1.0,
+            run(&mut h, 10.0, "Remaining", &[])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
+            0.7,
         );
-        run(&mut h, "Reset", &[]);
+        run(&mut h, 10.0, "Reset", &[]);
         approx(
-            run(&mut h, "Remaining", &[]).m1_scalar().unwrap().as_f64(),
+            run(&mut h, 100.0, "Remaining", &[])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
             0.0,
+        );
+    }
+
+    #[test]
+    fn timer_objects_keep_independent_deadlines() {
+        let mut h = Harness::new(0.1);
+        let first = CallSite::new("Root.Demo.FirstTimer", 0);
+        let second = CallSite::new("Root.Demo.SecondTimer", 0);
+        let run =
+            |h: &mut Harness, key: &CallSite, at: f64, method: &str, args: &[Value]| -> Value {
+                let mut ctx = EvalCtx {
+                    project: &h.project,
+                    calib: &h.calib,
+                    env: &mut h.env,
+                    state: &mut h.state,
+                    group: Some("Root.Demo"),
+                    fn_symbol: Some("Root.Demo.Update"),
+                    script_name: "Demo.Update.m1scr",
+                    dt: h.dt,
+                    scripts: &[],
+                    signature_m1_types: None,
+                    object_rules: None,
+                    depth: 0,
+                    trace: None,
+                };
+                let time = EvalTime::periodic(0, at, h.dt, h.dt);
+                timer(method, args, key.clone(), time, &mut ctx)
+                    .unwrap()
+                    .unwrap()
+            };
+
+        run(&mut h, &first, 0.0, "Start", &[n(1.0)]);
+        run(&mut h, &second, 0.0, "Start", &[n(2.0)]);
+        run(&mut h, &first, 0.5, "Stop", &[]);
+        approx(
+            run(&mut h, &first, 1.5, "Remaining", &[])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
+            0.5,
+        );
+        approx(
+            run(&mut h, &second, 1.5, "Remaining", &[])
+                .m1_scalar()
+                .unwrap()
+                .as_f64(),
+            0.5,
         );
     }
 

--- a/src/builtins/stateful.rs
+++ b/src/builtins/stateful.rs
@@ -195,19 +195,31 @@ fn advance_time(current: f64, dt: f64) -> f64 {
     current + dt
 }
 
-/// Evaluate a `Timer` object method (`Start`/`Stop`/`Reset`/`Remaining`).
-/// Returns `Ok(None)` for a non-Timer method so the caller fails loud.
+/// Source-compatible direct entry for a `Timer` object method.
 ///
-/// A `Timer` is a project *object*, so all four methods on the same object must
-/// share one countdown. We therefore key the state by the **object path**
-/// (`object_key`, a [`CallSite`] with the object path in the script slot and a
-/// zero offset) rather than the individual call site — `Start`/`Remaining`/… on
-/// one Timer all address the same state. `Start(period)` records an absolute
-/// deadline on the evaluator timeline. `Remaining` observes `deadline - now`
-/// without modifying state, so two reads at one instant are identical and a
-/// timer continues to elapse even on ticks where no script reads it. `Stop`
-/// freezes the duration at the current evaluator time; `Reset` clears it.
+/// The original signature has no absolute-time argument, so this wrapper uses
+/// periodic tick zero. Call [`timer_at`] when retaining a
+/// [`StateStore`](crate::env::StateStore) across direct evaluations;
+/// runner-backed calls already supply their current time.
 pub fn timer(
+    method: &str,
+    args: &[Value],
+    object_key: CallSite,
+    ctx: &mut EvalCtx,
+) -> Result<Option<Value>, EvalError> {
+    let time = EvalTime::at_start(ctx.dt);
+    timer_at(method, args, object_key, time, ctx)
+}
+
+/// Evaluate a `Timer` object method at explicit deterministic evaluator time.
+///
+/// A `Timer` is a project object, so all four methods on the same object share
+/// one countdown. State is keyed by the object path rather than the individual
+/// call site. `Start(period)` records an absolute deadline. `Remaining` observes
+/// `deadline - now` without modifying state, so two reads at one instant are
+/// identical and a timer continues to elapse on ticks where no script reads it.
+/// `Stop` freezes the duration at the current time; `Reset` clears it.
+pub fn timer_at(
     method: &str,
     args: &[Value],
     object_key: CallSite,
@@ -219,13 +231,12 @@ pub fn timer(
         return Ok(None);
     }
     let now = time.elapsed_s;
-    let slot = ctx.state.entry(object_key);
     // Read the current countdown (default: stopped at zero). While running,
     // `remaining` stores the absolute deadline; when stopped it stores the
     // frozen duration. This preserves the established public OpState shape.
-    let (mut remaining, mut running) = match slot {
-        OpState::Timer { remaining, running } => (*remaining, *running),
-        _ => (0.0, false),
+    let (mut remaining, mut running) = match ctx.state.get(&object_key) {
+        Some(OpState::Timer { remaining, running }) => (*remaining, *running),
+        Some(_) | None => (0.0, false),
     };
 
     let result = match method {
@@ -261,7 +272,7 @@ pub fn timer(
     // A read must not advance, decrement, stop, or otherwise rewrite the timer.
     // Start/Stop/Reset are the only state transitions.
     if method != "Remaining" {
-        *slot = OpState::Timer { remaining, running };
+        *ctx.state.entry(object_key) = OpState::Timer { remaining, running };
     }
     Ok(Some(result))
 }
@@ -1932,6 +1943,50 @@ mod tests {
     // ---- Task 18: Timer object ----
 
     #[test]
+    fn fresh_timer_remaining_does_not_create_state() {
+        let mut h = Harness::new(0.1);
+        let key = CallSite::new("Root.Demo.FreshTimer", 0);
+        let legacy_key = CallSite::new("Root.Demo.LegacyTimer", 0);
+        let mut ctx = EvalCtx {
+            project: &h.project,
+            calib: &h.calib,
+            env: &mut h.env,
+            state: &mut h.state,
+            group: Some("Root.Demo"),
+            fn_symbol: Some("Root.Demo.Update"),
+            script_name: "Demo.Update.m1scr",
+            dt: h.dt,
+            scripts: &[],
+            signature_m1_types: None,
+            object_rules: None,
+            depth: 0,
+            trace: None,
+        };
+
+        assert_eq!(
+            timer_at(
+                "Remaining",
+                &[],
+                key.clone(),
+                EvalTime::periodic(25, 2.5, h.dt, h.dt),
+                &mut ctx,
+            )
+            .unwrap(),
+            Some(Value::m1_float(0.0))
+        );
+        assert!(ctx.state.get(&key).is_none());
+
+        // The original public signature remains callable as a tick-zero
+        // compatibility wrapper and observes the same empty state.
+        assert_eq!(
+            timer("Remaining", &[], legacy_key.clone(), &mut ctx).unwrap(),
+            Some(Value::m1_float(0.0))
+        );
+        assert!(ctx.state.get(&legacy_key).is_none());
+        assert!(ctx.state.0.is_empty());
+    }
+
+    #[test]
     fn timer_remaining_observes_the_evaluator_timeline_without_mutating_state() {
         let mut h = Harness::new(0.1);
         let key = CallSite::new("Root.Demo.MyTimer", 0);
@@ -1952,7 +2007,7 @@ mod tests {
                 trace: None,
             };
             let time = EvalTime::periodic(0, at, h.dt, h.dt);
-            timer(method, args, key.clone(), time, &mut ctx)
+            timer_at(method, args, key.clone(), time, &mut ctx)
                 .unwrap()
                 .unwrap()
         };
@@ -2013,7 +2068,7 @@ mod tests {
                 trace: None,
             };
             let time = EvalTime::periodic(0, at, h.dt, h.dt);
-            timer(method, args, key.clone(), time, &mut ctx)
+            timer_at(method, args, key.clone(), time, &mut ctx)
                 .unwrap()
                 .unwrap()
         };
@@ -2071,7 +2126,7 @@ mod tests {
                 trace: None,
             };
             let time = EvalTime::periodic(0, at, h.dt, h.dt);
-            timer(method, args, key.clone(), time, &mut ctx)
+            timer_at(method, args, key.clone(), time, &mut ctx)
                 .unwrap()
                 .unwrap()
         };
@@ -2118,7 +2173,7 @@ mod tests {
                     trace: None,
                 };
                 let time = EvalTime::periodic(0, at, h.dt, h.dt);
-                timer(method, args, key.clone(), time, &mut ctx)
+                timer_at(method, args, key.clone(), time, &mut ctx)
                     .unwrap()
                     .unwrap()
             };

--- a/src/builtins/userfn.rs
+++ b/src/builtins/userfn.rs
@@ -84,6 +84,19 @@ pub fn call(
     call_with_runtime(callee_path, args, ctx, &mut runtime)
 }
 
+/// Evaluate an inline user-function call at explicit evaluator time.
+///
+/// The supplied time is retained through the callee body and every nested call.
+pub fn call_at_time(
+    callee_path: &str,
+    args: &[Value],
+    ctx: &mut EvalCtx,
+    time: crate::hardware::EvalTime,
+) -> Result<Option<Value>, EvalError> {
+    let mut runtime = EvalRuntime::from_time(time);
+    call_with_runtime(callee_path, args, ctx, &mut runtime)
+}
+
 pub(crate) fn call_with_runtime(
     callee_path: &str,
     args: &[Value],

--- a/src/env.rs
+++ b/src/env.rs
@@ -116,7 +116,9 @@ pub enum OpState {
     /// `Change.{To,From,Either}`: the previous boolean condition, plus a timer
     /// for the filtered overloads.
     ChangeEdge { prev: bool, held: f64 },
-    /// A countdown `Timer` object: the remaining time and whether it is running.
+    /// A countdown `Timer` object. While running, `remaining` stores its
+    /// absolute evaluator-timeline deadline; while stopped, it stores the
+    /// frozen duration returned by `Remaining`.
     Timer { remaining: f64, running: bool },
     /// `System.ElapsedTime`: evaluator time when this exact call site last ran.
     /// Each execution returns the interval from this timestamp, then replaces it.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -99,8 +99,14 @@ impl EvalRuntime<'static> {
     /// Such callers supply only `dt`, so the evaluation starts at tick zero and
     /// has no external hardware adapter.
     pub(crate) fn from_public(dt: f64) -> Self {
+        Self::from_time(EvalTime::at_start(dt))
+    }
+
+    /// Runtime for a direct evaluator caller that supplies deterministic time
+    /// but no hardware adapter.
+    pub(crate) fn from_time(time: EvalTime) -> Self {
         EvalRuntime {
-            time: EvalTime::at_start(dt),
+            time,
             hardware: None,
         }
     }
@@ -109,6 +115,16 @@ impl EvalRuntime<'static> {
 /// Evaluate an expression node to a [`Value`].
 pub fn eval(node: &Node, ctx: &mut EvalCtx) -> Result<Value, EvalError> {
     let mut runtime = EvalRuntime::from_public(ctx.dt);
+    eval_with_runtime(node, ctx, &mut runtime)
+}
+
+/// Evaluate an expression at an explicit deterministic evaluator time.
+///
+/// Use this entry point when reusing an [`EvalCtx`] and its [`StateStore`]
+/// across calls outside [`crate::runner`]. The long-standing [`eval`] wrapper
+/// remains source-compatible and represents periodic tick zero.
+pub fn eval_at_time(node: &Node, ctx: &mut EvalCtx, time: EvalTime) -> Result<Value, EvalError> {
+    let mut runtime = EvalRuntime::from_time(time);
     eval_with_runtime(node, ctx, &mut runtime)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,12 +33,12 @@ pub mod trace;
 pub use trace::Trace;
 
 pub mod expr;
-pub use expr::{EvalCtx, eval};
+pub use expr::{EvalCtx, eval, eval_at_time};
 
 pub mod builtins;
 
 pub mod stmt;
-pub use stmt::{exec, exec_script};
+pub use stmt::{exec, exec_at_time, exec_script, exec_script_at_time};
 
 pub mod scenario;
 pub use scenario::{InitialValue, InputKind, InputSeries, IoSeries, RunMode, Scenario};

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -45,6 +45,19 @@ pub fn exec(node: &Node, ctx: &mut EvalCtx) -> Result<(), EvalError> {
     exec_with_runtime(node, ctx, &mut runtime)
 }
 
+/// Execute one statement at an explicit deterministic evaluator time.
+///
+/// This is the direct-call counterpart of the runner's timed execution path.
+/// Stateful calls in `node` observe `time`; no hardware adapter is installed.
+pub fn exec_at_time(
+    node: &Node,
+    ctx: &mut EvalCtx,
+    time: crate::hardware::EvalTime,
+) -> Result<(), EvalError> {
+    let mut runtime = EvalRuntime::from_time(time);
+    exec_with_runtime(node, ctx, &mut runtime)
+}
+
 pub(crate) fn exec_with_runtime(
     node: &Node,
     ctx: &mut EvalCtx,
@@ -75,6 +88,18 @@ pub(crate) fn exec_with_runtime(
 /// statement is executed. A failure in any statement aborts the script fail-loud.
 pub fn exec_script(root: &Node, ctx: &mut EvalCtx) -> Result<(), EvalError> {
     let mut runtime = EvalRuntime::from_public(ctx.dt);
+    exec_script_with_runtime(root, ctx, &mut runtime)
+}
+
+/// Execute a parsed script at an explicit deterministic evaluator time.
+///
+/// One runtime is shared by every statement and nested call in the script.
+pub fn exec_script_at_time(
+    root: &Node,
+    ctx: &mut EvalCtx,
+    time: crate::hardware::EvalTime,
+) -> Result<(), EvalError> {
+    let mut runtime = EvalRuntime::from_time(time);
     exec_script_with_runtime(root, ctx, &mut runtime)
 }
 


### PR DESCRIPTION
Refs #44

## What changed

- make Timer deadlines use the deterministic evaluator timeline
- keep Remaining read-only, including on a fresh timer
- preserve independent timer objects and call sites across startup, periodic, nested, and counterfactual execution
- add explicit-time public evaluator wrappers while retaining the existing public signatures and EvalCtx shape
- cover late starts, stops, resets, expiry, sub-f32-ULP progression, and routed timed dispatch

## Verification

- full locked all-target/all-feature tests
- strict Clippy, rustdoc, formatting, Rust 1.88, and diff checks
- replay range-diff is exact for both reviewed commits

## Remaining acceptance gate

This PR lands the reviewed Timer slice but does not close #44. Filter, Integral, and Derivative families still require captured M1 Sim vectors before the full issue can close.
