### PR TITLE
feat: validate table lookup conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ do not compare computed channel values with captured M1 results.
 | Advertised area | State | Current contract |
 | --- | --- | --- |
 | Expressions, statements, enums, and inline user functions | **Assumed** | Covered by unit and synthetic-project tests. M1 evaluation results have not been captured for comparison. |
-| `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | Parsing, interpolation, and edge clamping use synthetic fixtures. Use the matching calibration file for actual values. Without it, parameters use typed external defaults. Table `.Lookup()` and `.Get()` fail in strict modes; whole-project mode may opt in to an external `0.0` fallback. |
+| `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | The reader honors explicit `Site="x,y,z"` coordinates with X changing fastest, enum axes, and each project's clamp or extrapolation flags. Synthetic vectors cover exact sites, interpolation, every boundary, and malformed tables. No M1 Sim table capture is available yet. Use the matching calibration for actual values. Without it, parameters use typed external defaults. Table `.Lookup()` and `.Get()` fail in strict modes; whole-project mode may opt in to an external `0.0` fallback. |
 | `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, core value-object methods, and table methods | **Assumed** | Implemented methods have hand-derived tests. `AsString`, `Validate`, `Constrain`, `GetUnscheduled`, and `Set` resolve against eligible receiver classes; channel `Set` applies its project validation range before writing. `--coverage` remains authoritative for the methods a project uses. |
 | Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. |
 | `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Assumed / Stubbed** | Each call crosses a typed adapter boundary with its resolved receiver, source call site, arguments, and evaluator time. Exact-site scenario values take precedence over wildcard values and an attached adapter. `System.ElapsedTime` reports the interval since that call site last ran. Its first tick-zero call returns zero, while a site first reached later uses its function step. Tick calls use the deterministic base timeline. `System.FlashSize` and `System.FlashFree` require scenario or adapter data; they never become a dangerous zero. Remaining unhandled calls use documented typed stubs or fail loud. |
@@ -52,7 +52,9 @@ dependency-cone runners.
   logical, bitwise), ternary, member access, enums, `if/else`, `when/is`,
   `expand/to`, `local` / `static local`.
 - **Table lookup** — 1/2/3-D linear interpolation over `.m1cfg` calibration
-  cells, with clamping at the axis edges.
+  cells. Body sites use X-fastest M1 coordinates. Numeric boundaries clamp by
+  default and extrapolate only when the project enables that end. Enum axes
+  select calibrated values exactly.
 - **Tier-1 pure builtins** — `Calculate.*`, `Limit.*`, `Convert.*`, table
   `.Lookup()`.
 - **Tier-2 stateful builtins** (the hard core) — `Filter.FirstOrder`,
@@ -252,13 +254,16 @@ m1-eval --project Project.m1prj --coverage
 # synthetic runner tests, not M1 compatibility evidence.
 m1-eval \
   --conformance tests/fixtures/conformance/synthetic-mini.toml \
-  --conformance tests/fixtures/conformance/synthetic-initial-state.toml
+  --conformance tests/fixtures/conformance/synthetic-initial-state.toml \
+  --conformance tests/fixtures/conformance/synthetic-tables.toml
 ```
 
 `--project` defaults to the nearest `Project.m1prj` upward (or `$M1_PROJECT`).
 See [`docs/cli.md`](docs/cli.md) for the full flag list, scenario format, and
 exit-code contract. [`docs/conformance.md`](docs/conformance.md) defines the
 golden-vector schema and the M1 Sim capture procedure.
+[`docs/table-conformance.md`](docs/table-conformance.md) records the table
+layout, boundary, malformed-data, and table-specific evidence contracts.
 
 The real-project smoke tests remain read-only and keep proprietary files out of
 the repository. Point each variable at a corpus repository root, version

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -132,6 +132,8 @@ meaningful mismatch.
 
 See [`conformance.md`](conformance.md) for the schema, comparison rules, M1 Sim
 capture procedure, synthetic examples, and the optional private-capture gate.
+Table captures also follow the stricter vector and corpus checks in
+[`table-conformance.md`](table-conformance.md).
 
 ## Output
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -19,7 +19,8 @@ steps in command-line order and stops at the first error or output mismatch.
 ```sh
 m1-eval \
   --conformance tests/fixtures/conformance/synthetic-mini.toml \
-  --conformance tests/fixtures/conformance/synthetic-initial-state.toml
+  --conformance tests/fixtures/conformance/synthetic-initial-state.toml \
+  --conformance tests/fixtures/conformance/synthetic-tables.toml
 ```
 
 Each fixture carries its own project and optional calibration path, so
@@ -208,6 +209,12 @@ signed, unsigned, binary32, fixed-point, enum, and string values through the
 full parser, evaluator, and comparator. The initial-state fixture starts two
 scheduled counters at non-zero values and runs the same fixture twice in one
 test. It catches state leakage and accidental per-tick reseeding.
+
+The table fixture checks one-, two-, and three-dimensional X-fastest layout,
+exact breakpoints, interior interpolation, lower and upper boundaries, a
+single-site axis, and project-enabled extrapolation. Its values are
+hand-derived. See [`table-conformance.md`](table-conformance.md) for the runtime
+contract and the separate M1 Sim capture gate.
 
 These files use `kind = "synthetic"` and cannot satisfy
 `--require-m1-sim-capture`.

--- a/docs/table-conformance.md
+++ b/docs/table-conformance.md
@@ -1,0 +1,129 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+# Table conformance
+
+Table behavior remains **Assumed** under the repository maturity contract. The
+committed vectors are synthetic and the real-project test checks only
+determinism. Neither is M1 Sim output.
+
+## Runtime contract
+
+M1 tables have one, two, or three axes. The calibration reader treats
+`.m1cfg` `Site="x,y,z"` coordinates as authoritative. It sorts cells by those
+coordinates before evaluation, so XML element order cannot change a result.
+The flat body offset is:
+
+```text
+ix + nx * (iy + ny * iz)
+```
+
+X changes fastest, followed by Y and Z. A hand-written calibration with no
+`Site` attributes uses that same X-fastest sequence. Mixing addressed and
+unaddressed cells is an error.
+
+Numeric axes retain the cell's declared M1 scalar family. Breakpoints must be
+finite, use one family per axis, and increase strictly. A single-site axis is a
+constant axis and accepts every finite numeric input. Repeated or descending
+breakpoints return a `MissingCalibration` diagnostic from `.Lookup()`. The
+evaluator does not choose one of two repeated sites; `.Get()` remains a raw
+flat-body read and does not inspect breakpoints.
+
+Enum axis cells store exact declared enum values. At a call site, the evaluator
+resolves the runtime member through the loaded project's enum definition and
+selects the matching site. The axis `Source` attribute binds the axis to that
+enum type; a member from another enum is an error even when both members have
+the same declared integer value. It does not interpolate enum sites. A missing
+source, missing value, or numeric value supplied to an enum axis is an error.
+Every calibrated value on a closed project enum must be one of that enum's
+declared member values. Firmware enums whose membership is explicitly open are
+exempt because their complete member set is unavailable offline.
+
+Body length must equal the product of the enabled axis lengths. Every body cell
+must use the same finite M1 scalar family. Exact breakpoint and clamped lookups
+return the stored body cell without a floating-point round trip. Interpolated
+floating-point results use binary32 arithmetic. Signed, unsigned, and
+fixed-point bodies retain their family only when the interpolated result is
+exactly representable in that storage.
+
+An axis clamps at both ends unless its table's `<Axis>` entry in `Project.m1prj`
+sets `Extrapolate` to `Below`, `Above`, or `Both`. The loader accepts both the
+direct `Component/Axis` shape used by the pinned project model and the
+`Component/Props/Axis` shape found in M1 project exports. Extrapolation uses the
+first two or last two sites at the enabled end. A single-site axis still returns
+its only body plane because it has no interval to extend. Boundary metadata
+follows the project's resolved `SymbolKind::Table` classification, including
+`BuiltIn.Table*` and `BuiltIn.CalibrationTable` components.
+
+## Synthetic vectors
+
+`tests/fixtures/conformance/synthetic-tables.toml` runs through the strict
+conformance API from issue #42. Its project and calibration hashes are part of
+the fixture.
+
+The fixture uses affine tables whose expected values can be checked by hand:
+
+| Table | Shape | Coverage |
+| --- | --- | --- |
+| Curve | 3 | Every breakpoint, a quarter-interval value, and both clamped ends |
+| Grid | 3 by 3 | X-fastest corner identity, quarter-interval bilinear interpolation, and isolated X/Y boundaries |
+| Cube | 2 by 3 by 2 | X/Y/Z layout, quarter-interval trilinear interpolation, and isolated X/Y/Z boundaries |
+| Single | 1 | Degenerate single-site behavior below, at, and above the site |
+| Extend | 2 by 2 | Bilinear interpolation and project-enabled extrapolation at both ends |
+| Enum Map | 3 enum sites | Exact selection for non-consecutive declared enum values |
+
+All 84 expected outputs use typed binary32 wire values with zero tolerance.
+That catches a changed body stride or boundary rule immediately. It does not
+claim that M1 Sim uses the same arithmetic order.
+
+## Private M1 Sim capture gate
+
+A genuine table capture must include all of these cases:
+
+1. Every site on a one-dimensional table and every corner on two- and
+   three-dimensional tables with unequal axis lengths.
+2. At least one non-midpoint interior coordinate per numeric axis. Non-midpoint
+   values can reveal operation-order rounding that midpoint-only data misses.
+3. A coordinate below and above every numeric axis while the other axes remain
+   inside their ranges.
+4. Separate tables for the default clamped policy and every enabled
+   extrapolation end used by the project.
+5. A single-site numeric axis and an enum axis with non-consecutive declared
+   values.
+6. The exact exported `.m1cfg` and `Project.m1prj`, including `Site` and
+   `Extrapolate` attributes. Hash every consumed file through the conformance
+   fixture manifest.
+
+Capture inputs before each calculation tick and outputs after it, starting from
+a reset M1 Sim session. Record the M1 Build and M1 Sim versions and capture time
+in `provenance`. Do not calculate the expected column with m1-eval. The general
+procedure in [`conformance.md`](conformance.md#capturing-from-m1-sim) still
+applies.
+
+Keep licensed or team-private material outside this repository. Point the
+table-specific gate at one or more approved fixtures using an operating-system
+path list:
+
+```sh
+M1_EVAL_TABLE_M1_SIM_FIXTURES=/secure/captures/tables.toml \
+  cargo test --test table_conformance \
+  configured_private_table_captures_form_an_optional_gate
+```
+
+The test requires at least one passing fixture with `m1-sim` provenance. A
+synthetic fixture cannot satisfy it.
+
+## Real-project determinism gate
+
+The optional project test loads a private project and its matching calibration.
+It evaluates the first site of every valid table twice and compares the exact
+typed result. Tables with repeated or descending axes must return the same
+diagnostic on both validations.
+
+```sh
+M1_EVAL_TABLE_PROJECT=/private/project/Project.m1prj \
+M1_EVAL_TABLE_CONFIG=/private/project/parameters.m1cfg \
+  cargo test --test table_conformance configured_real_project_tables_are_deterministic
+```
+
+This gate reads private files but never copies their names, values, or bytes
+into the repository. It is a regression test for loading and determinism, not
+evidence of numerical agreement with M1.

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -305,19 +305,14 @@ fn try_table_lookup(
         }
     };
 
-    // Each lookup coordinate must be numeric; collect them then interpolate.
-    let inputs = args
-        .iter()
-        .map(Value::m1_scalar)
-        .collect::<Result<Vec<_>, _>>()?;
-    // `table::lookup` validates arity (inputs vs axes) and clamps out-of-range
-    // coordinates, returning a BadCall on a mismatch.
-    let value = crate::table::lookup(table, &inputs)?;
+    // `table::lookup` validates arity and the coordinate family for every
+    // axis. Numeric axes interpolate; enum axes select an exact member site.
+    let value = crate::table::lookup_values(table, args, ctx.project)?;
     Ok(Some(Value::M1(value)))
 }
 
 /// Attempt a table `.Get(site)` — a raw read of one body cell by flat site
-/// index (row-major, matching [`crate::calib::CalTable`]'s documented layout),
+/// index (X-fastest, matching [`crate::calib::CalTable`]'s documented layout),
 /// with no interpolation. Returns `Ok(Some(value))` when `object` resolves to a
 /// project table with calibration cells; `Ok(None)` when `object` is not a
 /// table (so the caller continues to library-object dispatch). The site must be
@@ -1345,8 +1340,8 @@ mod tests {
     #[test]
     fn table_lookup_interpolates_over_calibration() {
         let mut h = Harness::new();
-        // The mini fixture's Demo.Map is 2-D: x in {0,100}, y in {0,1}, body
-        // (10,20,30,40). Corner and midpoint values come straight from table.rs.
+        // The mini fixture's Demo.Map is 2-D: x in {0,100}, y in {0,1}.
+        // Its M1 body order is (10,30,20,40), with X changing fastest.
         assert_eq!(
             h.call(
                 "Map",
@@ -1439,15 +1434,15 @@ mod tests {
     #[test]
     fn table_get_reads_flat_site() {
         let mut h = Harness::new();
-        // `.Get(i)` is a raw read of body cell i (row-major, no interpolation).
-        // Demo.Map's body is (10,20,30,40).
+        // `.Get(i)` is a raw read of body cell i (X-fastest, no interpolation).
+        // Demo.Map's flat body is (10,30,20,40).
         assert_eq!(
             h.call("Map", "Get", &[Value::m1_integer(0)]).unwrap(),
             Value::m1_float(10.0)
         );
         assert_eq!(
             h.call("Map", "Get", &[Value::m1_integer(2)]).unwrap(),
-            Value::m1_float(30.0)
+            Value::m1_float(20.0)
         );
         assert_eq!(
             h.call("Map", "Get", &[Value::m1_unsigned(3)]).unwrap(),

--- a/src/calib.rs
+++ b/src/calib.rs
@@ -24,12 +24,13 @@
 //!   according to the cell's declared type and restored to their M1-width scalar
 //!   family. Untyped and historical `f64` cells narrow to M1 binary32.
 //! - Scalar `enum` cells usually carry a member name (e.g. `On`) and are skipped.
-//!   Table enum axes instead contain the enum's numeric integer representation;
-//!   those values are retained as M1 integers. Boolean cells are not numeric
-//!   calibration values and are skipped.
+//!   Table enum axes instead contain exact declared numeric integer values and
+//!   retain their enum identity. Boolean cells are not numeric calibration
+//!   values and are skipped.
 //! - A `<Table Name="...">` has ordered `<X>`/`<Y>`/`<Z>` axis children, each
 //!   wrapping a `<Cells>` of breakpoint `<Cell>`s, plus a `<Body><Cells>` of
-//!   interpolation values.
+//!   interpolation values. `Site="x,y,z"` attributes define the axis and body
+//!   order independently of XML element order.
 //!
 //! Names are stored verbatim as the `.m1cfg` writes them. Real exports omit the
 //! implicit `Root.` group prefix that the symbol table uses; canonicalisation
@@ -38,27 +39,137 @@
 
 use crate::error::EvalError;
 use crate::value::{FixedPoint7dps, M1Scalar};
+use m1_typecheck::Project;
+use m1_typecheck::resolve::{Resolution, Scope, resolve};
+use m1_typecheck::symbols::{EnumId, SymbolKind};
 use std::collections::HashMap;
+
+/// Boundary policy for one numeric table axis.
+///
+/// M1 project metadata records this on the table's `<Axis>` entry. Missing
+/// metadata means that both ends clamp. Enum axes always use [`Self::Clamp`]
+/// because their sites are categorical, not interpolated coordinates.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AxisExtrapolation {
+    /// Clamp below the first site and above the last site.
+    #[default]
+    Clamp,
+    /// Extrapolate below the first site and clamp above the last site.
+    Below,
+    /// Clamp below the first site and extrapolate above the last site.
+    Above,
+    /// Extrapolate at both ends.
+    Both,
+}
+
+impl AxisExtrapolation {
+    pub(crate) const fn below(self) -> bool {
+        matches!(self, Self::Below | Self::Both)
+    }
+
+    pub(crate) const fn above(self) -> bool {
+        matches!(self, Self::Above | Self::Both)
+    }
+}
+
+/// Calibrated sites for one table axis.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CalAxisValues {
+    /// Ordered numeric breakpoints. Values retain their declared M1 family.
+    Numeric(Vec<M1Scalar>),
+    /// Ordered declared enum values and the project enum type that owns them.
+    /// Enum axes select a site exactly and never interpolate between members.
+    Enum {
+        /// Declared integer value at each calibrated site.
+        values: Vec<i64>,
+        /// Enum type resolved from the project axis `Source`. A raw `.m1cfg`
+        /// parse leaves this unbound until project properties are applied.
+        enum_id: Option<EnumId>,
+    },
+}
+
+/// One table axis and its boundary policy.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CalAxis {
+    /// Ordered numeric breakpoints or declared enum values.
+    pub values: CalAxisValues,
+    /// Numeric boundary behavior read from the project descriptor.
+    pub extrapolation: AxisExtrapolation,
+}
+
+impl CalAxis {
+    /// Construct a clamped numeric axis.
+    pub fn numeric(values: Vec<M1Scalar>) -> Self {
+        Self {
+            values: CalAxisValues::Numeric(values),
+            extrapolation: AxisExtrapolation::Clamp,
+        }
+    }
+
+    /// Construct a categorical enum axis.
+    pub fn enumerated(values: Vec<i64>) -> Self {
+        Self {
+            values: CalAxisValues::Enum {
+                values,
+                enum_id: None,
+            },
+            extrapolation: AxisExtrapolation::Clamp,
+        }
+    }
+
+    /// Construct a categorical enum axis bound to its project enum type.
+    pub fn enumerated_for(enum_id: EnumId, values: Vec<i64>) -> Self {
+        Self {
+            values: CalAxisValues::Enum {
+                values,
+                enum_id: Some(enum_id),
+            },
+            extrapolation: AxisExtrapolation::Clamp,
+        }
+    }
+
+    /// Number of calibrated sites on this axis.
+    pub fn len(&self) -> usize {
+        match &self.values {
+            CalAxisValues::Numeric(values) => values.len(),
+            CalAxisValues::Enum { values, .. } => values.len(),
+        }
+    }
+
+    /// Whether this axis has no calibrated sites.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
 
 /// A calibration table's concrete numbers: one breakpoint vector per input
 /// axis (in `<X>`,`<Y>`,`<Z>` order) plus the flat body cells.
 ///
 /// ## Body memory layout
 ///
-/// `body` is row-major with **axis 0 (X) outermost**: for a 2-D table the cell
-/// for breakpoint indices `(ix, iy)` lives at `ix * ny + iy` where `ny =
-/// axes[1].len()`. Generally the stride of axis `k` is the product of the
-/// lengths of all axes after `k`. `src/table.rs` relies on this layout.
+/// `body` uses the M1 site order recorded by `.m1cfg` `Site="x,y,z"`
+/// coordinates: X changes fastest, then Y, then Z. For a 2-D table the cell at
+/// `(ix, iy)` lives at `ix + nx * iy`, where `nx = axes[0].len()`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CalTable {
-    /// Breakpoint values per input axis, outermost first.
-    pub axes: Vec<Vec<M1Scalar>>,
-    /// Flat body cells, row-major with axis 0 outermost.
+    /// Axis sites in X, Y, Z order.
+    pub axes: Vec<CalAxis>,
+    /// Flat body cells in X-fastest M1 site order.
     pub body: Vec<M1Scalar>,
 }
 
-/// All numeric calibration values read from a `.m1cfg`: scalar parameters and
-/// tables, keyed by the name written in the file.
+impl CalTable {
+    /// Construct a table with clamped numeric axes.
+    pub fn numeric(axes: Vec<Vec<M1Scalar>>, body: Vec<M1Scalar>) -> Self {
+        Self {
+            axes: axes.into_iter().map(CalAxis::numeric).collect(),
+            body,
+        }
+    }
+}
+
+/// Calibration values read from a `.m1cfg`: numeric scalar parameters and
+/// numeric or enum-axis tables, keyed by the name written in the file.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Calibration {
     /// Scalar parameter values, keyed by `<Parameter Name>`.
@@ -71,8 +182,8 @@ impl Calibration {
     /// Parse a `.m1cfg` document's numeric values from its XML text.
     ///
     /// Malformed XML, unsupported numeric types, and values outside their M1
-    /// storage range fail loud. Named enum members and Boolean cells are skipped;
-    /// numeric enum representations (used by table axes) are retained.
+    /// storage range fail loud. Named enum members and Boolean parameters are
+    /// skipped; numeric enum representations and enum table axes are retained.
     pub fn from_m1cfg_str(xml: &str) -> Result<Calibration, EvalError> {
         let doc = roxmltree::Document::parse(xml).map_err(|e| EvalError::MissingCalibration {
             path: format!(".m1cfg parse error: {e}"),
@@ -99,7 +210,12 @@ impl Calibration {
             let Some(name) = tbl.attribute("Name") else {
                 continue;
             };
-            tables.insert(name.to_string(), parse_table(tbl)?);
+            let table = parse_table(tbl)?;
+            if tables.insert(name.to_string(), table).is_some() {
+                return Err(EvalError::MissingCalibration {
+                    path: format!("calibration declares table {name:?} more than once"),
+                });
+            }
         }
 
         Ok(Calibration { params, tables })
@@ -113,6 +229,157 @@ impl Calibration {
     /// The table values for a table path, if present.
     pub fn table(&self, path: &str) -> Option<&CalTable> {
         self.tables.get(path)
+    }
+
+    /// Apply per-axis extrapolation flags from an M1 project descriptor.
+    ///
+    /// Calibration exports carry sites and body values, while the project owns
+    /// the boundary policy. Calling this method joins those two halves. Tables
+    /// without an `Extrapolate` attribute keep the default clamped policy.
+    pub fn apply_project_table_properties(
+        &mut self,
+        xml: &str,
+        project: &Project,
+    ) -> Result<(), EvalError> {
+        let doc =
+            roxmltree::Document::parse(xml).map_err(|error| EvalError::MissingCalibration {
+                path: format!("project XML parse error while reading table properties: {error}"),
+            })?;
+
+        for component in doc
+            .descendants()
+            .filter(|node| node.has_tag_name("Component"))
+        {
+            let Some(project_name) = component.attribute("Name") else {
+                continue;
+            };
+            if !project
+                .symbols()
+                .get(project_name)
+                .is_some_and(|symbol| symbol.kind == SymbolKind::Table)
+            {
+                continue;
+            }
+            let config_name = project_name.strip_prefix("Root.").unwrap_or(project_name);
+            let key = if self.tables.contains_key(project_name) {
+                Some(project_name)
+            } else if self.tables.contains_key(config_name) {
+                Some(config_name)
+            } else {
+                None
+            };
+            let Some(key) = key else {
+                continue;
+            };
+            // The pinned project model reads a direct `<Component><Axis>`
+            // child, while real M1 project exports also place `<Axis>` inside
+            // `<Props>`. Prefer the direct form if both are present, then accept
+            // the evidenced export form.
+            let axis_properties = component
+                .children()
+                .find(|node| node.has_tag_name("Axis"))
+                .or_else(|| {
+                    component
+                        .children()
+                        .find(|node| node.has_tag_name("Props"))
+                        .and_then(|props| props.children().find(|node| node.has_tag_name("Axis")))
+                });
+            let table = self.tables.get_mut(key).expect("table key was checked");
+            for (index, tag) in ["X", "Y", "Z"].into_iter().enumerate() {
+                let Some(axis) = table.axes.get_mut(index) else {
+                    break;
+                };
+                let properties = axis_properties.and_then(|properties| {
+                    properties.children().find(|node| node.has_tag_name(tag))
+                });
+                if let Some(raw) = properties.and_then(|node| node.attribute("Extrapolate")) {
+                    axis.extrapolation = parse_extrapolation(raw).ok_or_else(|| {
+                        EvalError::MissingCalibration {
+                            path: format!(
+                                "table {project_name:?} axis {tag} has unknown Extrapolate value {raw:?}"
+                            ),
+                        }
+                    })?;
+                }
+                if let CalAxisValues::Enum { values, enum_id } = &mut axis.values {
+                    if axis.extrapolation != AxisExtrapolation::Clamp {
+                        return Err(EvalError::MissingCalibration {
+                            path: format!(
+                                "table {project_name:?} axis {tag} is enumerated and cannot extrapolate"
+                            ),
+                        });
+                    }
+                    let source = properties
+                        .and_then(|node| node.attribute("Source"))
+                        .ok_or_else(|| EvalError::MissingCalibration {
+                            path: format!(
+                                "table {project_name:?} enum axis {tag} has no project Source"
+                            ),
+                        })?;
+                    let resolved_id = resolve_enum_axis_source(project, project_name, tag, source)?;
+                    let enum_type = project.symbols().enum_type(resolved_id);
+                    if !enum_type.open {
+                        for value in values {
+                            if !enum_type
+                                .members
+                                .iter()
+                                .any(|(_, declared)| declared == value)
+                            {
+                                return Err(EvalError::MissingCalibration {
+                                    path: format!(
+                                        "table {project_name:?} enum axis {tag} calibrates value {value}, which is not declared by enum {:?}",
+                                        enum_type.name
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                    *enum_id = Some(resolved_id);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn resolve_enum_axis_source(
+    project: &Project,
+    table: &str,
+    axis: &str,
+    source: &str,
+) -> Result<EnumId, EvalError> {
+    let scope = Scope {
+        locals: HashMap::new(),
+        group: Some(table.to_string()),
+        project: Some(project),
+        fn_symbol: None,
+    };
+    let symbol = match resolve(source, &scope) {
+        Resolution::Symbol(symbol) => symbol,
+        _ => {
+            return Err(EvalError::MissingCalibration {
+                path: format!(
+                    "table {table:?} enum axis {axis} Source {source:?} does not resolve to a project value"
+                ),
+            });
+        }
+    };
+    symbol
+        .enum_assoc
+        .ok_or_else(|| EvalError::MissingCalibration {
+            path: format!(
+                "table {table:?} enum axis {axis} Source {source:?} is not bound to an enum type"
+            ),
+        })
+}
+
+fn parse_extrapolation(raw: &str) -> Option<AxisExtrapolation> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "none" | "neither" | "false" | "clamp" => Some(AxisExtrapolation::Clamp),
+        "below" => Some(AxisExtrapolation::Below),
+        "above" => Some(AxisExtrapolation::Above),
+        "both" => Some(AxisExtrapolation::Both),
+        _ => None,
     }
 }
 
@@ -156,9 +423,7 @@ fn cell_value(
             }
             M1Scalar::FloatingPoint(narrowed)
         }
-        "s8" | "s16" | "s32" | "s64" => text
-            .parse::<i32>()
-            .ok()
+        "s8" | "s16" | "s32" | "s64" => parse_calibration_i32(text)
             .map(M1Scalar::Integer)
             .ok_or_else(width_error)?,
         "u8" | "u16" | "u32" | "u64" => parse_unsigned_cell(text)
@@ -183,50 +448,356 @@ fn cell_value(
 fn parse_unsigned_cell(text: &str) -> Result<u32, std::num::ParseIntError> {
     let lower = text.to_ascii_lowercase();
     let body = lower.strip_suffix('u').unwrap_or(&lower);
+    let body = body.strip_prefix('+').unwrap_or(body);
     match body.strip_prefix("0x") {
         Some(hex) => u32::from_str_radix(hex, 16),
         None => body.parse::<u32>(),
     }
 }
 
-/// Collect the `<Cell>` breakpoint/body values under a `<Cells>` wrapper found
-/// directly inside `parent` (an axis `<X>/<Y>/<Z>` or a `<Body>`). Non-numeric
-/// cells fail loud, since a table cannot be silently missing interpolation
-/// data.
-fn cells_values(parent: roxmltree::Node<'_, '_>, ctx: &str) -> Result<Vec<M1Scalar>, EvalError> {
-    let Some(cells) = parent.children().find(|c| c.has_tag_name("Cells")) else {
-        return Ok(Vec::new());
-    };
-    let mut out = Vec::new();
-    let declared_type = cells.attribute("Type");
-    for cell in cells.children().filter(|c| c.has_tag_name("Cell")) {
-        match cell_value(cell, cell.attribute("Type").or(declared_type), ctx)? {
-            Some(v) => out.push(v),
-            None => {
-                return Err(EvalError::MissingCalibration {
-                    path: format!("non-numeric table cell in {ctx}"),
-                });
-            }
-        }
+fn parse_calibration_i32(text: &str) -> Option<i32> {
+    if let Ok(value) = text.parse::<i32>() {
+        return Some(value);
     }
-    Ok(out)
+    let (negative, magnitude) = match text.as_bytes().first() {
+        Some(b'-') => (true, &text[1..]),
+        Some(b'+') => (false, &text[1..]),
+        _ => (false, text),
+    };
+    let hex = magnitude
+        .strip_prefix("0x")
+        .or_else(|| magnitude.strip_prefix("0X"))?;
+    let magnitude = u32::from_str_radix(hex, 16).ok()?;
+    if negative {
+        i32::try_from(-(i64::from(magnitude))).ok()
+    } else {
+        i32::try_from(magnitude).ok()
+    }
 }
 
-/// Parse a `<Table>` element into its concrete [`CalTable`]: ordered `<X>`,
-/// `<Y>`, `<Z>` axis breakpoints and the `<Body>` cells.
+/// Parse the integer-valued decimal spelling used by enum axis cells. M1
+/// exports these as decimal or scientific notation even though they are exact
+/// enum values.
+fn parse_enum_value(text: &str) -> Option<i64> {
+    let text = text.trim();
+    let (negative, unsigned) = match text.as_bytes().first() {
+        Some(b'-') => (true, &text[1..]),
+        Some(b'+') => (false, &text[1..]),
+        _ => (false, text),
+    };
+    let mut exponent_split = unsigned.split(['e', 'E']);
+    let mantissa = exponent_split.next()?;
+    let exponent = match exponent_split.next() {
+        Some(value) if !value.is_empty() => value.parse::<i32>().ok()?,
+        Some(_) => return None,
+        None => 0,
+    };
+    if exponent_split.next().is_some() {
+        return None;
+    }
+    let mut decimal_split = mantissa.split('.');
+    let whole = decimal_split.next()?;
+    let fractional = decimal_split.next().unwrap_or("");
+    if decimal_split.next().is_some()
+        || (whole.is_empty() && fractional.is_empty())
+        || !whole.bytes().all(|byte| byte.is_ascii_digit())
+        || !fractional.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let mut digits = format!("{whole}{fractional}");
+    if digits.bytes().all(|byte| byte == b'0') {
+        return Some(0);
+    }
+    let shift = exponent.checked_sub(i32::try_from(fractional.len()).ok()?)?;
+    if shift < 0 {
+        let discarded = usize::try_from(shift.unsigned_abs()).ok()?;
+        let kept = digits.len().checked_sub(discarded)?;
+        if !digits[kept..].bytes().all(|byte| byte == b'0') {
+            return None;
+        }
+        digits.truncate(kept);
+    }
+    let significant = digits.trim_start_matches('0');
+    if significant.is_empty() {
+        return Some(0);
+    }
+    let coefficient = significant.parse::<u128>().ok()?;
+    let magnitude = if shift > 0 {
+        coefficient.checked_mul(10_u128.checked_pow(shift as u32)?)?
+    } else {
+        coefficient
+    };
+    let magnitude = i128::try_from(magnitude).ok()?;
+    let signed = if negative { -magnitude } else { magnitude };
+    i64::try_from(signed).ok()
+}
+
+type Site = [usize; 3];
+
+fn parse_site(cell: roxmltree::Node<'_, '_>, context: &str) -> Result<Option<Site>, EvalError> {
+    let Some(raw) = cell.attribute("Site") else {
+        return Ok(None);
+    };
+    let parts: Vec<&str> = raw.split(',').map(str::trim).collect();
+    if parts.is_empty() || parts.len() > 3 {
+        return Err(EvalError::MissingCalibration {
+            path: format!("{context} has invalid Site coordinate {raw:?}"),
+        });
+    }
+    let mut site = [0usize; 3];
+    for (index, part) in parts.into_iter().enumerate() {
+        site[index] = part
+            .parse::<usize>()
+            .map_err(|_| EvalError::MissingCalibration {
+                path: format!("{context} has invalid Site coordinate {raw:?}"),
+            })?;
+    }
+    Ok(Some(site))
+}
+
+fn order_axis_cells<T>(
+    entries: Vec<(Option<Site>, T)>,
+    axis_index: usize,
+    context: &str,
+) -> Result<Vec<T>, EvalError> {
+    let with_site = entries.iter().filter(|(site, _)| site.is_some()).count();
+    if with_site == 0 {
+        return Ok(entries.into_iter().map(|(_, value)| value).collect());
+    }
+    if with_site != entries.len() {
+        return Err(EvalError::MissingCalibration {
+            path: format!("{context} mixes cells with and without Site coordinates"),
+        });
+    }
+
+    let len = entries.len();
+    let mut ordered: Vec<Option<T>> = (0..len).map(|_| None).collect();
+    for (site, value) in entries {
+        let site = site.expect("all entries were checked for Site coordinates");
+        if site
+            .iter()
+            .enumerate()
+            .any(|(index, coordinate)| index != axis_index && *coordinate != 0)
+        {
+            return Err(EvalError::MissingCalibration {
+                path: format!(
+                    "{context} cell Site={},{},{} changes a different axis",
+                    site[0], site[1], site[2]
+                ),
+            });
+        }
+        let coordinate = site[axis_index];
+        if coordinate >= len {
+            return Err(EvalError::MissingCalibration {
+                path: format!("{context} Site index {coordinate} is outside its {len}-site axis"),
+            });
+        }
+        if ordered[coordinate].replace(value).is_some() {
+            return Err(EvalError::MissingCalibration {
+                path: format!("{context} declares Site index {coordinate} more than once"),
+            });
+        }
+    }
+    ordered
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| {
+            value.ok_or_else(|| EvalError::MissingCalibration {
+                path: format!("{context} is missing Site index {index}"),
+            })
+        })
+        .collect()
+}
+
+fn parse_axis(
+    axis: roxmltree::Node<'_, '_>,
+    axis_index: usize,
+    context: &str,
+) -> Result<CalAxis, EvalError> {
+    let Some(cells) = axis.children().find(|node| node.has_tag_name("Cells")) else {
+        return Ok(CalAxis::numeric(Vec::new()));
+    };
+    let default_type = cells.attribute("Type");
+    let nodes: Vec<_> = cells
+        .children()
+        .filter(|node| node.has_tag_name("Cell"))
+        .collect();
+    let enum_cells = nodes
+        .iter()
+        .filter(|cell| cell.attribute("Type").or(default_type) == Some("enum"))
+        .count();
+    if enum_cells != 0 && enum_cells != nodes.len() {
+        return Err(EvalError::MissingCalibration {
+            path: format!("{context} mixes enum and numeric sites"),
+        });
+    }
+
+    if enum_cells == nodes.len() && !nodes.is_empty() {
+        let mut entries = Vec::with_capacity(nodes.len());
+        for cell in nodes {
+            let raw = cell
+                .text()
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+                .ok_or_else(|| EvalError::MissingCalibration {
+                    path: format!("{context} has an empty enum site"),
+                })?;
+            let value = parse_enum_value(raw).ok_or_else(|| EvalError::MissingCalibration {
+                path: format!("{context} has invalid enum value {raw:?}"),
+            })?;
+            entries.push((parse_site(cell, context)?, value));
+        }
+        return order_axis_cells(entries, axis_index, context).map(CalAxis::enumerated);
+    }
+
+    let mut entries = Vec::with_capacity(nodes.len());
+    for cell in nodes {
+        let value = cell_value(cell, cell.attribute("Type").or(default_type), context)?
+            .ok_or_else(|| EvalError::MissingCalibration {
+                path: format!("{context} contains a non-numeric site"),
+            })?;
+        entries.push((parse_site(cell, context)?, value));
+    }
+    order_axis_cells(entries, axis_index, context).map(CalAxis::numeric)
+}
+
+fn body_offset(site: Site, axes: &[CalAxis], context: &str) -> Result<usize, EvalError> {
+    if site[axes.len()..].iter().any(|coordinate| *coordinate != 0) {
+        return Err(EvalError::MissingCalibration {
+            path: format!(
+                "{context} Site={},{},{} addresses a disabled axis",
+                site[0], site[1], site[2]
+            ),
+        });
+    }
+    let mut offset = 0usize;
+    let mut stride = 1usize;
+    for (index, axis) in axes.iter().enumerate() {
+        if site[index] >= axis.len() {
+            return Err(EvalError::MissingCalibration {
+                path: format!(
+                    "{context} Site={},{},{} is outside the table shape",
+                    site[0], site[1], site[2]
+                ),
+            });
+        }
+        offset = offset
+            .checked_add(site[index].checked_mul(stride).ok_or_else(|| {
+                EvalError::MissingCalibration {
+                    path: format!("{context} shape overflows a host index"),
+                }
+            })?)
+            .ok_or_else(|| EvalError::MissingCalibration {
+                path: format!("{context} shape overflows a host index"),
+            })?;
+        stride = stride
+            .checked_mul(axis.len())
+            .ok_or_else(|| EvalError::MissingCalibration {
+                path: format!("{context} shape overflows a host index"),
+            })?;
+    }
+    Ok(offset)
+}
+
+fn parse_body(
+    body: Option<roxmltree::Node<'_, '_>>,
+    axes: &[CalAxis],
+    context: &str,
+) -> Result<Vec<M1Scalar>, EvalError> {
+    let Some(cells) = body.and_then(|body| body.children().find(|node| node.has_tag_name("Cells")))
+    else {
+        return Ok(Vec::new());
+    };
+    let default_type = cells.attribute("Type");
+    let mut entries = Vec::new();
+    for cell in cells.children().filter(|node| node.has_tag_name("Cell")) {
+        let value = cell_value(cell, cell.attribute("Type").or(default_type), context)?
+            .ok_or_else(|| EvalError::MissingCalibration {
+                path: format!("{context} contains a non-numeric cell"),
+            })?;
+        entries.push((parse_site(cell, context)?, value));
+    }
+    let with_site = entries.iter().filter(|(site, _)| site.is_some()).count();
+    if with_site == 0 {
+        // Compatibility path for hand-written fixtures. M1 exports include
+        // explicit Site coordinates and use this same X-fastest order.
+        return Ok(entries.into_iter().map(|(_, value)| value).collect());
+    }
+    if with_site != entries.len() {
+        return Err(EvalError::MissingCalibration {
+            path: format!("{context} mixes cells with and without Site coordinates"),
+        });
+    }
+
+    let expected = axes.iter().try_fold(1usize, |product, axis| {
+        product
+            .checked_mul(axis.len())
+            .ok_or_else(|| EvalError::MissingCalibration {
+                path: format!("{context} shape overflows a host index"),
+            })
+    })?;
+    if entries.len() != expected {
+        return Err(EvalError::MissingCalibration {
+            path: format!(
+                "{context} has {} addressed cells, expected {expected} for the axis shape",
+                entries.len()
+            ),
+        });
+    }
+    let mut ordered: Vec<Option<M1Scalar>> = (0..expected).map(|_| None).collect();
+    for (site, value) in entries {
+        let offset = body_offset(
+            site.expect("all body cells were checked for Site coordinates"),
+            axes,
+            context,
+        )?;
+        if ordered[offset].replace(value).is_some() {
+            return Err(EvalError::MissingCalibration {
+                path: format!("{context} declares body offset {offset} more than once"),
+            });
+        }
+    }
+    ordered
+        .into_iter()
+        .enumerate()
+        .map(|(offset, value)| {
+            value.ok_or_else(|| EvalError::MissingCalibration {
+                path: format!("{context} is missing body offset {offset}"),
+            })
+        })
+        .collect()
+}
+
+/// Parse a `<Table>` element into its concrete X/Y/Z axes and body.
 fn parse_table(tbl: roxmltree::Node<'_, '_>) -> Result<CalTable, EvalError> {
     let name = tbl.attribute("Name").unwrap_or("<unnamed>");
     let mut axes = Vec::new();
-    for tag in ["X", "Y", "Z"] {
-        if let Some(axis) = tbl.children().find(|c| c.has_tag_name(tag)) {
-            axes.push(cells_values(axis, &format!("table {name} axis {tag}"))?);
+    let mut found_gap = false;
+    for (axis_index, tag) in ["X", "Y", "Z"].into_iter().enumerate() {
+        match tbl.children().find(|node| node.has_tag_name(tag)) {
+            Some(_) if found_gap => {
+                return Err(EvalError::MissingCalibration {
+                    path: format!("table {name:?} declares axis {tag} after a disabled axis"),
+                });
+            }
+            Some(axis) => axes.push(parse_axis(
+                axis,
+                axis_index,
+                &format!("table {name:?} axis {tag}"),
+            )?),
+            None => found_gap = true,
         }
     }
-    let body = match tbl.children().find(|c| c.has_tag_name("Body")) {
-        Some(b) => cells_values(b, &format!("table {name} body"))?,
-        None => Vec::new(),
-    };
-    Ok(CalTable { axes, body })
+    let body = parse_body(
+        tbl.children().find(|node| node.has_tag_name("Body")),
+        &axes,
+        &format!("table {name:?} body"),
+    )?;
+    let table = CalTable { axes, body };
+    crate::table::validate_shape_named(&table, &format!("table {name:?}"))?;
+    Ok(table)
 }
 
 #[cfg(test)]
@@ -235,6 +806,13 @@ mod tests {
 
     fn f(value: f32) -> M1Scalar {
         M1Scalar::FloatingPoint(value)
+    }
+
+    fn numeric_values(axis: &CalAxis) -> &[M1Scalar] {
+        match &axis.values {
+            CalAxisValues::Numeric(values) => values,
+            CalAxisValues::Enum { .. } => panic!("expected numeric axis"),
+        }
     }
 
     /// Synthetic 2-D table + scalar, mirroring the m1cfg fixture shape:
@@ -254,8 +832,8 @@ mod tests {
         assert_eq!(c.param("Root.A.Gain"), Some(f(2.5)));
         let t = c.table("Root.A.Map").unwrap();
         assert_eq!(t.axes.len(), 2);
-        assert_eq!(t.axes[0], vec![f(0.0), f(100.0)]);
-        assert_eq!(t.axes[1], vec![f(0.0), f(1.0)]);
+        assert_eq!(numeric_values(&t.axes[0]), [f(0.0), f(100.0)]);
+        assert_eq!(numeric_values(&t.axes[1]), [f(0.0), f(1.0)]);
         assert_eq!(t.body, vec![f(10.0), f(20.0), f(30.0), f(40.0)]);
     }
 
@@ -329,7 +907,7 @@ mod tests {
         let c = Calibration::from_m1cfg_str(xml).unwrap();
         let t = c.table("Root.Curve").unwrap();
         assert_eq!(t.axes.len(), 1);
-        assert_eq!(t.axes[0], vec![f(0.0), f(1.0), f(2.0)]);
+        assert_eq!(numeric_values(&t.axes[0]), [f(0.0), f(1.0), f(2.0)]);
         assert_eq!(t.body, vec![f(5.0), f(15.0), f(25.0)]);
     }
 
@@ -344,8 +922,11 @@ mod tests {
         let calibration = Calibration::from_m1cfg_str(xml).unwrap();
         let table = calibration.table("Root.Enum Curve").unwrap();
         assert_eq!(
-            table.axes[0],
-            vec![M1Scalar::Integer(0), M1Scalar::Integer(2)]
+            table.axes[0].values,
+            CalAxisValues::Enum {
+                values: vec![0, 2],
+                enum_id: None,
+            }
         );
 
         let fractional = r#"<Configuration>
@@ -413,5 +994,200 @@ mod tests {
         </Configuration>"#;
         let error = Calibration::from_m1cfg_str(host_overflow).unwrap_err();
         assert!(format!("{error}").contains("f32"), "{error}");
+    }
+
+    #[test]
+    fn site_coordinates_define_axis_and_x_fastest_body_order() {
+        let xml = r#"<Configuration>
+          <Table Name="Map">
+            <X><Cells Type="f32">
+              <Cell Site="1,0,0">10</Cell><Cell Site="0,0,0">0</Cell>
+            </Cells></X>
+            <Y><Cells Type="f32">
+              <Cell Site="0,1,0">1</Cell><Cell Site="0,0,0">0</Cell>
+            </Cells></Y>
+            <Body><Cells Type="f32">
+              <Cell Site="1,1,0">40</Cell><Cell Site="0,1,0">20</Cell>
+              <Cell Site="1,0,0">30</Cell><Cell Site="0,0,0">10</Cell>
+            </Cells></Body>
+          </Table>
+        </Configuration>"#;
+        let calibration = Calibration::from_m1cfg_str(xml).unwrap();
+        let table = calibration.table("Map").unwrap();
+        assert_eq!(numeric_values(&table.axes[0]), [f(0.0), f(10.0)]);
+        assert_eq!(numeric_values(&table.axes[1]), [f(0.0), f(1.0)]);
+        assert_eq!(table.body, vec![f(10.0), f(30.0), f(20.0), f(40.0)]);
+    }
+
+    #[test]
+    fn enum_axis_values_keep_site_order() {
+        assert_eq!(parse_enum_value("0e-999"), Some(0));
+        assert_eq!(parse_enum_value("-2.000e+0"), Some(-2));
+        assert_eq!(parse_enum_value("1.5"), None);
+
+        let xml = r#"<Configuration>
+          <Table Name="Modes">
+            <X><Cells Type="enum">
+              <Cell Site="1,0,0">2.000000000e+00</Cell><Cell Site="0,0,0">0</Cell>
+            </Cells></X>
+            <Body><Cells Type="f32">
+              <Cell Site="1,0,0">20</Cell><Cell Site="0,0,0">10</Cell>
+            </Cells></Body>
+          </Table>
+        </Configuration>"#;
+        let calibration = Calibration::from_m1cfg_str(xml).unwrap();
+        let table = calibration.table("Modes").unwrap();
+        assert_eq!(
+            table.axes[0].values,
+            CalAxisValues::Enum {
+                values: vec![0, 2],
+                enum_id: None,
+            }
+        );
+        assert_eq!(table.body, vec![f(10.0), f(20.0)]);
+    }
+
+    #[test]
+    fn canonical_project_axis_properties_cover_every_table_class() {
+        for classname in ["BuiltIn.TableVariant", "BuiltIn.CalibrationTable"] {
+            let mut calibration = Calibration::from_m1cfg_str(XML).unwrap();
+            let project_xml = format!(
+                r#"<MoTeCM1BuildSession><Project><ComponentStream><List>
+                  <Component Classname="{classname}" Name="Root.A.Map">
+                    <Props Type="f32" NumAxes="2"/>
+                    <Axis><X Extrapolate="Below"/><Y Extrapolate="Above"/></Axis>
+                  </Component>
+                </List></ComponentStream></Project></MoTeCM1BuildSession>"#
+            );
+            let temp = tempfile::tempdir().unwrap();
+            let project_path = temp.path().join("Project.m1prj");
+            std::fs::write(&project_path, &project_xml).unwrap();
+            let project = Project::load(&project_path).unwrap();
+
+            calibration
+                .apply_project_table_properties(&project_xml, &project)
+                .unwrap();
+            let table = calibration.table("Root.A.Map").unwrap();
+            assert_eq!(table.axes[0].extrapolation, AxisExtrapolation::Below);
+            assert_eq!(table.axes[1].extrapolation, AxisExtrapolation::Above);
+        }
+    }
+
+    #[test]
+    fn closed_enum_axes_reject_undeclared_sites_but_open_enums_accept_them() {
+        let calibration_xml = r#"<Configuration><Table Name="A.Map">
+          <X><Cells Type="enum"><Cell>0</Cell><Cell>99</Cell></Cells></X>
+          <Body><Cells Type="f32"><Cell>1</Cell><Cell>2</Cell></Cells></Body>
+        </Table></Configuration>"#;
+        let project_xml = |type_declaration: &str, source_type: &str| {
+            format!(
+                r#"<MoTeCM1BuildSession><Project>
+                  <DataTypes>{type_declaration}</DataTypes>
+                  <ComponentStream><List>
+                    <Component Classname="BuiltIn.GroupCompound" Name="Root.A"/>
+                    <Component Classname="BuiltIn.Channel" Name="Root.A.Mode"><Props Type="{source_type}"/></Component>
+                    <Component Classname="BuiltIn.Table" Name="Root.A.Map">
+                      <Props Type="f32" NumAxes="1"/>
+                      <Axis><X Source="Parent.Mode"/></Axis>
+                    </Component>
+                  </List></ComponentStream>
+                </Project></MoTeCM1BuildSession>"#
+            )
+        };
+        let load_project = |xml: &str| {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join("Project.m1prj");
+            std::fs::write(&path, xml).unwrap();
+            (temp, Project::load(&path).unwrap())
+        };
+
+        let closed_xml = project_xml(
+            r#"<Type Storage="enum" Name="Mode" Default="Idle">
+              <Enum Name="Idle" ContainerOrder="0"/>
+            </Type>"#,
+            "::This.Mode",
+        );
+        let (_closed_temp, closed_project) = load_project(&closed_xml);
+        let mut closed = Calibration::from_m1cfg_str(calibration_xml).unwrap();
+        let error = closed
+            .apply_project_table_properties(&closed_xml, &closed_project)
+            .expect_err("closed enum excludes calibration value 99");
+        assert!(format!("{error}").contains("value 99"), "{error}");
+
+        let open_xml = project_xml("", "MoTeC Types.Undocumented Table Mode");
+        let (_open_temp, open_project) = load_project(&open_xml);
+        let mut open = Calibration::from_m1cfg_str(calibration_xml).unwrap();
+        open.apply_project_table_properties(&open_xml, &open_project)
+            .expect("open firmware enum membership is not exhaustively known");
+        let CalAxisValues::Enum {
+            enum_id: Some(enum_id),
+            ..
+        } = &open.table("A.Map").unwrap().axes[0].values
+        else {
+            panic!("enum axis is bound to its open project type");
+        };
+        assert!(open_project.symbols().enum_is_open(*enum_id));
+    }
+
+    #[test]
+    fn sparse_addressed_body_rejects_shape_before_large_allocation() {
+        let sites = (0..1_000)
+            .map(|value| format!("<Cell>{value}</Cell>"))
+            .collect::<String>();
+        let xml = format!(
+            r#"<Configuration><Table Name="Sparse">
+              <X><Cells Type="f32">{sites}</Cells></X>
+              <Y><Cells Type="f32">{sites}</Cells></Y>
+              <Z><Cells Type="f32">{sites}</Cells></Z>
+              <Body><Cells Type="f32"><Cell Site="0,0,0">1</Cell></Cells></Body>
+            </Table></Configuration>"#
+        );
+        let error = Calibration::from_m1cfg_str(&xml).unwrap_err();
+        assert!(
+            format!("{error}").contains("1 addressed cells, expected 1000000000"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn invalid_sites_axes_and_shapes_fail_during_calibration_load() {
+        let cases = [
+            (
+                r#"<Configuration><Table Name="Gap"><X><Cells Type="f32"><Cell>0</Cell></Cells></X><Z><Cells Type="f32"><Cell>0</Cell></Cells></Z><Body><Cells Type="f32"><Cell>1</Cell></Cells></Body></Table></Configuration>"#,
+                "after a disabled axis",
+            ),
+            (
+                r#"<Configuration><Table Name="Mixed"><X><Cells Type="f32"><Cell Site="0,0,0">0</Cell><Cell>1</Cell></Cells></X><Body><Cells Type="f32"><Cell>1</Cell><Cell>2</Cell></Cells></Body></Table></Configuration>"#,
+                "mixes cells with and without Site",
+            ),
+            (
+                r#"<Configuration><Table Name="DuplicateAxis"><X><Cells Type="f32"><Cell Site="0,0,0">0</Cell><Cell Site="0,0,0">1</Cell></Cells></X><Body><Cells Type="f32"><Cell>1</Cell><Cell>2</Cell></Cells></Body></Table></Configuration>"#,
+                "Site index 0 more than once",
+            ),
+            (
+                r#"<Configuration><Table Name="OutsideBody"><X><Cells Type="f32"><Cell>0</Cell><Cell>1</Cell></Cells></X><Body><Cells Type="f32"><Cell Site="0,0,0">1</Cell><Cell Site="2,0,0">2</Cell></Cells></Body></Table></Configuration>"#,
+                "outside the table shape",
+            ),
+            (
+                r#"<Configuration><Table Name="DuplicateBody"><X><Cells Type="f32"><Cell>0</Cell><Cell>1</Cell></Cells></X><Body><Cells Type="f32"><Cell Site="0,0,0">1</Cell><Cell Site="0,0,0">2</Cell></Cells></Body></Table></Configuration>"#,
+                "body offset 0 more than once",
+            ),
+            (
+                r#"<Configuration><Table Name="DisabledAxis"><X><Cells Type="f32"><Cell>0</Cell></Cells></X><Body><Cells Type="f32"><Cell Site="0,1,0">1</Cell></Cells></Body></Table></Configuration>"#,
+                "addresses a disabled axis",
+            ),
+            (
+                r#"<Configuration><Table Name="Shape"><X><Cells Type="f32"><Cell>0</Cell><Cell>1</Cell></Cells></X><Body><Cells Type="f32"><Cell>1</Cell></Cells></Body></Table></Configuration>"#,
+                "expected 2",
+            ),
+            (
+                r#"<Configuration><Table Name="Zero"><Body><Cells Type="f32"><Cell>1</Cell></Cells></Body></Table></Configuration>"#,
+                "require one, two, or three",
+            ),
+        ];
+        for (xml, needle) in cases {
+            let error = Calibration::from_m1cfg_str(xml).expect_err("invalid table must fail");
+            assert!(format!("{error}").contains(needle), "{error}");
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,10 @@ pub mod value;
 pub use value::{FixedPoint7dps, M1Scalar, M1ScalarKind, Value};
 
 pub mod calib;
-pub use calib::{CalTable, Calibration};
+pub use calib::{AxisExtrapolation, CalAxis, CalAxisValues, CalTable, Calibration};
 
 pub mod table;
+pub use table::TableInput;
 
 pub mod loader;
 pub use loader::{Loaded, load};

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -112,7 +112,7 @@ pub fn load(project_path: &Path, cfg_path: Option<&Path>) -> Result<Loaded, Eval
     // Read the calibration *values*. We read the file ourselves (rather than
     // re-using `m1-typecheck`'s loader) because `with_config` keeps only the
     // shape; `Calibration::from_m1cfg_str` keeps the numbers.
-    let calib = match cfg_path {
+    let mut calib = match cfg_path {
         Some(cfg) => {
             let xml = read_xml(cfg)?;
             Calibration::from_m1cfg_str(&xml)?
@@ -121,6 +121,7 @@ pub fn load(project_path: &Path, cfg_path: Option<&Path>) -> Result<Loaded, Eval
     };
 
     let project_xml = read_xml(project_path)?;
+    calib.apply_project_table_properties(&project_xml, &project)?;
     let signature_m1_types = signature_m1_types(&project_xml)?;
     let object_rules = ObjectRules::from_project_xml(&project_xml)?;
     let triggers = TriggerMap::from_project_xml(&project_xml, &project, &scripts)?;
@@ -294,7 +295,7 @@ mod tests {
         assert_eq!(map.axes.len(), 2);
         assert_eq!(
             map.body,
-            vec![10.0, 20.0, 30.0, 40.0]
+            vec![10.0, 30.0, 20.0, 40.0]
                 .into_iter()
                 .map(crate::value::M1Scalar::FloatingPoint)
                 .collect::<Vec<_>>()

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,37 +1,73 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-//! N-dimensional clamped multilinear interpolation over a [`CalTable`].
+//! One-, two-, and three-dimensional table evaluation over a [`CalTable`].
 //!
-//! Given per-axis breakpoint vectors and a flat body, [`lookup`] returns the
-//! multilinearly interpolated value at an arbitrary point. Inputs outside an
-//! axis's breakpoint range are **clamped** to the nearest end (no
-//! extrapolation).
+//! Numeric axes interpolate linearly. Enum axes select an exact member site.
+//! Inputs outside a numeric axis clamp unless the project descriptor enables
+//! extrapolation below, above, or at both ends.
 //!
 //! ## Body memory layout
 //!
-//! The body is row-major with **axis 0 (X) outermost** — matching
-//! [`crate::calib::CalTable`]'s documented layout. For breakpoint indices
-//! `(i0, i1, …, i_{n-1})` the flat offset is
-//! `sum_k i_k * stride_k`, where `stride_k = prod_{j>k} len(axis_j)` (so the
-//! last/innermost axis has stride 1). For a 2-D `nx*ny` table this is the
-//! familiar `ix * ny + iy`.
-//!
-//! ## Clamp vs extend (assumption)
-//!
-//! Phase 1 **clamps** out-of-range inputs to the axis endpoints. MoTeC's exact
-//! extrapolation behaviour (clamp vs linear extend past the last breakpoint) is
-//! to be confirmed against M1 Sim during fidelity work; until then this is the
-//! documented assumption, not silently-wrong output.
+//! M1 `.m1cfg` cells carry `Site="x,y,z"` coordinates. X changes fastest, then
+//! Y, then Z. The flat offset is `ix + nx * (iy + ny * iz)`. The calibration
+//! reader sorts explicitly addressed cells into this order, so XML document
+//! order cannot change a lookup result.
 
-use crate::calib::CalTable;
+use crate::calib::{AxisExtrapolation, CalAxis, CalAxisValues, CalTable};
 use crate::error::EvalError;
-use crate::value::{FixedPoint7dps, M1Scalar, M1ScalarKind};
+use crate::value::{FixedPoint7dps, M1Scalar, M1ScalarKind, Value};
+use m1_typecheck::Project;
+use std::collections::BTreeSet;
 
-/// Multilinear interpolation of `t` at `inputs` (one coordinate per axis).
+/// One resolved table coordinate.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TableInput {
+    /// M1-width numeric coordinate.
+    Numeric(M1Scalar),
+    /// Project enum identity and declared integer value of one member.
+    Enum {
+        /// Enum type id in the loaded project.
+        enum_id: usize,
+        /// Declared integer value of the member.
+        value: i64,
+    },
+}
+
+/// Evaluate a table from M1-width numeric coordinates.
 ///
-/// - Arity must equal `t.axes.len()`, else [`EvalError::BadCall`].
-/// - Each input is clamped to its axis's `[first, last]` range.
-/// - Empty/malformed tables fail loud rather than guessing.
+/// Use [`lookup_values`] for runtime values that may include enum members.
 pub fn lookup(t: &CalTable, inputs: &[M1Scalar]) -> Result<M1Scalar, EvalError> {
+    let inputs: Vec<TableInput> = inputs.iter().copied().map(TableInput::Numeric).collect();
+    lookup_inputs(t, &inputs)
+}
+
+/// Resolve runtime enum members through `project`, then evaluate the table.
+pub fn lookup_values(
+    table: &CalTable,
+    inputs: &[Value],
+    project: &Project,
+) -> Result<M1Scalar, EvalError> {
+    let inputs = inputs
+        .iter()
+        .map(|input| match input {
+            Value::M1(value) => Ok(TableInput::Numeric(*value)),
+            Value::Enum { id, .. } => input.as_enum_int(project).map(|value| TableInput::Enum {
+                enum_id: *id,
+                value,
+            }),
+            other => Err(EvalError::TypeError {
+                detail: format!("{other:?} is not a numeric or enum table coordinate"),
+            }),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    lookup_inputs(table, &inputs)
+}
+
+/// Evaluate a table from already-resolved numeric or enum coordinates.
+///
+/// Arity must match the axis count. Numeric inputs clamp or extrapolate from
+/// their axis metadata. Enum inputs must equal one calibrated declared value.
+/// Empty, repeated, descending, mixed-type, or misshapen tables fail loud.
+pub fn lookup_inputs(t: &CalTable, inputs: &[TableInput]) -> Result<M1Scalar, EvalError> {
     if inputs.len() != t.axes.len() {
         return Err(EvalError::BadCall {
             detail: format!(
@@ -41,66 +77,24 @@ pub fn lookup(t: &CalTable, inputs: &[M1Scalar]) -> Result<M1Scalar, EvalError> 
             ),
         });
     }
-    if inputs
-        .iter()
-        .any(|input| matches!(input, M1Scalar::FloatingPoint(value) if value.is_nan()))
-    {
-        return Err(EvalError::BadCall {
-            detail: "table lookup coordinate is NaN".to_string(),
-        });
-    }
-
-    // A scalar (0-axis) "table" is just its single body cell.
-    if t.axes.is_empty() {
-        return match t.body.as_slice() {
-            [v] => Ok(*v),
-            _ => Err(EvalError::MissingCalibration {
-                path: "0-axis table without exactly one body cell".to_string(),
-            }),
-        };
-    }
-
-    // Expected body length is the product of axis lengths.
-    let mut expected = 1usize;
-    for axis in &t.axes {
-        if axis.is_empty() {
-            return Err(EvalError::MissingCalibration {
-                path: "table axis has no breakpoints".to_string(),
-            });
-        }
-        expected = expected.saturating_mul(axis.len());
-    }
-    if t.body.len() != expected {
-        return Err(EvalError::MissingCalibration {
-            path: format!(
-                "table body has {} cells, expected {} for axis shape",
-                t.body.len(),
-                expected
-            ),
-        });
-    }
-
+    validate(t)?;
     let body_kind = t.body[0].kind();
-    if t.body.iter().any(|value| value.kind() != body_kind) {
-        return Err(EvalError::MissingCalibration {
-            path: "table body mixes M1 scalar types".to_string(),
-        });
-    }
 
-    // Per-axis: lower bracket index and fractional position in [0, 1].
+    // Per-axis: lower bracket index and relative position. Clamped coordinates
+    // stay in [0, 1]; enabled extrapolation can produce values outside it.
     let n = t.axes.len();
     let mut lo = vec![0usize; n];
     let mut frac = vec![0.0f64; n];
     for (k, axis) in t.axes.iter().enumerate() {
-        let (i, f) = bracket(axis, inputs[k].as_f64());
+        let (i, f) = bracket(axis, &inputs[k], k)?;
         lo[k] = i;
         frac[k] = f;
     }
 
-    // Row-major strides with axis 0 outermost (innermost stride = 1).
+    // M1 site strides with axis 0 (X) innermost.
     let mut stride = vec![1usize; n];
-    for k in (0..n - 1).rev() {
-        stride[k] = stride[k + 1] * t.axes[k + 1].len();
+    for k in 1..n {
+        stride[k] = stride[k - 1] * t.axes[k - 1].len();
     }
 
     // Preserve the stored scalar bit-for-bit at exact breakpoints and clamps.
@@ -205,21 +199,213 @@ fn narrow_interpolated(kind: M1ScalarKind, value: f64) -> Result<M1Scalar, EvalE
     }
 }
 
-/// For a sorted-ascending breakpoint axis, return the lower bracket index and
-/// the fractional position of `x` between that breakpoint and the next.
-///
-/// Out-of-range inputs clamp: below `axis[0]` -> index 0, frac 0; at or above
-/// `axis[last]` -> index `last-1`, frac 1 (so the upper corner is the last
-/// breakpoint). A single-breakpoint axis returns index 0, frac 0.
-fn bracket(axis: &[M1Scalar], x: f64) -> (usize, f64) {
+/// Validate an in-memory table before interpolation.
+pub fn validate(table: &CalTable) -> Result<(), EvalError> {
+    validate_named(table, "table")
+}
+
+pub(crate) fn validate_named(table: &CalTable, label: &str) -> Result<(), EvalError> {
+    validate_shape_named(table, label)?;
+    let invalid = |detail: String| EvalError::MissingCalibration {
+        path: format!("{label}: {detail}"),
+    };
+    for (axis_index, axis) in table.axes.iter().enumerate() {
+        let axis_name = axis_name(axis_index);
+        match &axis.values {
+            CalAxisValues::Numeric(values) => {
+                for (index, pair) in values.windows(2).enumerate() {
+                    let lower = pair[0].as_f64();
+                    let upper = pair[1].as_f64();
+                    if upper == lower {
+                        return Err(invalid(format!(
+                            "axis {axis_name} repeats a breakpoint at sites {index} and {}",
+                            index + 1
+                        )));
+                    }
+                    if upper < lower {
+                        return Err(invalid(format!(
+                            "axis {axis_name} is not strictly ascending at sites {index} and {}",
+                            index + 1
+                        )));
+                    }
+                }
+            }
+            CalAxisValues::Enum { values, enum_id } => {
+                if enum_id.is_none() {
+                    return Err(invalid(format!(
+                        "enum axis {axis_name} has no resolved project enum type"
+                    )));
+                }
+                let mut seen = BTreeSet::new();
+                for value in values {
+                    if !seen.insert(value) {
+                        return Err(invalid(format!(
+                            "enum axis {axis_name} repeats value {value}"
+                        )));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_shape_named(table: &CalTable, label: &str) -> Result<(), EvalError> {
+    let invalid = |detail: String| EvalError::MissingCalibration {
+        path: format!("{label}: {detail}"),
+    };
+    if !(1..=3).contains(&table.axes.len()) {
+        return Err(invalid(format!(
+            "has {} axes; M1 tables require one, two, or three",
+            table.axes.len()
+        )));
+    }
+    let mut expected = 1usize;
+    for (axis_index, axis) in table.axes.iter().enumerate() {
+        let axis_name = axis_name(axis_index);
+        if axis.is_empty() {
+            return Err(invalid(format!("axis {axis_name} has no calibrated sites")));
+        }
+        expected = expected.checked_mul(axis.len()).ok_or_else(|| {
+            invalid(format!(
+                "axis shape overflows while adding axis {axis_name}"
+            ))
+        })?;
+        match &axis.values {
+            CalAxisValues::Numeric(values) => {
+                let kind = values[0].kind();
+                for (index, value) in values.iter().copied().enumerate() {
+                    if value.kind() != kind {
+                        return Err(invalid(format!(
+                            "axis {axis_name} mixes M1 scalar families at site {index}"
+                        )));
+                    }
+                    if !value.as_f64().is_finite() {
+                        return Err(invalid(format!(
+                            "axis {axis_name} site {index} is not finite"
+                        )));
+                    }
+                }
+            }
+            CalAxisValues::Enum { .. } => {
+                if axis.extrapolation != AxisExtrapolation::Clamp {
+                    return Err(invalid(format!("enum axis {axis_name} cannot extrapolate")));
+                }
+            }
+        }
+    }
+    if table.body.len() != expected {
+        return Err(invalid(format!(
+            "body has {} cells, expected {expected} for the axis shape",
+            table.body.len()
+        )));
+    }
+    let body_kind = table.body[0].kind();
+    for (index, value) in table.body.iter().copied().enumerate() {
+        if value.kind() != body_kind {
+            return Err(invalid(format!(
+                "body mixes M1 scalar families at offset {index}"
+            )));
+        }
+        if !value.as_f64().is_finite() {
+            return Err(invalid(format!("body offset {index} is not finite")));
+        }
+    }
+    Ok(())
+}
+
+fn axis_name(index: usize) -> &'static str {
+    ["X", "Y", "Z"].get(index).copied().unwrap_or("?")
+}
+
+fn bracket(
+    axis: &CalAxis,
+    input: &TableInput,
+    axis_index: usize,
+) -> Result<(usize, f64), EvalError> {
+    match (&axis.values, input) {
+        (CalAxisValues::Numeric(values), TableInput::Numeric(value)) => {
+            let x = value.as_f64();
+            if !x.is_finite() {
+                return Err(EvalError::BadCall {
+                    detail: format!(
+                        "table axis {} coordinate is not finite",
+                        axis_name(axis_index)
+                    ),
+                });
+            }
+            Ok(bracket_numeric(values, x, axis.extrapolation))
+        }
+        (CalAxisValues::Numeric(_), other) => Err(EvalError::TypeError {
+            detail: format!(
+                "table axis {} is numeric, got {other:?}",
+                axis_name(axis_index)
+            ),
+        }),
+        (
+            CalAxisValues::Enum {
+                values,
+                enum_id: Some(expected_enum_id),
+            },
+            TableInput::Enum { enum_id, value },
+        ) if enum_id == expected_enum_id => {
+            let index = values
+                .iter()
+                .position(|candidate| candidate == value)
+                .ok_or_else(|| EvalError::BadCall {
+                    detail: format!(
+                        "table enum axis {} has no calibrated value {value}",
+                        axis_name(axis_index)
+                    ),
+                })?;
+            if index + 1 == values.len() && index != 0 {
+                Ok((index - 1, 1.0))
+            } else {
+                Ok((index, 0.0))
+            }
+        }
+        (
+            CalAxisValues::Enum {
+                enum_id: Some(expected_enum_id),
+                ..
+            },
+            TableInput::Enum { enum_id, .. },
+        ) => Err(EvalError::TypeError {
+            detail: format!(
+                "table enum axis {} expects enum type {expected_enum_id}, got enum type {enum_id}",
+                axis_name(axis_index)
+            ),
+        }),
+        (CalAxisValues::Enum { .. }, other) => Err(EvalError::TypeError {
+            detail: format!(
+                "table axis {} is enumerated, got {other:?}",
+                axis_name(axis_index)
+            ),
+        }),
+    }
+}
+
+/// For a validated ascending numeric axis, return the lower site and the
+/// relative position between that site and the next.
+fn bracket_numeric(axis: &[M1Scalar], x: f64, extrapolation: AxisExtrapolation) -> (usize, f64) {
     let last = axis.len() - 1;
     if last == 0 {
         return (0, 0.0);
     }
-    if x <= axis[0].as_f64() {
+    let first = axis[0].as_f64();
+    if x <= first {
+        if x < first && extrapolation.below() {
+            let next = axis[1].as_f64();
+            return (0, (x - first) / (next - first));
+        }
         return (0, 0.0);
     }
-    if x >= axis[last].as_f64() {
+    let end = axis[last].as_f64();
+    if x >= end {
+        if x > end && extrapolation.above() {
+            let previous = axis[last - 1].as_f64();
+            return (last - 1, (x - previous) / (end - previous));
+        }
         return (last - 1, 1.0);
     }
     // Linear scan: axes are short (calibration tables are small), so a binary
@@ -228,10 +414,7 @@ fn bracket(axis: &[M1Scalar], x: f64) -> (usize, f64) {
         let a = axis[i].as_f64();
         let b = axis[i + 1].as_f64();
         if x >= a && x <= b {
-            // b > a here because x is strictly inside (a..last] and not <= a.
-            let span = b - a;
-            let f = if span > 0.0 { (x - a) / span } else { 0.0 };
-            return (i, f);
+            return (i, (x - a) / (b - a));
         }
     }
     // Unreachable for monotonic axes given the range checks above; clamp high.
@@ -251,40 +434,45 @@ mod tests {
         values.iter().copied().map(f).collect()
     }
 
+    fn v(value: f32) -> M1Scalar {
+        f(value)
+    }
+
+    fn vs(values: &[f32]) -> Vec<M1Scalar> {
+        values.iter().copied().map(v).collect()
+    }
+
     fn t() -> CalTable {
-        CalTable {
-            axes: vec![fs(&[0.0, 100.0]), fs(&[0.0, 1.0])],
-            body: fs(&[10.0, 20.0, 30.0, 40.0]),
-        }
+        CalTable::numeric(
+            vec![fs(&[0.0, 100.0]), fs(&[0.0, 1.0])],
+            fs(&[10.0, 30.0, 20.0, 40.0]),
+        )
     }
 
     #[test]
     fn corners_and_midpoint() {
-        assert_eq!(lookup(&t(), &fs(&[0.0, 0.0])).unwrap(), f(10.0));
-        assert_eq!(lookup(&t(), &fs(&[100.0, 1.0])).unwrap(), f(40.0));
-        assert_eq!(lookup(&t(), &fs(&[0.0, 1.0])).unwrap(), f(20.0));
-        assert_eq!(lookup(&t(), &fs(&[100.0, 0.0])).unwrap(), f(30.0));
-        assert_eq!(lookup(&t(), &fs(&[50.0, 0.0])).unwrap(), f(20.0));
-        assert_eq!(lookup(&t(), &fs(&[0.0, 0.5])).unwrap(), f(15.0));
-        assert_eq!(lookup(&t(), &fs(&[50.0, 0.5])).unwrap(), f(25.0));
+        assert_eq!(lookup(&t(), &vs(&[0.0, 0.0])).unwrap(), f(10.0));
+        assert_eq!(lookup(&t(), &vs(&[100.0, 1.0])).unwrap(), f(40.0));
+        assert_eq!(lookup(&t(), &vs(&[0.0, 1.0])).unwrap(), f(20.0));
+        assert_eq!(lookup(&t(), &vs(&[100.0, 0.0])).unwrap(), f(30.0));
+        assert_eq!(lookup(&t(), &vs(&[50.0, 0.0])).unwrap(), f(20.0));
+        assert_eq!(lookup(&t(), &vs(&[0.0, 0.5])).unwrap(), f(15.0));
+        assert_eq!(lookup(&t(), &vs(&[50.0, 0.5])).unwrap(), f(25.0));
     }
 
     #[test]
     fn clamps_out_of_range() {
-        assert_eq!(lookup(&t(), &fs(&[-5.0, 0.0])).unwrap(), f(10.0));
-        assert_eq!(lookup(&t(), &fs(&[999.0, 2.0])).unwrap(), f(40.0));
-        assert_eq!(lookup(&t(), &fs(&[-5.0, 0.5])).unwrap(), f(15.0));
-        assert_eq!(lookup(&t(), &fs(&[999.0, 0.5])).unwrap(), f(35.0));
+        assert_eq!(lookup(&t(), &vs(&[-5.0, 0.0])).unwrap(), f(10.0));
+        assert_eq!(lookup(&t(), &vs(&[999.0, 2.0])).unwrap(), f(40.0));
+        assert_eq!(lookup(&t(), &vs(&[-5.0, 0.5])).unwrap(), f(15.0));
+        assert_eq!(lookup(&t(), &vs(&[999.0, 0.5])).unwrap(), f(35.0));
     }
 
     #[test]
     fn nan_coordinate_fails_loud_instead_of_clamping_high() {
-        let table = CalTable {
-            axes: vec![fs(&[0.0, 1.0])],
-            body: fs(&[10.0, 20.0]),
-        };
+        let table = CalTable::numeric(vec![fs(&[0.0, 1.0])], fs(&[10.0, 20.0]));
         assert!(matches!(
-            lookup(&table, &[f(f32::NAN)]),
+            lookup(&table, &[v(f32::NAN)]),
             Err(EvalError::BadCall { .. })
         ));
     }
@@ -292,21 +480,18 @@ mod tests {
     #[test]
     fn arity_mismatch_is_error() {
         assert!(matches!(
-            lookup(&t(), &fs(&[1.0])),
+            lookup(&t(), &vs(&[1.0])),
             Err(EvalError::BadCall { .. })
         ));
         assert!(matches!(
-            lookup(&t(), &fs(&[1.0, 2.0, 3.0])),
+            lookup(&t(), &vs(&[1.0, 2.0, 3.0])),
             Err(EvalError::BadCall { .. })
         ));
     }
 
     #[test]
     fn one_dimensional_interpolation() {
-        let c = CalTable {
-            axes: vec![fs(&[0.0, 10.0, 20.0])],
-            body: fs(&[0.0, 100.0, 50.0]),
-        };
+        let c = CalTable::numeric(vec![fs(&[0.0, 10.0, 20.0])], fs(&[0.0, 100.0, 50.0]));
         for (input, expected) in [
             (0.0, 0.0),
             (10.0, 100.0),
@@ -315,90 +500,183 @@ mod tests {
             (-1.0, 0.0),
             (99.0, 50.0),
         ] {
-            assert_eq!(lookup(&c, &[f(input)]).unwrap(), f(expected));
+            assert_eq!(lookup(&c, &[v(input)]).unwrap(), f(expected));
         }
     }
 
     #[test]
     fn three_dimensional_corners() {
-        let c = CalTable {
-            axes: vec![fs(&[0.0, 1.0]), fs(&[0.0, 1.0]), fs(&[0.0, 1.0])],
-            body: (0..8).map(|value| f(value as f32)).collect(),
-        };
-        assert_eq!(lookup(&c, &fs(&[0.0, 0.0, 0.0])).unwrap(), f(0.0));
-        assert_eq!(lookup(&c, &fs(&[0.0, 0.0, 1.0])).unwrap(), f(1.0));
-        assert_eq!(lookup(&c, &fs(&[0.0, 1.0, 0.0])).unwrap(), f(2.0));
-        assert_eq!(lookup(&c, &fs(&[1.0, 0.0, 0.0])).unwrap(), f(4.0));
-        assert_eq!(lookup(&c, &fs(&[1.0, 1.0, 1.0])).unwrap(), f(7.0));
-        assert_eq!(lookup(&c, &fs(&[0.5, 0.5, 0.5])).unwrap(), f(3.5));
+        let c = CalTable::numeric(
+            vec![fs(&[0.0, 1.0]), fs(&[0.0, 1.0]), fs(&[0.0, 1.0])],
+            (0..8).map(|value| f(value as f32)).collect(),
+        );
+        assert_eq!(lookup(&c, &vs(&[0.0, 0.0, 0.0])).unwrap(), f(0.0));
+        assert_eq!(lookup(&c, &vs(&[0.0, 0.0, 1.0])).unwrap(), f(4.0));
+        assert_eq!(lookup(&c, &vs(&[0.0, 1.0, 0.0])).unwrap(), f(2.0));
+        assert_eq!(lookup(&c, &vs(&[1.0, 0.0, 0.0])).unwrap(), f(1.0));
+        assert_eq!(lookup(&c, &vs(&[1.0, 1.0, 1.0])).unwrap(), f(7.0));
+        assert_eq!(lookup(&c, &vs(&[0.5, 0.5, 0.5])).unwrap(), f(3.5));
     }
 
     #[test]
     fn single_breakpoint_axis() {
-        let c = CalTable {
-            axes: vec![fs(&[5.0]), fs(&[0.0, 1.0])],
-            body: fs(&[10.0, 20.0]),
+        let c = CalTable::numeric(vec![fs(&[5.0]), fs(&[0.0, 1.0])], fs(&[10.0, 20.0]));
+        assert_eq!(lookup(&c, &vs(&[5.0, 0.0])).unwrap(), f(10.0));
+        assert_eq!(lookup(&c, &vs(&[999.0, 1.0])).unwrap(), f(20.0));
+        assert_eq!(lookup(&c, &vs(&[0.0, 0.5])).unwrap(), f(15.0));
+    }
+
+    #[test]
+    fn project_boundary_policy_controls_extrapolation_per_end() {
+        let mut both = CalTable::numeric(vec![fs(&[0.0, 10.0])], fs(&[1.0, 21.0]));
+        both.axes[0].extrapolation = AxisExtrapolation::Both;
+        assert_eq!(lookup(&both, &[v(-5.0)]).unwrap(), f(-9.0));
+        assert_eq!(lookup(&both, &[v(15.0)]).unwrap(), f(31.0));
+
+        both.axes[0].extrapolation = AxisExtrapolation::Below;
+        assert_eq!(lookup(&both, &[v(-5.0)]).unwrap(), f(-9.0));
+        assert_eq!(lookup(&both, &[v(15.0)]).unwrap(), f(21.0));
+
+        both.axes[0].extrapolation = AxisExtrapolation::Above;
+        assert_eq!(lookup(&both, &[v(-5.0)]).unwrap(), f(1.0));
+        assert_eq!(lookup(&both, &[v(15.0)]).unwrap(), f(31.0));
+    }
+
+    #[test]
+    fn enum_axes_select_exact_sites_without_interpolation() {
+        let table = CalTable {
+            axes: vec![CalAxis::enumerated_for(4, vec![0, 2, 7])],
+            body: fs(&[10.0, 20.0, 30.0]),
         };
-        assert_eq!(lookup(&c, &fs(&[5.0, 0.0])).unwrap(), f(10.0));
-        assert_eq!(lookup(&c, &fs(&[999.0, 1.0])).unwrap(), f(20.0));
-        assert_eq!(lookup(&c, &fs(&[0.0, 0.5])).unwrap(), f(15.0));
+        for (value, expected) in [(0, 10.0), (2, 20.0), (7, 30.0)] {
+            assert_eq!(
+                lookup_inputs(&table, &[TableInput::Enum { enum_id: 4, value }]).unwrap(),
+                f(expected)
+            );
+        }
+        assert!(matches!(
+            lookup_inputs(
+                &table,
+                &[TableInput::Enum {
+                    enum_id: 4,
+                    value: 99,
+                }]
+            ),
+            Err(EvalError::BadCall { .. })
+        ));
+        assert!(matches!(
+            lookup_inputs(
+                &table,
+                &[TableInput::Enum {
+                    enum_id: 5,
+                    value: 0,
+                }]
+            ),
+            Err(EvalError::TypeError { .. })
+        ));
+        assert!(matches!(
+            lookup_inputs(&table, &[TableInput::Numeric(v(1.0))]),
+            Err(EvalError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_axes_have_precise_diagnostics() {
+        let repeated = CalTable::numeric(vec![fs(&[0.0, 0.0])], fs(&[1.0, 2.0]));
+        let descending = CalTable::numeric(vec![fs(&[1.0, 0.0])], fs(&[1.0, 2.0]));
+        let empty = CalTable::numeric(vec![Vec::new()], Vec::new());
+        let duplicate_enum = CalTable {
+            axes: vec![CalAxis::enumerated_for(0, vec![0, 0])],
+            body: fs(&[1.0, 2.0]),
+        };
+        let mixed_family =
+            CalTable::numeric(vec![vec![f(0.0), M1Scalar::Integer(1)]], fs(&[1.0, 2.0]));
+        let non_finite = CalTable::numeric(vec![fs(&[0.0, f32::INFINITY])], fs(&[1.0, 2.0]));
+        let mixed_body =
+            CalTable::numeric(vec![fs(&[0.0, 1.0])], vec![f(1.0), M1Scalar::Integer(2)]);
+        let non_finite_body =
+            CalTable::numeric(vec![fs(&[0.0, 1.0])], fs(&[1.0, f32::NEG_INFINITY]));
+        for (table, needle) in [
+            (repeated, "repeats a breakpoint"),
+            (descending, "not strictly ascending"),
+            (empty, "has no calibrated sites"),
+            (duplicate_enum, "repeats value"),
+            (mixed_family, "mixes M1 scalar families"),
+            (non_finite, "is not finite"),
+            (mixed_body, "body mixes M1 scalar families"),
+            (non_finite_body, "body offset 1 is not finite"),
+        ] {
+            let error = validate(&table).expect_err("invalid axis must fail");
+            assert!(format!("{error}").contains(needle), "{error}");
+        }
+    }
+
+    #[test]
+    fn zero_and_four_axis_tables_are_not_m1_tables() {
+        let zero = CalTable {
+            axes: Vec::new(),
+            body: fs(&[1.0]),
+        };
+        let four = CalTable::numeric(
+            vec![fs(&[0.0]), fs(&[0.0]), fs(&[0.0]), fs(&[0.0])],
+            fs(&[1.0]),
+        );
+        assert!(validate(&zero).is_err());
+        assert!(validate(&four).is_err());
     }
 
     #[test]
     fn body_shape_mismatch_fails_loud() {
-        let c = CalTable {
-            axes: vec![fs(&[0.0, 1.0]), fs(&[0.0, 1.0])],
-            body: fs(&[1.0, 2.0, 3.0]),
-        };
+        let c = CalTable::numeric(vec![fs(&[0.0, 1.0]), fs(&[0.0, 1.0])], fs(&[1.0, 2.0, 3.0]));
         assert!(matches!(
-            lookup(&c, &fs(&[0.5, 0.5])),
+            lookup(&c, &vs(&[0.5, 0.5])),
             Err(EvalError::MissingCalibration { .. })
         ));
     }
 
     #[test]
     fn integral_body_kind_is_preserved() {
-        let table = CalTable {
-            axes: vec![fs(&[0.0, 1.0])],
-            body: vec![M1Scalar::UnsignedInteger(10), M1Scalar::UnsignedInteger(20)],
-        };
+        let table = CalTable::numeric(
+            vec![fs(&[0.0, 1.0])],
+            vec![M1Scalar::UnsignedInteger(10), M1Scalar::UnsignedInteger(20)],
+        );
         assert_eq!(
-            lookup(&table, &[f(0.5)]).unwrap(),
+            lookup(&table, &[v(0.5)]).unwrap(),
             M1Scalar::UnsignedInteger(15)
         );
-        assert!(lookup(&table, &[f(0.25)]).is_err());
+        assert!(lookup(&table, &[v(0.25)]).is_err());
     }
 
     #[test]
     fn integral_interpolation_does_not_round_through_binary32() {
-        let signed = CalTable {
-            axes: vec![fs(&[0.0, 1.0])],
-            body: vec![M1Scalar::Integer(16_777_216), M1Scalar::Integer(16_777_218)],
-        };
+        let signed = CalTable::numeric(
+            vec![fs(&[0.0, 1.0])],
+            vec![M1Scalar::Integer(16_777_216), M1Scalar::Integer(16_777_218)],
+        );
         assert_eq!(
-            lookup(&signed, &[f(0.5)]).unwrap(),
+            lookup(&signed, &[v(0.5)]).unwrap(),
             M1Scalar::Integer(16_777_217)
         );
 
-        let unsigned = CalTable {
-            axes: vec![fs(&[0.0, 1.0])],
-            body: vec![
+        let unsigned = CalTable::numeric(
+            vec![fs(&[0.0, 1.0])],
+            vec![
                 M1Scalar::UnsignedInteger(u32::MAX - 2),
                 M1Scalar::UnsignedInteger(u32::MAX),
             ],
-        };
+        );
         assert_eq!(
-            lookup(&unsigned, &[f(0.5)]).unwrap(),
+            lookup(&unsigned, &[v(0.5)]).unwrap(),
             M1Scalar::UnsignedInteger(u32::MAX - 1)
         );
 
-        let near_endpoint = CalTable {
-            axes: vec![vec![
+        let near_endpoint = CalTable::numeric(
+            vec![vec![
                 M1Scalar::UnsignedInteger(0),
                 M1Scalar::UnsignedInteger(33_554_432),
             ]],
-            body: vec![M1Scalar::Integer(0), M1Scalar::Integer(33_554_432)],
-        };
+            vec![M1Scalar::Integer(0), M1Scalar::Integer(33_554_432)],
+        );
         assert_eq!(
             lookup(&near_endpoint, &[M1Scalar::UnsignedInteger(33_554_431)]).unwrap(),
             M1Scalar::Integer(33_554_431)
@@ -407,13 +685,13 @@ mod tests {
 
     #[test]
     fn large_unsigned_axis_does_not_collapse_through_binary32() {
-        let table = CalTable {
-            axes: vec![vec![
+        let table = CalTable::numeric(
+            vec![vec![
                 M1Scalar::UnsignedInteger(u32::MAX - 2),
                 M1Scalar::UnsignedInteger(u32::MAX),
             ]],
-            body: fs(&[0.0, 10.0]),
-        };
+            fs(&[0.0, 10.0]),
+        );
         assert_eq!(
             lookup(&table, &[M1Scalar::UnsignedInteger(u32::MAX - 1)]).unwrap(),
             f(5.0)
@@ -422,28 +700,28 @@ mod tests {
 
     #[test]
     fn fixed_point_body_interpolates_in_raw_storage() {
-        let table = CalTable {
-            axes: vec![fs(&[0.0, 1.0])],
-            body: vec![
+        let table = CalTable::numeric(
+            vec![fs(&[0.0, 1.0])],
+            vec![
                 M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(10)),
                 M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(20)),
             ],
-        };
+        );
         assert_eq!(
-            lookup(&table, &[f(0.5)]).unwrap(),
+            lookup(&table, &[v(0.5)]).unwrap(),
             M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(15))
         );
-        assert!(lookup(&table, &[f(0.25)]).is_err());
+        assert!(lookup(&table, &[v(0.25)]).is_err());
 
-        let above_binary32_integer_precision = CalTable {
-            axes: vec![fs(&[0.0, 1.0])],
-            body: vec![
+        let above_binary32_integer_precision = CalTable::numeric(
+            vec![fs(&[0.0, 1.0])],
+            vec![
                 M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(16_777_216)),
                 M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(16_777_218)),
             ],
-        };
+        );
         assert_eq!(
-            lookup(&above_binary32_integer_precision, &[f(0.5)]).unwrap(),
+            lookup(&above_binary32_integer_precision, &[v(0.5)]).unwrap(),
             M1Scalar::FixedPoint7dps(FixedPoint7dps::from_raw(16_777_217))
         );
     }

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -82,11 +82,12 @@ fn committed_synthetic_fixtures_pass_without_claiming_capture_evidence() {
     let paths = vec![
         fixture("synthetic-mini.toml"),
         fixture("synthetic-initial-state.toml"),
+        fixture("synthetic-tables.toml"),
         fixture("synthetic-types.toml"),
     ];
     let reports = run_conformance_suite(&paths, ConformanceOptions::default())
         .expect("synthetic conformance fixtures pass");
-    assert_eq!(reports.len(), 3);
+    assert_eq!(reports.len(), 4);
     assert!(
         reports
             .iter()

--- a/tests/fixtures/conformance/synthetic-mini.toml
+++ b/tests/fixtures/conformance/synthetic-mini.toml
@@ -19,7 +19,7 @@ sha256 = "687fb0e0ac83f5a0c689a9769d82fbf97de4f3250216ea2e5947a4c18b936f09"
 
 [[project.files]]
 path = "parameters.m1cfg"
-sha256 = "d81ad7d8f6df9ae33b199425a663e2f08a428e0e60433d3e1dc3f6a945d5c664"
+sha256 = "dedc08b536fde1240e5c24dfa37dfedd78983c6840df0530e56cef1fe107e941"
 
 [provenance]
 kind = "synthetic"

--- a/tests/fixtures/conformance/synthetic-tables.toml
+++ b/tests/fixtures/conformance/synthetic-tables.toml
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Hand-derived table vectors. This is not M1 Sim evidence.
+schema_version = 1
+name = "synthetic table layout and boundaries"
+calculation_rate_hz = 100.0
+
+[project]
+root = "../table-conformance"
+project = "Project.m1prj"
+config = "parameters.m1cfg"
+
+[[project.files]]
+path = "Project.m1prj"
+sha256 = "5c619271b5b14fea6f1a85a1e6aec1b722bd902de082ca40a51e0edb9bdf30d7"
+
+[[project.files]]
+path = "Scripts/Tables.Update.m1scr"
+sha256 = "41bcda8073cc2dcd48dbd82f77a618aa3b12efb3a8398d1977ea5b2534e76e3c"
+
+[[project.files]]
+path = "parameters.m1cfg"
+sha256 = "3c75c0d982d972647583d1f0a927dab1561e70f7bb2e245002e7884b9722d03a"
+
+[provenance]
+kind = "synthetic"
+source = "tests/fixtures/table-conformance, affine 1-D, 2-D, and 3-D tables"
+procedure = "docs/table-conformance.md#synthetic-vectors"
+notes = "Expected values are hand-derived. They exercise the runner but do not establish M1 Sim compatibility."
+
+[run]
+mode = "function"
+target = "Tables.Update"
+
+[[steps]]
+time_s = 0.0
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "-5" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "-1" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "10" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Idle" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "50" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "-8" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "-90" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "1" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "11" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+[[steps]]
+time_s = 0.01
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "10" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "1" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "2" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "20" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "10" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "20" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Active" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "100" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "122" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "140" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "81" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "22" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+[[steps]]
+time_s = 0.02
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "20" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "25" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "1" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "6" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "20" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "10" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "20" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Fault" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "200" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "382" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "180" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "81" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "77" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+[[steps]]
+time_s = 0.03
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "-7.5" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "2.5" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "-2.5" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "-0.5" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "0.5" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "12.5" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "2.5" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Active" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "62.5" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "24.5" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "-32.5" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "21" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "22" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+[[steps]]
+time_s = 0.04
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "-20" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "-2" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "-1" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "-100" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "-5" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Idle" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "50" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "-8" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "-90" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "-39" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "11" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+# Isolated X-low probes; every other numeric axis remains inside its range.
+[[steps]]
+time_s = 0.05
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "-20" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "-2" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "1" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "15" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "-100" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "-5" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "10" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Active" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "50" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "7" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "-75" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "21" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "22" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+# Isolated X-high probes.
+[[steps]]
+time_s = 0.06
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "40" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "2" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "1" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "15" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "100" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "15" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "10" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Fault" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "200" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "307" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "125" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "61" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "77" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+# Isolated Y-low probes.
+[[steps]]
+time_s = 0.07
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "-5" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "-1" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "15" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Idle" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "75" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "15" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "-19" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "11" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+# Isolated Y-high probes.
+[[steps]]
+time_s = 0.08
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "-5" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "7" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "15" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Active" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "75" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "132" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "75" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "101" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "22" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+# Isolated Z-low probes.
+[[steps]]
+time_s = 0.09
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "-5" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "1" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "10" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Fault" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "75" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "57" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "20" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "41" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "77" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+# Isolated Z-high probes.
+[[steps]]
+time_s = 0.10
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "-5" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "1" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "25" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "10" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Idle" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "75" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "57" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "30" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "41" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "11" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+[[steps]]
+time_s = 0.11
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "40" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "2" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "7" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "25" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "100" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "15" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Fault" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "200" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "382" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "180" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "121" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "77" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+[[steps]]
+time_s = 0.12
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "-20" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "-2" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "7" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "5" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "0" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "-5" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Active" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "50" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "82" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "-30" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "81" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "22" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]
+
+[[steps]]
+time_s = 0.13
+inputs = [
+  { channel = "Root.Tables.Curve X", value = { type = "floating-point", value = "30" } },
+  { channel = "Root.Tables.Grid X", value = { type = "floating-point", value = "40" } },
+  { channel = "Root.Tables.Grid Y", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Cube X", value = { type = "floating-point", value = "2" } },
+  { channel = "Root.Tables.Cube Y", value = { type = "floating-point", value = "-1" } },
+  { channel = "Root.Tables.Cube Z", value = { type = "floating-point", value = "25" } },
+  { channel = "Root.Tables.Single X", value = { type = "floating-point", value = "10" } },
+  { channel = "Root.Tables.Extend X", value = { type = "floating-point", value = "15" } },
+  { channel = "Root.Tables.Extend Y", value = { type = "floating-point", value = "-10" } },
+  { channel = "Root.Tables.Mode In", value = { type = "enum", enum_type = "Table Mode", member = "Idle" } },
+]
+expected = [
+  { channel = "Root.Tables.Curve Out", value = { type = "floating-point", value = "200" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Grid Out", value = { type = "floating-point", value = "292" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Cube Out", value = { type = "floating-point", value = "120" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Single Out", value = { type = "floating-point", value = "42" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Extend Out", value = { type = "floating-point", value = "1" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+  { channel = "Root.Tables.Enum Out", value = { type = "floating-point", value = "11" }, tolerance = { type = "floating-point", absolute = "0", relative = "0" } },
+]

--- a/tests/fixtures/mini/parameters.m1cfg
+++ b/tests/fixtures/mini/parameters.m1cfg
@@ -5,9 +5,9 @@
    <Cell Type="f32"><![CDATA[2.5]]></Cell>
   </Parameter>
   <Table Name="Demo.Map">
-   <X><Cells Type="f32" Unit="rpm"><Cell>0</Cell><Cell>100</Cell></Cells></X>
-   <Y><Cells Type="f32" Unit="%"><Cell>0</Cell><Cell>1</Cell></Cells></Y>
-   <Body><Cells Type="f32"><Cell>10</Cell><Cell>20</Cell><Cell>30</Cell><Cell>40</Cell></Cells></Body>
+   <X><Cells Type="f32" Unit="rpm"><Cell Site="0,0,0">0</Cell><Cell Site="1,0,0">100</Cell></Cells></X>
+   <Y><Cells Type="f32" Unit="%"><Cell Site="0,0,0">0</Cell><Cell Site="0,1,0">1</Cell></Cells></Y>
+   <Body><Cells Type="f32"><Cell Site="0,0,0">10</Cell><Cell Site="1,0,0">30</Cell><Cell Site="0,1,0">20</Cell><Cell Site="1,1,0">40</Cell></Cells></Body>
   </Table>
  </Group>
 </Configuration>

--- a/tests/fixtures/table-conformance/Project.m1prj
+++ b/tests/fixtures/table-conformance/Project.m1prj
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!-- Synthetic table-conformance project. No proprietary MoTeC content. -->
+<MoTeCM1BuildSession>
+ <Project Name="TableConformance" TargetHardware="ecu120">
+  <DataTypes>
+   <Type Storage="enum" Name="Table Mode" Default="Idle">
+    <Enum Name="Idle" ContainerOrder="0"/>
+    <Enum Name="Active" ContainerOrder="2"/>
+    <Enum Name="Fault" ContainerOrder="7"/>
+   </Type>
+   <Type Storage="enum" Name="Other Table Mode" Default="Idle">
+    <Enum Name="Idle" ContainerOrder="0"/>
+    <Enum Name="Active" ContainerOrder="2"/>
+    <Enum Name="Fault" ContainerOrder="7"/>
+   </Type>
+  </DataTypes>
+  <ComponentStream><List>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Tables"/>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Curve X"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Grid X"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Grid Y"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Cube X"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Cube Y"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Cube Z"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Single X"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Extend X"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Extend Y"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Mode In"><Props Type="::This.Table Mode"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Curve Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Grid Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Cube Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Single Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Extend Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Tables.Enum Out"><Props Type="f32"/></Component>
+   <Component Classname="BuiltIn.Table" Name="Root.Tables.Curve"><Props Type="f32" NumAxes="1"/><Axis><X/></Axis></Component>
+   <Component Classname="BuiltIn.Table" Name="Root.Tables.Grid"><Props Type="f32" NumAxes="2"/><Axis><X/><Y/></Axis></Component>
+   <Component Classname="BuiltIn.Table3D" Name="Root.Tables.Cube"><Props Type="f32" NumAxes="3"/><Axis><X/><Y/><Z/></Axis></Component>
+   <Component Classname="BuiltIn.Table" Name="Root.Tables.Single"><Props Type="f32" NumAxes="1"/><Axis><X/></Axis></Component>
+   <Component Classname="BuiltIn.CalibrationTable" Name="Root.Tables.Extend"><Props Type="f32" NumAxes="2"><Axis><X Extrapolate="Both"/><Y Extrapolate="Both"/></Axis></Props></Component>
+   <Component Classname="BuiltIn.Table" Name="Root.Tables.Enum Map"><Props Type="f32" NumAxes="1"/><Axis><X Source="Parent.Mode In"/></Axis></Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Tables.Update.m1scr" Name="Root.Tables.Update"/>
+  </List></ComponentStream>
+ </Project>
+</MoTeCM1BuildSession>

--- a/tests/fixtures/table-conformance/Scripts/Tables.Update.m1scr
+++ b/tests/fixtures/table-conformance/Scripts/Tables.Update.m1scr
@@ -1,0 +1,7 @@
+// Synthetic table conformance fixture. No proprietary content.
+Curve Out = Curve.Lookup(Curve X);
+Grid Out = Grid.Lookup(Grid X, Grid Y);
+Cube Out = Cube.Lookup(Cube X, Cube Y, Cube Z);
+Single Out = Single.Lookup(Single X);
+Extend Out = Extend.Lookup(Extend X, Extend Y);
+Enum Out = Enum Map.Lookup(Mode In);

--- a/tests/fixtures/table-conformance/parameters.m1cfg
+++ b/tests/fixtures/table-conformance/parameters.m1cfg
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<!-- Synthetic table conformance calibration. X is the fastest body axis. -->
+<Configuration Locale="English_Australia.1252" DefaultLocale="C">
+ <Group Name="">
+  <Table Name="Tables.Curve">
+   <X><Cells Type="f32"><Cell Site="0,0,0">-10</Cell><Cell Site="1,0,0">0</Cell><Cell Site="2,0,0">20</Cell></Cells></X>
+   <Body><Cells Type="f32"><Cell Site="0,0,0">50</Cell><Cell Site="1,0,0">100</Cell><Cell Site="2,0,0">200</Cell></Cells></Body>
+  </Table>
+  <Table Name="Tables.Grid">
+   <X><Cells Type="f32"><Cell Site="0,0,0">0</Cell><Cell Site="1,0,0">10</Cell><Cell Site="2,0,0">30</Cell></Cells></X>
+   <Y><Cells Type="f32"><Cell Site="0,0,0">-5</Cell><Cell Site="0,1,0">5</Cell><Cell Site="0,2,0">25</Cell></Cells></Y>
+   <Body><Cells Type="f32">
+    <Cell Site="0,0,0">-8</Cell><Cell Site="1,0,0">92</Cell><Cell Site="2,0,0">292</Cell>
+    <Cell Site="0,1,0">22</Cell><Cell Site="1,1,0">122</Cell><Cell Site="2,1,0">322</Cell>
+    <Cell Site="0,2,0">82</Cell><Cell Site="1,2,0">182</Cell><Cell Site="2,2,0">382</Cell>
+   </Cells></Body>
+  </Table>
+  <Table Name="Tables.Cube">
+   <X><Cells Type="f32"><Cell Site="0,0,0">-1</Cell><Cell Site="1,0,0">1</Cell></Cells></X>
+   <Y><Cells Type="f32"><Cell Site="0,0,0">0</Cell><Cell Site="0,1,0">2</Cell><Cell Site="0,2,0">6</Cell></Cells></Y>
+   <Z><Cells Type="f32"><Cell Site="0,0,0">10</Cell><Cell Site="0,0,1">20</Cell></Cells></Z>
+   <Body><Cells Type="f32">
+    <Cell Site="0,0,0">-90</Cell><Cell Site="1,0,0">110</Cell>
+    <Cell Site="0,1,0">-70</Cell><Cell Site="1,1,0">130</Cell>
+    <Cell Site="0,2,0">-30</Cell><Cell Site="1,2,0">170</Cell>
+    <Cell Site="0,0,1">-80</Cell><Cell Site="1,0,1">120</Cell>
+    <Cell Site="0,1,1">-60</Cell><Cell Site="1,1,1">140</Cell>
+    <Cell Site="0,2,1">-20</Cell><Cell Site="1,2,1">180</Cell>
+   </Cells></Body>
+  </Table>
+  <Table Name="Tables.Single">
+   <X><Cells Type="f32"><Cell Site="0,0,0">5</Cell></Cells></X>
+   <Body><Cells Type="f32"><Cell Site="0,0,0">42</Cell></Cells></Body>
+  </Table>
+  <Table Name="Tables.Extend">
+   <X><Cells Type="f32"><Cell Site="0,0,0">0</Cell><Cell Site="1,0,0">10</Cell></Cells></X>
+   <Y><Cells Type="f32"><Cell Site="0,0,0">0</Cell><Cell Site="0,1,0">20</Cell></Cells></Y>
+   <Body><Cells Type="f32">
+    <Cell Site="0,0,0">1</Cell><Cell Site="1,0,0">21</Cell>
+    <Cell Site="0,1,0">61</Cell><Cell Site="1,1,0">81</Cell>
+   </Cells></Body>
+  </Table>
+  <Table Name="Tables.Enum Map">
+   <X><Cells Type="enum"><Cell Site="0,0,0">0</Cell><Cell Site="1,0,0">2</Cell><Cell Site="2,0,0">7</Cell></Cells></X>
+   <Body><Cells Type="f32"><Cell Site="0,0,0">11</Cell><Cell Site="1,0,0">22</Cell><Cell Site="2,0,0">77</Cell></Cells></Body>
+  </Table>
+ </Group>
+</Configuration>

--- a/tests/table_conformance.rs
+++ b/tests/table_conformance.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Table-specific golden vectors and optional private evidence gates.
+
+use m1_eval::table::{lookup_inputs, lookup_values, validate};
+use m1_eval::{
+    CalAxisValues, ConformanceOptions, EvalError, ProvenanceKind, TableInput, Value, load,
+    run_conformance_fixture, run_conformance_suite,
+};
+use std::path::{Path, PathBuf};
+
+fn synthetic_fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/conformance/synthetic-tables.toml")
+}
+
+#[test]
+fn synthetic_vectors_cover_table_layout_interpolation_and_boundaries() {
+    let report = run_conformance_fixture(&synthetic_fixture())
+        .expect("synthetic table conformance fixture passes");
+    assert_eq!(report.provenance, ProvenanceKind::Synthetic);
+    assert_eq!(report.steps_checked, 14);
+    assert_eq!(report.assertions_checked, 84);
+}
+
+#[test]
+fn enum_table_axis_rejects_an_unrelated_enum_with_the_same_declared_value() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/table-conformance");
+    let loaded = load(
+        &root.join("Project.m1prj"),
+        Some(&root.join("parameters.m1cfg")),
+    )
+    .expect("synthetic table project loads");
+    let expected_id = loaded
+        .project
+        .symbols()
+        .enum_by_name("Table Mode")
+        .expect("table enum type exists");
+    let other_id = loaded
+        .project
+        .symbols()
+        .enum_by_name("Other Table Mode")
+        .expect("unrelated enum type exists");
+    let table = loaded
+        .calib
+        .table("Tables.Enum Map")
+        .expect("enum map calibration exists");
+    assert!(matches!(
+        &table.axes[0].values,
+        CalAxisValues::Enum {
+            enum_id: Some(id),
+            ..
+        } if *id == expected_id
+    ));
+
+    let error = lookup_values(
+        table,
+        &[Value::Enum {
+            id: other_id,
+            member: "Idle".to_string(),
+        }],
+        &loaded.project,
+    )
+    .expect_err("a numerically identical member from another enum must fail");
+    assert!(matches!(error, EvalError::TypeError { .. }));
+}
+
+#[test]
+fn configured_private_table_captures_form_an_optional_gate() {
+    let Some(paths) = std::env::var_os("M1_EVAL_TABLE_M1_SIM_FIXTURES") else {
+        return;
+    };
+    let paths: Vec<PathBuf> = std::env::split_paths(&paths).collect();
+    assert!(
+        !paths.is_empty(),
+        "M1_EVAL_TABLE_M1_SIM_FIXTURES was set but contained no paths"
+    );
+    run_conformance_suite(
+        &paths,
+        ConformanceOptions {
+            require_m1_sim_capture: true,
+        },
+    )
+    .expect("configured M1 Sim table captures pass conformance");
+}
+
+#[test]
+fn configured_real_project_tables_are_deterministic() {
+    let project = std::env::var_os("M1_EVAL_TABLE_PROJECT").map(PathBuf::from);
+    let config = std::env::var_os("M1_EVAL_TABLE_CONFIG").map(PathBuf::from);
+    let (project, config) = match (project, config) {
+        (None, None) => return,
+        (Some(project), Some(config)) => (project, config),
+        _ => panic!("set M1_EVAL_TABLE_PROJECT and M1_EVAL_TABLE_CONFIG together"),
+    };
+
+    let loaded = load(&project, Some(&config)).expect("configured real project and config load");
+    let mut table_names: Vec<&str> = loaded.calib.tables.keys().map(String::as_str).collect();
+    table_names.sort_unstable();
+    assert!(!table_names.is_empty(), "configured project has no tables");
+
+    let mut evaluated = 0usize;
+    for name in table_names {
+        let table = loaded.calib.table(name).expect("table key remains present");
+        match validate(table) {
+            Ok(()) => {
+                let first_inputs: Vec<TableInput> = table
+                    .axes
+                    .iter()
+                    .map(|axis| match &axis.values {
+                        CalAxisValues::Numeric(values) => TableInput::Numeric(values[0]),
+                        CalAxisValues::Enum {
+                            values,
+                            enum_id: Some(enum_id),
+                        } => TableInput::Enum {
+                            enum_id: *enum_id,
+                            value: values[0],
+                        },
+                        CalAxisValues::Enum { enum_id: None, .. } => {
+                            unreachable!("validated enum axis has a project enum id")
+                        }
+                    })
+                    .collect();
+                let first = lookup_inputs(table, &first_inputs)
+                    .expect("validated table evaluates at its first sites");
+                let second = lookup_inputs(table, &first_inputs)
+                    .expect("repeated table evaluation succeeds");
+                assert_eq!(
+                    first, second,
+                    "table {name:?} changed across identical calls"
+                );
+                evaluated += 1;
+            }
+            Err(first) => {
+                let second = validate(table).expect_err("invalid table stays invalid");
+                assert_eq!(
+                    first.to_string(),
+                    second.to_string(),
+                    "table {name:?} produced an unstable diagnostic"
+                );
+            }
+        }
+    }
+    assert!(
+        evaluated > 0,
+        "configured project has no valid table to evaluate"
+    );
+}


### PR DESCRIPTION
Refs #43

## What changed

- add deterministic table vectors for exact breakpoints, interpolation, clamping, degenerate axes, repeated breakpoints, and invalid shapes
- preserve exact M1 scalar families and enum identity through calibration parsing and lookup
- validate multidimensional X-fastest storage layout and reject malformed tables
- integrate the vectors with the reusable conformance runner

## Verification

- full locked default and all-feature test suites
- strict Clippy, rustdoc, formatting, Rust 1.88, and diff checks
- replay preserved the #47 named-enum, numeric-axis, and hexadecimal calibration behavior

## Remaining acceptance gate

This PR does not close #43. The committed vectors are synthetic and independently derived. A genuine M1 Sim capture is still required to remove the documented table layout and boundary assumptions.
