### PR TITLE
feat: implement deterministic UnixTime catalogue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
@@ -661,9 +661,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "num-conv",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +362,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "time",
  "toml",
 ]
 
@@ -396,6 +406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +422,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -636,6 +658,24 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ motec-i2 = { version = "0.2", optional = true }
 assert_cmd = "2"
 tempfile = "3"
 insta = "1"
+time = { version = "=0.3.44", default-features = false }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ motec-i2 = { version = "0.2", optional = true }
 assert_cmd = "2"
 tempfile = "3"
 insta = "1"
-time = { version = "=0.3.44", default-features = false }
+time = { version = "=0.3.47", default-features = false }
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ do not compare computed channel values with captured M1 results.
 | --- | --- | --- |
 | Expressions, statements, enums, and inline user functions | **Assumed** | Covered by unit and synthetic-project tests. M1 evaluation results have not been captured for comparison. |
 | `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | Parsing, interpolation, and edge clamping use synthetic fixtures. Use the matching calibration file for actual values. Without it, parameters use typed external defaults. Table `.Lookup()` and `.Get()` fail in strict modes; whole-project mode may opt in to an external `0.0` fallback. |
-| `Calculate.*`, `Limit.*`, `Convert.*`, enum conversions, core value-object methods, and table methods | **Assumed** | Implemented methods have hand-derived tests. `AsString`, `Validate`, `Constrain`, `GetUnscheduled`, and `Set` resolve against eligible receiver classes; channel `Set` applies its project validation range before writing. `--coverage` remains authoritative for the methods a project uses. |
+| `Calculate.*`, `Limit.*`, `Convert.*`, `UnixTime.*`, enum conversions, core value-object methods, and table methods | **Assumed** | Implemented methods have hand-derived or independent-reference tests. `UnixTime` uses deterministic Gregorian/POSIX arithmetic and evaluator-local timezone state; it never reads the host clock or timezone. `AsString`, `Validate`, `Constrain`, `GetUnscheduled`, and `Set` resolve against eligible receiver classes; channel `Set` applies its project validation range before writing. `--coverage` remains authoritative for the methods a project uses. |
 | Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. |
 | `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Assumed / Stubbed** | Each call crosses a typed adapter boundary with its resolved receiver, source call site, arguments, and evaluator time. Exact-site scenario values take precedence over wildcard values and an attached adapter. `System.ElapsedTime` reports the interval since that call site last ran. Its first tick-zero call returns zero, while a site first reached later uses its function step. Tick calls use the deterministic base timeline. `System.FlashSize` and `System.FlashFree` require scenario or adapter data; they never become a dangerous zero. Remaining unhandled calls use documented typed stubs or fail loud. |
 | Scenario parsing, tick grids, trace output, and `--coverage` | **Assumed** | These are deterministic m1-eval contracts tested with synthetic data. A `Supported` coverage entry means implemented, not M1-verified. |
@@ -53,8 +53,8 @@ dependency-cone runners.
   `expand/to`, `local` / `static local`.
 - **Table lookup** — 1/2/3-D linear interpolation over `.m1cfg` calibration
   cells, with clamping at the axis edges.
-- **Tier-1 pure builtins** — `Calculate.*`, `Limit.*`, `Convert.*`, table
-  `.Lookup()`.
+- **Tier-1 direct builtins** — `Calculate.*`, `Limit.*`, `Convert.*`,
+  deterministic `UnixTime.*`, and table `.Lookup()`.
 - **Tier-2 stateful builtins** (the hard core) — `Filter.FirstOrder`,
   `Filter.{Maximum,Minimum}`, `Integral.Normal`, `Derivative.*`, `Debounce.*`,
   `Delay.*`, `Change.*`, timers, and `static local` persistence. Each is a small
@@ -96,6 +96,13 @@ The implemented behavior is still **Assumed** under the maturity contract above:
   Whole-number inputs `-214..=214` fit the documented signed 32-bit, seven-place
   representation; values immediately outside that domain fail with a range
   error.
+- `UnixTime.*` uses signed 32-bit POSIX timestamps, proleptic-Gregorian calendar
+  arithmetic, and a fixed evaluator-local timezone. Constructors accept the
+  catalogue's 1970–2038 range and fail if the result exceeds M1 `Integer`.
+  `FromGPS` floors fractional seconds and maps two-digit years `70..99` to
+  1970–1999 and `00..38` to 2000–2038. Constructor seconds `60` and `61` are
+  normalized into the next minute. Those M1-specific choices remain Assumed;
+  every ordinary calendar vector is checked against an independent library.
 
 ## What it adds (Phase 2 — the whole-project multi-rate scheduler)
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -211,3 +211,13 @@ test. It catches state leakage and accidental per-tick reseeding.
 
 These files use `kind = "synthetic"` and cannot satisfy
 `--require-m1-sim-capture`.
+
+## Independent-reference fixtures
+
+`kind = "independent"` records expected values checked against a named public
+standard or separate implementation. This is stronger evidence than a
+hand-derived runner fixture, but it is not M1 output and cannot satisfy
+`--require-m1-sim-capture`. The committed UnixTime fixture uses POSIX epoch and
+Gregorian calendar rules and is differentially checked against the Rust `time`
+crate; its M1-specific GPS pivot, leap-second normalization, and timezone
+encoding remain documented assumptions pending a genuine M1 Sim capture.

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -24,6 +24,7 @@ pub mod io_stub;
 pub mod limit;
 pub mod object;
 pub mod stateful;
+pub mod unix_time;
 pub mod userfn;
 
 use crate::env::CallSite;
@@ -138,6 +139,10 @@ pub(crate) fn dispatch_with_runtime(
                 "fabs" => Ok(Value::m1_float(args[0].m1_scalar()?.as_f32().abs())),
                 _ => Err(unsupported(object, method)),
             }
+        }
+        CallRoute::UnixTime => {
+            validate_arity("UnixTime", object, method, args.len())?;
+            unix_time::call(method, args, ctx.env)
         }
         CallRoute::EnumAsInteger => {
             validate_object_arity(object, method, args.len())?;
@@ -514,6 +519,7 @@ enum CallRoute {
     StatefulLibrary(String),
     IoLibrary(String),
     MathAssumption(String),
+    UnixTime,
     TableLookup,
     TableGet,
     EnumAsInteger,
@@ -752,6 +758,9 @@ fn classify_library(object: &str, method: &str) -> CallCapability {
             BuiltinSupport::Modeled,
             CallRoute::MathAssumption(object.to_string()),
         );
+    }
+    if object == "UnixTime" && unix_time::METHODS.contains(&method) {
+        return capability(BuiltinSupport::Direct, CallRoute::UnixTime);
     }
     if STUB_OBJECTS.contains(&object) {
         let known = !intrinsics::get()
@@ -1088,6 +1097,53 @@ mod tests {
             )
             .unwrap(),
             Value::m1_float(0.0)
+        );
+        assert_eq!(
+            h.call(
+                "Library.UnixTime",
+                "FromUtc",
+                &[
+                    Value::m1_integer(1970),
+                    Value::m1_integer(0),
+                    Value::m1_integer(1),
+                    Value::m1_integer(0),
+                    Value::m1_integer(0),
+                    Value::m1_integer(0),
+                ],
+            )
+            .unwrap(),
+            Value::m1_integer(0)
+        );
+    }
+
+    #[test]
+    fn every_catalogued_unix_time_method_is_direct_and_dispatches() {
+        let mut h = Harness::new();
+        for method in unix_time::METHODS {
+            assert_eq!(
+                classify_builtin("UnixTime", method),
+                BuiltinSupport::Direct,
+                "UnixTime.{method} classification"
+            );
+            let args = match *method {
+                "FromGPS" => vec![Value::m1_unsigned(1_0170), Value::m1_float(0.0)],
+                "FromLocal" | "FromUtc" => vec![
+                    Value::m1_integer(1970),
+                    Value::m1_integer(0),
+                    Value::m1_integer(1),
+                    Value::m1_integer(0),
+                    Value::m1_integer(0),
+                    Value::m1_integer(0),
+                ],
+                "Timezone" => vec![Value::m1_integer(0)],
+                _ => vec![Value::m1_integer(0)],
+            };
+            h.call("UnixTime", method, &args)
+                .unwrap_or_else(|error| panic!("UnixTime.{method} failed: {error}"));
+        }
+        assert_eq!(
+            classify_builtin("UnixTime", "NoSuchMethod"),
+            BuiltinSupport::Unsupported
         );
     }
 

--- a/src/builtins/unix_time.rs
+++ b/src/builtins/unix_time.rs
@@ -1,0 +1,642 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Deterministic `UnixTime.*` construction and calendar decomposition.
+//!
+//! The M1 catalogue represents Unix timestamps as signed 32-bit `Integer`
+//! values. There is no current-time method in that catalogue: every constructor
+//! takes explicit date/time arguments, and every decomposition method takes an
+//! explicit timestamp. This module therefore uses only integer Gregorian/POSIX
+//! arithmetic. It never reads the host clock, locale, or timezone.
+//!
+//! `UnixTime.Timezone` sets run-local state on [`Env`]. Whole values `-12..=14`
+//! mean hours; other values use signed `HHMM`, within the documented
+//! `-1245..=1445` range. Local conversion uses that fixed offset and defaults to
+//! UTC in a fresh environment.
+//!
+//! The catalogue permits constructor seconds `60` and `61`. POSIX timestamps do
+//! not encode leap seconds, so this model normalizes those values into the next
+//! minute. `FromGPS` floors its non-negative fractional seconds. Both details
+//! remain explicit evaluator assumptions until a publishable M1 capture exists.
+
+use crate::env::Env;
+use crate::error::EvalError;
+use crate::value::{M1Scalar, Value};
+
+const SECONDS_PER_MINUTE: i64 = 60;
+const SECONDS_PER_HOUR: i64 = 60 * SECONDS_PER_MINUTE;
+const SECONDS_PER_DAY: i64 = 24 * SECONDS_PER_HOUR;
+
+/// The exact `UnixTime` method set implemented by runtime and coverage.
+pub(crate) const METHODS: &[&str] = &[
+    "FromGPS",
+    "FromLocal",
+    "FromUtc",
+    "Timezone",
+    "ToLocalDay",
+    "ToLocalHour",
+    "ToLocalMinute",
+    "ToLocalMonth",
+    "ToLocalSecond",
+    "ToLocalWeekDay",
+    "ToLocalYear",
+    "ToLocalYearDay",
+    "ToUtcDay",
+    "ToUtcHour",
+    "ToUtcMinute",
+    "ToUtcMonth",
+    "ToUtcSecond",
+    "ToUtcWeekDay",
+    "ToUtcYear",
+    "ToUtcYearDay",
+];
+
+/// Evaluate one catalogue-backed `UnixTime.<method>` call.
+pub(crate) fn call(method: &str, args: &[Value], env: &mut Env) -> Result<Value, EvalError> {
+    match method {
+        "FromGPS" => from_gps(args),
+        "FromLocal" => from_components(args, env.unix_timezone_offset_seconds(), method),
+        "FromUtc" => from_components(args, 0, method),
+        "Timezone" => set_timezone(args, env),
+        "ToLocalDay" => component(args, env, method, |civil| civil.day),
+        "ToLocalHour" => component(args, env, method, |civil| civil.hour),
+        "ToLocalMinute" => component(args, env, method, |civil| civil.minute),
+        "ToLocalMonth" => component(args, env, method, |civil| civil.month),
+        "ToLocalSecond" => component(args, env, method, |civil| civil.second),
+        "ToLocalWeekDay" => component(args, env, method, |civil| civil.weekday),
+        "ToLocalYear" => component(args, env, method, |civil| civil.year),
+        "ToLocalYearDay" => component(args, env, method, |civil| civil.year_day),
+        "ToUtcDay" => utc_component(args, method, |civil| civil.day),
+        "ToUtcHour" => utc_component(args, method, |civil| civil.hour),
+        "ToUtcMinute" => utc_component(args, method, |civil| civil.minute),
+        "ToUtcMonth" => utc_component(args, method, |civil| civil.month),
+        "ToUtcSecond" => utc_component(args, method, |civil| civil.second),
+        "ToUtcWeekDay" => utc_component(args, method, |civil| civil.weekday),
+        "ToUtcYear" => utc_component(args, method, |civil| civil.year),
+        "ToUtcYearDay" => utc_component(args, method, |civil| civil.year_day),
+        _ => Err(EvalError::UnsupportedBuiltin {
+            object: "UnixTime".to_string(),
+            method: method.to_string(),
+        }),
+    }
+}
+
+fn from_gps(args: &[Value]) -> Result<Value, EvalError> {
+    let date = unsigned_arg("FromGPS", "date", &args[0])?;
+    if date > 999_999 {
+        return Err(bad_call(
+            "FromGPS",
+            format!("date {date} is not a DDMMYY value"),
+        ));
+    }
+    let day = i32::try_from(date / 10_000).expect("six-digit date day fits i32");
+    let month = i32::try_from((date / 100) % 100).expect("six-digit date month fits i32");
+    let short_year = i32::try_from(date % 100).expect("two-digit year fits i32");
+    let year = match short_year {
+        70..=99 => 1900 + short_year,
+        0..=38 => 2000 + short_year,
+        _ => {
+            return Err(bad_call(
+                "FromGPS",
+                format!("two-digit year {short_year:02} is outside 1970-2038"),
+            ));
+        }
+    };
+    let seconds = float_arg("FromGPS", "time", &args[1])?;
+    if !seconds.is_finite() || !(0.0..86_400.0).contains(&seconds) {
+        return Err(bad_call(
+            "FromGPS",
+            format!("UTC seconds since midnight must be finite and in [0, 86400), got {seconds:?}"),
+        ));
+    }
+    let whole_seconds = seconds.floor() as i64;
+    let hour = i32::try_from(whole_seconds / SECONDS_PER_HOUR).expect("GPS hour fits i32");
+    let minute =
+        i32::try_from((whole_seconds / SECONDS_PER_MINUTE) % 60).expect("GPS minute fits i32");
+    let second = i32::try_from(whole_seconds % 60).expect("GPS second fits i32");
+    construct_timestamp("FromGPS", year, month - 1, day, hour, minute, second, 0)
+}
+
+fn from_components(args: &[Value], offset_seconds: i32, method: &str) -> Result<Value, EvalError> {
+    let year = integer_arg(method, "year", &args[0])?;
+    let month = integer_arg(method, "month", &args[1])?;
+    let day = integer_arg(method, "day", &args[2])?;
+    let hour = integer_arg(method, "hour", &args[3])?;
+    let minute = integer_arg(method, "minute", &args[4])?;
+    let second = integer_arg(method, "second", &args[5])?;
+    construct_timestamp(
+        method,
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        offset_seconds,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn construct_timestamp(
+    method: &str,
+    year: i32,
+    month: i32,
+    day: i32,
+    hour: i32,
+    minute: i32,
+    second: i32,
+    offset_seconds: i32,
+) -> Result<Value, EvalError> {
+    if !(1970..=2038).contains(&year) {
+        return Err(bad_call(
+            method,
+            format!("year must be in 1970..=2038, got {year}"),
+        ));
+    }
+    if !(0..=11).contains(&month) {
+        return Err(bad_call(
+            method,
+            format!("month must be in 0..=11, got {month}"),
+        ));
+    }
+    let days = days_from_civil(year, month, day).ok_or_else(|| {
+        bad_call(
+            method,
+            format!("day {day} is invalid for year {year}, month {month}"),
+        )
+    })?;
+    if !(0..=23).contains(&hour) {
+        return Err(bad_call(
+            method,
+            format!("hour must be in 0..=23, got {hour}"),
+        ));
+    }
+    if !(0..=59).contains(&minute) {
+        return Err(bad_call(
+            method,
+            format!("minute must be in 0..=59, got {minute}"),
+        ));
+    }
+    if !(0..=61).contains(&second) {
+        return Err(bad_call(
+            method,
+            format!("second must be in 0..=61, got {second}"),
+        ));
+    }
+    let local_seconds = days
+        .checked_mul(SECONDS_PER_DAY)
+        .and_then(|value| value.checked_add(i64::from(hour) * SECONDS_PER_HOUR))
+        .and_then(|value| value.checked_add(i64::from(minute) * SECONDS_PER_MINUTE))
+        .and_then(|value| value.checked_add(i64::from(second)))
+        .expect("supported calendar range fits i64");
+    let unix = local_seconds - i64::from(offset_seconds);
+    let unix = i32::try_from(unix).map_err(|_| {
+        bad_call(
+            method,
+            format!("date/time resolves to Unix timestamp {unix}, outside the M1 Integer range"),
+        )
+    })?;
+    Ok(Value::m1_integer(unix))
+}
+
+fn set_timezone(args: &[Value], env: &mut Env) -> Result<Value, EvalError> {
+    let encoded = integer_arg("Timezone", "hour", &args[0])?;
+    let seconds = timezone_seconds(encoded)?;
+    env.set_unix_timezone_offset_seconds(seconds);
+    Ok(Value::Bool(true))
+}
+
+fn timezone_seconds(encoded: i32) -> Result<i32, EvalError> {
+    if (-12..=14).contains(&encoded) {
+        return Ok(encoded * 3_600);
+    }
+    if !(-1245..=1445).contains(&encoded) {
+        return Err(bad_call(
+            "Timezone",
+            format!("offset must be an hour in -12..=14 or HHMM in -1245..=1445, got {encoded}"),
+        ));
+    }
+    let magnitude = encoded.unsigned_abs();
+    let hours = magnitude / 100;
+    let minutes = magnitude % 100;
+    if minutes >= 60 {
+        return Err(bad_call(
+            "Timezone",
+            format!("HHMM minute field must be in 00..=59, got {encoded}"),
+        ));
+    }
+    let magnitude_seconds = hours * 3_600 + minutes * 60;
+    let signed = i32::try_from(magnitude_seconds).expect("documented timezone fits i32");
+    Ok(if encoded < 0 { -signed } else { signed })
+}
+
+fn component(
+    args: &[Value],
+    env: &Env,
+    method: &str,
+    select: impl FnOnce(Civil) -> i32,
+) -> Result<Value, EvalError> {
+    let unix = integer_arg(method, "unix", &args[0])?;
+    let civil = decompose(unix, env.unix_timezone_offset_seconds());
+    Ok(Value::m1_integer(select(civil)))
+}
+
+fn utc_component(
+    args: &[Value],
+    method: &str,
+    select: impl FnOnce(Civil) -> i32,
+) -> Result<Value, EvalError> {
+    let unix = integer_arg(method, "unix", &args[0])?;
+    Ok(Value::m1_integer(select(decompose(unix, 0))))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Civil {
+    year: i32,
+    /// Zero-based month, matching the catalogue.
+    month: i32,
+    day: i32,
+    hour: i32,
+    minute: i32,
+    second: i32,
+    /// Sunday is zero, matching POSIX `tm_wday` and the M1 manual convention.
+    weekday: i32,
+    /// Zero-based day within the year.
+    year_day: i32,
+}
+
+fn decompose(unix: i32, offset_seconds: i32) -> Civil {
+    let adjusted = i64::from(unix) + i64::from(offset_seconds);
+    let days = adjusted.div_euclid(SECONDS_PER_DAY);
+    let within_day = adjusted.rem_euclid(SECONDS_PER_DAY);
+    let (year, month, day) = civil_from_days(days);
+    let first_day = days_from_civil(year, 0, 1).expect("January 1 is always valid");
+    Civil {
+        year,
+        month,
+        day,
+        hour: i32::try_from(within_day / SECONDS_PER_HOUR).expect("hour fits i32"),
+        minute: i32::try_from((within_day / SECONDS_PER_MINUTE) % 60).expect("minute fits i32"),
+        second: i32::try_from(within_day % 60).expect("second fits i32"),
+        weekday: i32::try_from((days + 4).rem_euclid(7)).expect("weekday fits i32"),
+        year_day: i32::try_from(days - first_day).expect("year day fits i32"),
+    }
+}
+
+/// Days since 1970-01-01 for a validated proleptic-Gregorian date.
+fn days_from_civil(year: i32, month_zero: i32, day: i32) -> Option<i64> {
+    if !(0..=11).contains(&month_zero) || day < 1 || day > days_in_month(year, month_zero) {
+        return None;
+    }
+    let month = i64::from(month_zero + 1);
+    let mut year = i64::from(year);
+    year -= i64::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let month_prime = month + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * month_prime + 2) / 5 + i64::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    Some(era * 146_097 + day_of_era - 719_468)
+}
+
+/// Inverse of [`days_from_civil`] for every timestamp representable by M1.
+fn civil_from_days(days_since_epoch: i64) -> (i32, i32, i32) {
+    let days = days_since_epoch + 719_468;
+    let era = if days >= 0 { days } else { days - 146_096 } / 146_097;
+    let day_of_era = days - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    (
+        i32::try_from(year).expect("M1 timestamp year fits i32"),
+        i32::try_from(month - 1).expect("month fits i32"),
+        i32::try_from(day).expect("day fits i32"),
+    )
+}
+
+fn days_in_month(year: i32, month_zero: i32) -> i32 {
+    match month_zero {
+        0 | 2 | 4 | 6 | 7 | 9 | 11 => 31,
+        3 | 5 | 8 | 10 => 30,
+        1 if is_leap_year(year) => 29,
+        1 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: i32) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+}
+
+fn integer_arg(method: &str, name: &str, value: &Value) -> Result<i32, EvalError> {
+    match value {
+        Value::M1(M1Scalar::Integer(value)) => Ok(*value),
+        other => Err(bad_call(
+            method,
+            format!("{name} expects M1 Integer, got {other:?}"),
+        )),
+    }
+}
+
+fn unsigned_arg(method: &str, name: &str, value: &Value) -> Result<u32, EvalError> {
+    match value {
+        Value::M1(M1Scalar::UnsignedInteger(value)) => Ok(*value),
+        other => Err(bad_call(
+            method,
+            format!("{name} expects M1 UnsignedInteger, got {other:?}"),
+        )),
+    }
+}
+
+fn float_arg(method: &str, name: &str, value: &Value) -> Result<f32, EvalError> {
+    match value {
+        Value::M1(M1Scalar::FloatingPoint(value)) => Ok(*value),
+        other => Err(bad_call(
+            method,
+            format!("{name} expects M1 FloatingPoint, got {other:?}"),
+        )),
+    }
+}
+
+fn bad_call(method: &str, detail: impl std::fmt::Display) -> EvalError {
+    EvalError::BadCall {
+        detail: format!("UnixTime.{method}: {detail}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn int(value: Value) -> i32 {
+        match value {
+            Value::M1(M1Scalar::Integer(value)) => value,
+            other => panic!("expected Integer, got {other:?}"),
+        }
+    }
+
+    fn invoke(method: &str, args: &[Value], env: &mut Env) -> Result<Value, EvalError> {
+        call(method, args, env)
+    }
+
+    fn from_utc(parts: [i32; 6]) -> Result<i32, EvalError> {
+        let mut env = Env::new();
+        let args = parts.map(Value::m1_integer);
+        invoke("FromUtc", &args, &mut env).map(int)
+    }
+
+    #[test]
+    fn implementation_table_matches_the_catalogue_exactly() {
+        let object = m1_typecheck::intrinsics::get()
+            .library_object("UnixTime")
+            .expect("catalogue has UnixTime");
+        let catalogued: BTreeSet<&str> = object
+            .functions
+            .iter()
+            .map(|overload| overload.name.as_str())
+            .collect();
+        let implemented: BTreeSet<&str> = METHODS.iter().copied().collect();
+        assert_eq!(implemented, catalogued);
+        assert_eq!(METHODS.len(), 20, "duplicate implementation entries");
+    }
+
+    #[test]
+    fn independent_epoch_leap_and_signed_maximum_vectors() {
+        for (parts, expected) in [
+            ([1970, 0, 1, 0, 0, 0], 0),
+            ([1970, 0, 2, 0, 0, 0], 86_400),
+            ([2000, 1, 29, 12, 34, 56], 951_827_696),
+            ([2038, 0, 19, 3, 14, 7], i32::MAX),
+        ] {
+            assert_eq!(from_utc(parts).unwrap(), expected, "parts={parts:?}");
+        }
+    }
+
+    #[test]
+    fn utc_decomposition_covers_every_catalogued_component() {
+        let mut env = Env::new();
+        let unix = Value::m1_integer(from_utc([2004, 1, 29, 12, 34, 56]).unwrap());
+        for (method, expected) in [
+            ("ToUtcYear", 2004),
+            ("ToUtcMonth", 1),
+            ("ToUtcDay", 29),
+            ("ToUtcHour", 12),
+            ("ToUtcMinute", 34),
+            ("ToUtcSecond", 56),
+            ("ToUtcWeekDay", 0),
+            ("ToUtcYearDay", 59),
+        ] {
+            assert_eq!(
+                int(invoke(method, std::slice::from_ref(&unix), &mut env).unwrap()),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn local_decomposition_uses_fixed_offset_across_day_and_year_boundaries() {
+        let mut env = Env::new();
+        assert_eq!(
+            invoke("Timezone", &[Value::m1_integer(530)], &mut env).unwrap(),
+            Value::Bool(true)
+        );
+        let unix = Value::m1_integer(from_utc([1999, 11, 31, 20, 0, 1]).unwrap());
+        for (method, expected) in [
+            ("ToLocalYear", 2000),
+            ("ToLocalMonth", 0),
+            ("ToLocalDay", 1),
+            ("ToLocalHour", 1),
+            ("ToLocalMinute", 30),
+            ("ToLocalSecond", 1),
+            ("ToLocalWeekDay", 6),
+            ("ToLocalYearDay", 0),
+        ] {
+            assert_eq!(
+                int(invoke(method, std::slice::from_ref(&unix), &mut env).unwrap()),
+                expected
+            );
+        }
+        let local_args = [2000, 0, 1, 1, 30, 1].map(Value::m1_integer);
+        assert_eq!(
+            int(invoke("FromLocal", &local_args, &mut env).unwrap()),
+            int(unix)
+        );
+    }
+
+    #[test]
+    fn timezone_encodings_persist_and_fresh_env_resets_to_utc() {
+        for (encoded, seconds) in [
+            (0, 0),
+            (10, 36_000),
+            (-5, -18_000),
+            (530, 19_800),
+            (-930, -34_200),
+            (1245, 45_900),
+            (1445, 53_100),
+        ] {
+            let mut env = Env::new();
+            invoke("Timezone", &[Value::m1_integer(encoded)], &mut env).unwrap();
+            assert_eq!(env.unix_timezone_offset_seconds(), seconds);
+        }
+        assert_eq!(Env::new().unix_timezone_offset_seconds(), 0);
+    }
+
+    #[test]
+    fn invalid_timezone_does_not_replace_previous_state() {
+        let mut env = Env::new();
+        invoke("Timezone", &[Value::m1_integer(10)], &mut env).unwrap();
+        for invalid in [1260, -1260, 1446, -1246, i32::MIN, i32::MAX] {
+            assert!(invoke("Timezone", &[Value::m1_integer(invalid)], &mut env).is_err());
+            assert_eq!(env.unix_timezone_offset_seconds(), 36_000);
+        }
+    }
+
+    #[test]
+    fn gps_date_pivot_and_fractional_seconds_are_explicit() {
+        let mut env = Env::new();
+        for (date, seconds, expected) in [
+            (1_0170, 0.0, 0),
+            (29_0204, 45_296.75, 1_078_058_096),
+            (19_0138, 11_647.99, i32::MAX),
+        ] {
+            let actual = invoke(
+                "FromGPS",
+                &[Value::m1_unsigned(date), Value::m1_float(seconds)],
+                &mut env,
+            )
+            .unwrap();
+            assert_eq!(int(actual), expected, "date={date:06}, seconds={seconds}");
+        }
+        for date in [1_0139, 31_1269] {
+            assert!(
+                invoke(
+                    "FromGPS",
+                    &[Value::m1_unsigned(date), Value::m1_float(0.0)],
+                    &mut env,
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn leap_seconds_normalize_and_invalid_components_fail_loud() {
+        assert_eq!(
+            from_utc([1998, 11, 31, 23, 59, 60]).unwrap(),
+            from_utc([1999, 0, 1, 0, 0, 0]).unwrap()
+        );
+        assert_eq!(
+            from_utc([1998, 11, 31, 23, 59, 61]).unwrap(),
+            from_utc([1999, 0, 1, 0, 0, 1]).unwrap()
+        );
+        for parts in [
+            [1969, 0, 1, 0, 0, 0],
+            [2039, 0, 1, 0, 0, 0],
+            [2001, 1, 29, 0, 0, 0],
+            [2000, 12, 1, 0, 0, 0],
+            [2000, 0, 1, 24, 0, 0],
+            [2000, 0, 1, 0, 60, 0],
+            [2000, 0, 1, 0, 0, 62],
+        ] {
+            assert!(from_utc(parts).is_err(), "parts={parts:?}");
+        }
+        assert!(from_utc([2038, 0, 19, 3, 14, 8]).is_err());
+    }
+
+    #[test]
+    fn argument_families_are_strict() {
+        let mut env = Env::new();
+        assert!(matches!(
+            invoke("ToUtcYear", &[Value::m1_unsigned(0)], &mut env),
+            Err(EvalError::BadCall { .. })
+        ));
+        assert!(matches!(
+            invoke(
+                "FromGPS",
+                &[Value::m1_integer(1_0170), Value::m1_float(0.0)],
+                &mut env,
+            ),
+            Err(EvalError::BadCall { .. })
+        ));
+        assert!(matches!(
+            invoke(
+                "FromGPS",
+                &[Value::m1_unsigned(1_0170), Value::m1_float(f32::NAN)],
+                &mut env,
+            ),
+            Err(EvalError::BadCall { .. })
+        ));
+    }
+
+    #[test]
+    fn every_supported_day_round_trips_and_matches_independent_time_crate() {
+        use time::{Date, Month, PrimitiveDateTime, Time};
+
+        let mut days = 0_i64;
+        loop {
+            let (year, month, day) = civil_from_days(days);
+            if year > 2038 {
+                break;
+            }
+            let ours = from_utc([year, month, day, 0, 0, 0]);
+            if let Ok(ours) = ours {
+                assert_eq!(
+                    decompose(ours, 0),
+                    Civil {
+                        year,
+                        month,
+                        day,
+                        hour: 0,
+                        minute: 0,
+                        second: 0,
+                        weekday: i32::try_from((days + 4).rem_euclid(7)).unwrap(),
+                        year_day: i32::try_from(days - days_from_civil(year, 0, 1).unwrap())
+                            .unwrap(),
+                    }
+                );
+                let month_ref = Month::try_from(u8::try_from(month + 1).unwrap()).unwrap();
+                let date_ref =
+                    Date::from_calendar_date(year, month_ref, u8::try_from(day).unwrap()).unwrap();
+                let expected = PrimitiveDateTime::new(date_ref, Time::MIDNIGHT)
+                    .assume_utc()
+                    .unix_timestamp();
+                assert_eq!(i64::from(ours), expected);
+            }
+            days += 1;
+        }
+    }
+
+    #[test]
+    fn signed_timestamp_extrema_decompose_without_host_clock_or_overflow() {
+        assert_eq!(
+            decompose(i32::MIN, 0),
+            Civil {
+                year: 1901,
+                month: 11,
+                day: 13,
+                hour: 20,
+                minute: 45,
+                second: 52,
+                weekday: 5,
+                year_day: 346,
+            }
+        );
+        assert_eq!(
+            decompose(i32::MAX, 0),
+            Civil {
+                year: 2038,
+                month: 0,
+                day: 19,
+                hour: 3,
+                minute: 14,
+                second: 7,
+                weekday: 2,
+                year_day: 18,
+            }
+        );
+    }
+}

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -104,6 +104,9 @@ pub struct FixtureProvenance {
 pub enum ProvenanceKind {
     /// Hand-derived expected values used to test the runner itself.
     Synthetic,
+    /// Expected values checked against a named independent implementation or
+    /// published standard, but not captured from M1 Sim.
+    Independent,
     /// Values captured from M1 Sim.
     M1Sim,
 }
@@ -112,6 +115,7 @@ impl fmt::Display for ProvenanceKind {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Synthetic => formatter.write_str("synthetic"),
+            Self::Independent => formatter.write_str("independent"),
             Self::M1Sim => formatter.write_str("m1-sim"),
         }
     }

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -640,6 +640,7 @@ Output = i;
             "Library.Calculate.Max(1, 2);\n\
              Library.Debounce.Filter(true, 0.1);\n\
              Library.Math.fabs(-1.0);\n\
+             Library.UnixTime.ToUtcYear(0);\n\
              Library.CanComms.GetFloat(1, 2);\n",
         ));
 
@@ -648,6 +649,13 @@ Output = i;
                 .supported
                 .iter()
                 .any(|item| item.name == "Library.Calculate.Max"),
+            "{report:?}"
+        );
+        assert!(
+            report
+                .supported
+                .iter()
+                .any(|item| item.name == "Library.UnixTime.ToUtcYear"),
             "{report:?}"
         );
         for name in ["Library.Debounce.Filter", "Library.Math.fabs"] {

--- a/src/env.rs
+++ b/src/env.rs
@@ -253,6 +253,25 @@ impl Env {
             .insert(site_override_key(&call, &site), value);
     }
 
+    /// The evaluator-local Unix-timezone offset, in seconds east of UTC.
+    ///
+    /// The state lives in a private NUL-prefixed namespace inside the existing
+    /// override map so adding `UnixTime.Timezone` does not change the public
+    /// [`Env`] struct shape. M1 identifiers cannot contain NUL, so a script or
+    /// scenario value cannot collide with this key. A fresh environment is UTC.
+    pub(crate) fn unix_timezone_offset_seconds(&self) -> i32 {
+        match self.io_overrides.get(UNIX_TIMEZONE_KEY) {
+            Some(Value::M1(M1Scalar::Integer(seconds))) => *seconds,
+            _ => 0,
+        }
+    }
+
+    /// Replace the evaluator-local Unix-timezone offset.
+    pub(crate) fn set_unix_timezone_offset_seconds(&mut self, seconds: i32) {
+        self.io_overrides
+            .insert(UNIX_TIMEZONE_KEY.to_string(), Value::m1_integer(seconds));
+    }
+
     /// Write the current frame's `Out` return slot — the value an `Out = <expr>;`
     /// statement assigns inside a user-function body.
     pub fn set_out(&mut self, value: Value) {
@@ -295,6 +314,9 @@ fn site_override_key(call: &str, site: &CallSite) -> String {
         site.offset()
     )
 }
+
+/// Private `Env::io_overrides` key for `UnixTime.Timezone` state.
+const UNIX_TIMEZONE_KEY: &str = "\0m1-eval-unix-timezone";
 
 #[cfg(test)]
 mod tests {

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -95,6 +95,27 @@ fn committed_synthetic_fixtures_pass_without_claiming_capture_evidence() {
 }
 
 #[test]
+fn independent_unix_time_fixture_covers_the_catalogue_without_claiming_m1_capture() {
+    let reports = run_conformance_suite(
+        &[fixture("independent-unix-time.toml")],
+        ConformanceOptions::default(),
+    )
+    .expect("independent UnixTime fixture passes");
+    assert_eq!(reports.len(), 1);
+    assert_eq!(reports[0].provenance, ProvenanceKind::Independent);
+    assert_eq!(reports[0].assertions_checked, 21);
+
+    let error = run_conformance_suite(
+        &[fixture("independent-unix-time.toml")],
+        ConformanceOptions {
+            require_m1_sim_capture: true,
+        },
+    )
+    .expect_err("independent evidence must not satisfy the M1 Sim gate");
+    assert!(matches!(error, ConformanceError::MissingM1SimCapture));
+}
+
+#[test]
 fn json_fixture_uses_the_same_schema_and_runner() {
     let template = fixture("synthetic-mini.toml");
     let body = std::fs::read_to_string(template).expect("read template fixture");

--- a/tests/fixtures/conformance-unix-time/Project.m1prj
+++ b/tests/fixtures/conformance-unix-time/Project.m1prj
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!-- Synthetic UnixTime conformance project. No proprietary content. -->
+<MoTeCM1BuildSession>
+ <Project Name="ConformanceUnixTime" TargetHardware="ecu120">
+  <ComponentStream><List>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Unix"/>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.From GPS"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.From UTC"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.From Local"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Arithmetic"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Comparison"><Props Type="bool"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.UTC Day"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.UTC Hour"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.UTC Minute"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.UTC Month"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.UTC Second"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.UTC Week Day"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.UTC Year"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.UTC Year Day"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Local Day"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Local Hour"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Local Minute"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Local Month"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Local Second"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Local Week Day"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Local Year"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Unix.Local Year Day"><Props Type="s32"/></Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Unix.Update.m1scr" Name="Root.Unix.Update"/>
+  </List></ComponentStream>
+ </Project>
+</MoTeCM1BuildSession>

--- a/tests/fixtures/conformance-unix-time/Scripts/Unix.Update.m1scr
+++ b/tests/fixtures/conformance-unix-time/Scripts/Unix.Update.m1scr
@@ -1,0 +1,29 @@
+// Independent UnixTime vectors. No proprietary content.
+UnixTime.Timezone(530);
+local gps = UnixTime.FromGPS(290204u, 45296.75);
+local utc = UnixTime.FromUtc(2004, 1, 29, 12, 34, 56);
+local localTimestamp = UnixTime.FromLocal(2004, 1, 29, 18, 4, 56);
+
+From GPS = gps;
+From UTC = utc;
+From Local = localTimestamp;
+Arithmetic = utc + 60;
+Comparison = gps == utc;
+
+UTC Day = UnixTime.ToUtcDay(utc);
+UTC Hour = UnixTime.ToUtcHour(utc);
+UTC Minute = UnixTime.ToUtcMinute(utc);
+UTC Month = UnixTime.ToUtcMonth(utc);
+UTC Second = UnixTime.ToUtcSecond(utc);
+UTC Week Day = UnixTime.ToUtcWeekDay(utc);
+UTC Year = UnixTime.ToUtcYear(utc);
+UTC Year Day = UnixTime.ToUtcYearDay(utc);
+
+Local Day = UnixTime.ToLocalDay(utc);
+Local Hour = UnixTime.ToLocalHour(utc);
+Local Minute = UnixTime.ToLocalMinute(utc);
+Local Month = UnixTime.ToLocalMonth(utc);
+Local Second = UnixTime.ToLocalSecond(utc);
+Local Week Day = UnixTime.ToLocalWeekDay(utc);
+Local Year = UnixTime.ToLocalYear(utc);
+Local Year Day = UnixTime.ToLocalYearDay(utc);

--- a/tests/fixtures/conformance/independent-unix-time.toml
+++ b/tests/fixtures/conformance/independent-unix-time.toml
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Public Gregorian/POSIX reference vectors. This is not M1 Sim evidence.
+schema_version = 1
+name = "independent UnixTime catalogue vectors"
+calculation_rate_hz = 10.0
+
+[project]
+root = "../conformance-unix-time"
+project = "Project.m1prj"
+
+[[project.files]]
+path = "Project.m1prj"
+sha256 = "363a4de3369e9d91dee1c1e1dcfb33a813480d281e4c24efd968b59ad766d8b0"
+
+[[project.files]]
+path = "Scripts/Unix.Update.m1scr"
+sha256 = "28c8e2e5c831e16e4652636bd6aa750206aa127316c5f5fbfddd36dee5871aea"
+
+[provenance]
+kind = "independent"
+source = "POSIX seconds-since-Epoch rules and time crate 0.3.44"
+procedure = "docs/conformance.md#independent-reference-fixtures"
+notes = "M1-specific GPS pivot, leap-second normalization, and timezone encoding remain Assumed."
+
+[run]
+mode = "function"
+target = "Unix.Update"
+
+[[steps]]
+time_s = 0.0
+
+[[steps.expected]]
+channel = "Root.Unix.From GPS"
+value = { type = "integer", value = 1078058096 }
+
+[[steps.expected]]
+channel = "Root.Unix.From UTC"
+value = { type = "integer", value = 1078058096 }
+
+[[steps.expected]]
+channel = "Root.Unix.From Local"
+value = { type = "integer", value = 1078058096 }
+
+[[steps.expected]]
+channel = "Root.Unix.Arithmetic"
+value = { type = "integer", value = 1078058156 }
+
+[[steps.expected]]
+channel = "Root.Unix.Comparison"
+value = { type = "boolean", value = true }
+
+[[steps.expected]]
+channel = "Root.Unix.UTC Day"
+value = { type = "integer", value = 29 }
+
+[[steps.expected]]
+channel = "Root.Unix.UTC Hour"
+value = { type = "integer", value = 12 }
+
+[[steps.expected]]
+channel = "Root.Unix.UTC Minute"
+value = { type = "integer", value = 34 }
+
+[[steps.expected]]
+channel = "Root.Unix.UTC Month"
+value = { type = "integer", value = 1 }
+
+[[steps.expected]]
+channel = "Root.Unix.UTC Second"
+value = { type = "integer", value = 56 }
+
+[[steps.expected]]
+channel = "Root.Unix.UTC Week Day"
+value = { type = "integer", value = 0 }
+
+[[steps.expected]]
+channel = "Root.Unix.UTC Year"
+value = { type = "integer", value = 2004 }
+
+[[steps.expected]]
+channel = "Root.Unix.UTC Year Day"
+value = { type = "integer", value = 59 }
+
+[[steps.expected]]
+channel = "Root.Unix.Local Day"
+value = { type = "integer", value = 29 }
+
+[[steps.expected]]
+channel = "Root.Unix.Local Hour"
+value = { type = "integer", value = 18 }
+
+[[steps.expected]]
+channel = "Root.Unix.Local Minute"
+value = { type = "integer", value = 4 }
+
+[[steps.expected]]
+channel = "Root.Unix.Local Month"
+value = { type = "integer", value = 1 }
+
+[[steps.expected]]
+channel = "Root.Unix.Local Second"
+value = { type = "integer", value = 56 }
+
+[[steps.expected]]
+channel = "Root.Unix.Local Week Day"
+value = { type = "integer", value = 0 }
+
+[[steps.expected]]
+channel = "Root.Unix.Local Year"
+value = { type = "integer", value = 2004 }
+
+[[steps.expected]]
+channel = "Root.Unix.Local Year Day"
+value = { type = "integer", value = 59 }

--- a/tests/fixtures/conformance/independent-unix-time.toml
+++ b/tests/fixtures/conformance/independent-unix-time.toml
@@ -18,7 +18,7 @@ sha256 = "28c8e2e5c831e16e4652636bd6aa750206aa127316c5f5fbfddd36dee5871aea"
 
 [provenance]
 kind = "independent"
-source = "POSIX seconds-since-Epoch rules and time crate 0.3.44"
+source = "POSIX seconds-since-Epoch rules and time crate 0.3.47"
 procedure = "docs/conformance.md#independent-reference-fixtures"
 notes = "M1-specific GPS pivot, leap-second normalization, and timezone encoding remain Assumed."
 


### PR DESCRIPTION
Closes #53

## What changed

- implement all 20 pinned UnixTime catalogue methods for bare and Library-qualified calls
- use deterministic Gregorian/POSIX arithmetic without host clock, locale, or timezone reads
- preserve fixed timezone state within each evaluator environment and reset it across fresh runs
- validate leap years, day transitions, invalid components, signed extrema, GPS conversion, and second normalization
- add an independently verified, hash-locked conformance fixture without claiming M1 Sim provenance

## Verification

- full locked all-target/all-feature tests
- strict Clippy, rustdoc, formatting, Rust 1.88, and diff checks
- exact replay of the independently reviewed implementation commit
