### PR TITLE
feat: add deterministic virtual serial adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ do not compare computed channel values with captured M1 results.
 | `.m1cfg` parameters and 1/2/3-D table lookup | **Assumed** | The reader honors explicit `Site="x,y,z"` coordinates with X changing fastest, enum axes, and each project's clamp or extrapolation flags. Synthetic vectors cover exact sites, interpolation, every boundary, and malformed tables. No M1 Sim table capture is available yet. Use the matching calibration for actual values. Without it, parameters use typed external defaults. Table `.Lookup()` and `.Get()` fail in strict modes; whole-project mode may opt in to an external `0.0` fallback. |
 | `Calculate.*`, `Limit.*`, `Convert.*`, `UnixTime.*`, enum conversions, core value-object methods, and table methods | **Assumed** | Implemented methods have hand-derived or independent-reference tests. `UnixTime` uses deterministic Gregorian/POSIX arithmetic and evaluator-local timezone state; it never reads the host clock or timezone. `AsString`, `Validate`, `Constrain`, `GetUnscheduled`, and `Set` resolve against eligible receiver classes; channel `Set` applies its project validation range before writing. `--coverage` remains authoritative for the methods a project uses. |
 | Filters, integrals, derivatives, debounce, delay, change detection, timers, and `static local` state | **Assumed** | Update laws and startup behavior are explicit implementation assumptions with hand-derived tests, not M1 value comparisons. Timer countdowns use absolute evaluator time: `Remaining` is a read-only observation, while `Start`, `Stop`, and `Reset` are the only state transitions. |
-| `CanComms.*`, `Serial.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Assumed / Stubbed** | Each call crosses a typed adapter boundary with its resolved receiver, source call site, arguments, and evaluator time. Exact-site scenario values take precedence over wildcard values and an attached adapter. `System.ElapsedTime` reports the interval since that call site last ran. Its first tick-zero call returns zero, while a site first reached later uses its function step. Tick calls use the deterministic base timeline. `System.FlashSize` and `System.FlashFree` require scenario or adapter data; they never become a dangerous zero. Remaining unhandled calls use documented typed stubs or fail loud. |
+| Virtual `Serial.*` RS232 byte buffers | **Assumed** | A fresh adapter per run provides stable nonzero handles, timed scenario RX, independent handle cursors, endian-aware numeric access, TX capture, and real port status. LIN stays unsupported. The exact evaluator contracts and evidence boundaries are in [`docs/virtual-serial.md`](docs/virtual-serial.md). |
+| `CanComms.*`, `System.*`, `Logging.*`, DBC objects, and other hardware-backed calls | **Assumed / Stubbed** | Each call crosses a typed adapter boundary with its resolved receiver, source call site, arguments, and evaluator time. Exact-site scenario values take precedence over wildcard values and an attached adapter. `System.ElapsedTime` reports the interval since that call site last ran. Its first tick-zero call returns zero, while a site first reached later uses its function step. Tick calls use the deterministic base timeline. `System.FlashSize` and `System.FlashFree` require scenario or adapter data; they never become a dangerous zero. Remaining unhandled calls use documented typed stubs or fail loud. |
 | Scenario parsing, tick grids, trace output, and `--coverage` | **Assumed** | These are deterministic m1-eval contracts tested with synthetic data. A `Supported` coverage entry means implemented, not M1-verified. |
 | Typed conformance fixture parser and runner | **Assumed** | Synthetic fixtures cover typed values, project hashes, initial-state reset, tolerances, and mismatch reporting. No genuine M1 Sim capture is committed yet, so this runner does not make another area Verified by itself. |
 | Single-function and upstream dependency-cone runners | **Assumed** | Selection, ordering, and zero-order hold are tested on synthetic projects. |
@@ -64,8 +65,9 @@ dependency-cone runners.
 - **Tier-3 IO.** Hardware calls use a typed `HardwareAdapter` boundary. The
   adapter receives `ResolvedReceiver`, `CallSite`, arguments, and `EvalTime`.
   Routing is exact-site scenario value, wildcard scenario value, adapter,
-  deterministic `System` model, generic typed stub, then fail loud. Trace
-  provenance records which route supplied each call site.
+  virtual serial, deterministic `System` model, generic typed stub, then fail
+  loud. Trace provenance records which route supplied each call site. Virtual
+  serial transfers also have ordered byte events in JSON traces.
 - **Two runners** — *single-function* (run one chosen function each tick over a
   time series) and *dependency-cone* (run a target channel plus its upstream
   cone, topologically ordered).
@@ -209,10 +211,12 @@ exact call.
 ## Quickstart
 
 `m1-eval` runs offline. It does not connect to an ECU, sample sensors, emulate a
-CAN or serial bus, or reproduce firmware timing. A `Project.m1prj` is always
-required because it supplies symbols, types, and trigger rates. Pass the matching
-`.m1cfg` when a run needs real parameter values or table cells. Without it, an
-unseeded parameter uses a type-correct externally-driven default. Table
+CAN bus, perform live serial IO, or reproduce firmware timing. It does provide a
+deterministic virtual RS232 byte-buffer model for scenario tests. A
+`Project.m1prj` is always required because it supplies symbols, types, and trigger
+rates. Pass the matching `.m1cfg` when a run needs real parameter values or table
+cells. Without it, an unseeded parameter uses a type-correct externally-driven
+default. Table
 `.Lookup()` and `.Get()` fail in strict modes. In whole-project mode,
 `allow_default_inputs` also permits an externally-driven `0.0` table fallback.
 The evaluator does not load `.m1dbc` files.
@@ -224,6 +228,11 @@ values win over wildcards. Library consumers can instead call
 `Engine::run_with_adapter`. `System.FlashSize` and `System.FlashFree` require one
 of those sources. Run `--coverage` first to see the implemented, assumed,
 adapter-backed, stubbed, and unsupported calls in a project.
+
+Inject virtual RS232 bytes with `[[serial.rx]]`. The runner releases each chunk
+according to evaluator time, and JSON traces retain ordered RX/TX byte events;
+CSV remains channel-only. See [`docs/virtual-serial.md`](docs/virtual-serial.md)
+for the schema, supported methods, routing order, and explicit assumptions.
 
 Whole-project mode is strict about ordinary missing channels unless
 `allow_default_inputs = true` or `--allow-default-inputs` is set. The CLI then

--- a/README.md
+++ b/README.md
@@ -182,12 +182,15 @@ The multi-rate model:
 
 Before running, `m1-eval --coverage` reports, per project, which builtins and
 constructs each script uses and whether the engine dispatches them through a
-**direct implementation**, an explicit offline **model**, required
-**adapter-backed** metadata, a hardware **stub**, or no implementation. The
-rendered labels are `Supported`, `Assumed`, `Adapter-backed`, `Stubbed`, and
-`Unsupported`. These are execution-route labels, separate from the evidence
-maturity contract above. Both `Supported` and `Assumed` coverage entries remain
-**Assumed** maturity until captured M1 output verifies them.
+**direct implementation**, an explicit offline **model**, a typed
+**adapter-backed** route, a hardware **stub**, or no implementation. An adapter
+route may use a user `HardwareAdapter` or an evaluator-owned adapter such as
+virtual serial. Required external metadata, including `System.FlashSize` and
+`System.FlashFree`, is only one subset of this bucket. The rendered labels are
+`Supported`, `Assumed`, `Adapter-backed`, `Stubbed`, and `Unsupported`. These are
+execution-route labels, separate from the evidence maturity contract above.
+Both `Supported` and `Assumed` coverage entries remain **Assumed** maturity until
+captured M1 output verifies them.
 
 The report also prints a **`Schedule:`** section: every script-backed function
 with its execution rate (`@ 500 Hz`, `@ 50 Hz`, …), `startup, runs once`, or
@@ -232,7 +235,10 @@ adapter-backed, stubbed, and unsupported calls in a project.
 Inject virtual RS232 bytes with `[[serial.rx]]`. The runner releases each chunk
 according to evaluator time, and JSON traces retain ordered RX/TX byte events;
 CSV remains channel-only. See [`docs/virtual-serial.md`](docs/virtual-serial.md)
-for the schema, supported methods, routing order, and explicit assumptions.
+for the schema, supported methods, routing order, run-mode boundaries, source
+migration, and explicit assumptions. Only whole-project mode runs `On Startup`;
+function and cone selections must initialize serial in their own call chain.
+Counterfactual replay has no serial scenario or startup pass.
 
 Whole-project mode is strict about ordinary missing channels unless
 `allow_default_inputs = true` or `--allow-default-inputs` is set. The CLI then

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,6 +117,13 @@ const = 4194304
 [[io]]
 call = "System.FlashFree"
 const = 1048576
+
+# One-shot virtual RS232 input. Chunks become available when evaluator time
+# reaches time_s. Equal-time chunks retain declaration order.
+[[serial.rx]]
+time_s = 0.125
+port = 0
+bytes = [0x1b, 0x30, 0x35, 0x0d]
 ```
 
 Identifiers may contain spaces (e.g. `Cooling Fan.Output`); channel names are
@@ -138,17 +145,24 @@ Table captures also follow the stricter vector and corpus checks in
 ## Output
 
 - **JSON** (`--out trace.json`, or no `--out`):
-  `{ "time": [...], "channels": { path: [...] }, "external": [...], "hardware": [...] }`.
+  `{ "time": [...], "channels": { path: [...] }, "external": [...], "hardware": [...], "serial": [...] }`.
   Each `hardware` record names the resolved receiver, source spelling, method,
   script, byte offset, and selected route (`scenario-exact`,
-  `scenario-wildcard`, `adapter`, `system-model`, or `generic-stub`). The
+  `scenario-wildcard`, `adapter`, `virtual-serial`, `virtual-serial-rx`,
+  `system-model`, or `generic-stub`). Each ordered `serial` record contains the
+  RX/TX direction, evaluator time and phase, base tick, port, stable handle,
+  bytes, script, and call offset. The
   `external` list names channels whose values were externally driven rather than
   computed, including scenario inputs, held initial state, Tier-3 stubs,
   parameter defaults, opt-in table fallbacks, and opt-in defaults for unseeded
   channels. JSON has no non-finite numeric values, so NaN and positive or
   negative infinity are written as `null`.
 - **CSV** (`--out trace.csv`): a `time` header column followed by one column per
-  channel in sorted-name order, one row per tick.
+  channel in sorted-name order, one row per tick. Serial byte events are JSON
+  metadata and are deliberately absent from CSV.
+
+The virtual serial model is fresh for each run. Its complete method and error
+contract is documented in [`virtual-serial.md`](virtual-serial.md).
 
 Both are deterministic: the same scenario always produces byte-identical output.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,10 +46,12 @@ declared in the scenario file; at most one may be given (combining two is a usag
 error, exit `2`). `--override` and `--diff` require `--log`.
 
 The `Supported`, `Assumed`, `Adapter-backed`, and `Stubbed` buckets distinguish a
-direct implementation, an explicit offline model, required external hardware
-metadata, and a typed offline fallback. They are execution-route labels, not
-evidence maturity. `Supported` and `Assumed` remain **Assumed** maturity until
-compared with captured M1 output. See the
+direct implementation, an explicit offline model, a typed adapter route, and a
+typed offline fallback. An adapter route may use a user `HardwareAdapter` or an
+evaluator-owned adapter such as virtual serial. Required external hardware
+metadata is only a subset of `Adapter-backed`. These are execution-route labels,
+not evidence maturity. `Supported` and `Assumed` remain **Assumed** maturity
+until compared with captured M1 output. See the
 [README maturity contract](../README.md#maturity-contract) for the evidence
 labels and current status of each evaluator area.
 
@@ -125,6 +127,14 @@ time_s = 0.125
 port = 0
 bytes = [0x1b, 0x30, 0x35, 0x0d]
 ```
+
+Whole-project mode shares one virtual adapter between `On Startup` and periodic
+functions. Function and cone modes skip startup, so their selected call chain
+must initialize the port before virtual receive or transmit calls. A serial RX
+declaration schedules bytes but does not initialize a port. Counterfactual
+replay has neither scenario RX declarations nor a startup pass. See
+[`virtual-serial.md`](virtual-serial.md) for state ownership and mixed-route
+failure rules.
 
 Identifiers may contain spaces (e.g. `Cooling Fan.Output`); channel names are
 used verbatim and never split on whitespace, only on `.` for path segments.

--- a/docs/specs/2026-06-23-m1-eval-design.md
+++ b/docs/specs/2026-06-23-m1-eval-design.md
@@ -1,7 +1,8 @@
 # m1-eval — Design Spec
 
 **Date:** 2026-06-23
-**Status:** Approved design, pre-implementation
+**Status:** Historical pre-implementation design. The README and current feature
+documentation define the implemented contract.
 **Companion tool:** `m1-visualiser` (separate spec — depends on this engine for its value-overlay feature)
 
 ## Summary
@@ -55,8 +56,9 @@ From surveying the grammar, `m1-typecheck`, the M1 manuals, and ~80 real EV-M1 s
   `Integral`, `Derivative`, `Debounce`, `Delay`, `Limit`, `Convert`, `Change`,
   table lookup, plus IO-ish `CanComms`/`Serial`/`System`). Matching MoTeC's exact
   filter/integral/interpolation semantics is the main correctness risk.
-- **Some builtins touch hardware** (CAN, Serial, System ticks) and cannot be truly
-  evaluated; they are stubbed or fed from the scenario.
+- **Some builtins touch hardware** (CAN, serial devices, System ticks). Live IO
+  cannot be evaluated offline, so the current engine uses typed adapter routes,
+  explicit deterministic models, scenario values, or documented stubs.
 - **Table cell values live outside the scripts**, in `.m1cfg` calibration. Real lookups
   require that file as an input.
 - **Scripts run as scheduled functions at fixed rates** (500/200/50/10/2 Hz); rate
@@ -85,7 +87,9 @@ and scripts have side effects (channel writes, `Output.SetState(...)`).
 
 ### Non-goals (v1, YAGNI)
 - A real-time / hardware-in-the-loop simulator. This is offline, deterministic evaluation.
-- CAN bus / Serial IO emulation. Those are stubbed or scenario-fed.
+- Live CAN bus and serial-device IO. CAN remains stubbed or scenario-fed. The
+  implemented evaluator now includes a deterministic virtual RS232 byte-buffer
+  subset for offline scenarios.
 - Re-implementing or driving MoTeC's GUI tools. (M1 Sim is used only as a validation
   oracle, see Fidelity.)
 - Editing/writing `.m1cfg` or `.m1prj`. The engine reads; it does not mutate the project.
@@ -178,8 +182,9 @@ silently-wrong number):
   `Change.*`, `Filter.{Maximum,Minimum}`, timers, `static local` persistence. Each is a
   small state object keyed by call-site and advanced by `dt`. Fidelity risk concentrates
   here.
-- **Tier 3 (stub / scenario-fed):** `CanComms.*`, `Serial.*`, `System.*`, `Logging.*` —
-  return scenario-provided or documented stub values, flagged as "externally driven."
+- **Tier 3 (adapter / model / stub):** `CanComms.*`, `System.*`, `Logging.*`, and
+  hardware calls use typed adapter routes, explicit models, or documented stubs.
+  `Serial.*` has a deterministic virtual RS232 subset; LIN remains unsupported.
   Real CAN can later be fed from logged CAN channels.
 
 **Fidelity strategy:**

--- a/docs/virtual-serial.md
+++ b/docs/virtual-serial.md
@@ -35,6 +35,26 @@ same virtual port therefore observe the same injected stream independently.
 This fan-out is an explicit evaluator contract requested for repeatable tests;
 it is not a claim about a physical port's destructive read behavior.
 
+## Run-mode boundaries
+
+Whole-project mode creates one virtual adapter before the `On Startup` pass and
+shares it with every periodic function. A startup `Serial.PortInit` therefore
+configures the port used by later `Receive` and `Transmit` calls.
+
+Function and cone modes do not run the project's startup functions. The selected
+function or cone must call `PortInit` before it reaches virtual `Receive` or
+`Transmit`. A `[[serial.rx]]` declaration supplies bytes; it does not initialize
+a port. A higher-priority `[[io]]` value or user adapter may replace the serial
+sequence, but it must own every state-dependent call in that sequence.
+
+Counterfactual replay has no `Scenario`, so it has no `[[serial.rx]]` stream. It
+also skips project startup and begins with an empty virtual adapter. A number
+loaded from a log's handle channel is data, not a handle allocated by that
+adapter. Counterfactual cone code must initialize its ports and create its
+handles in the recomputed call chain. A user adapter can instead own the full
+serial sequence. Missing setup fails with the same uninitialized-port or
+invalid-handle error as any other run.
+
 ## Routing
 
 Hardware calls use this precedence:
@@ -50,6 +70,15 @@ Hardware calls use this precedence:
 An external adapter can therefore replace any serial method. Scenario `[[io]]`
 can also replace one method result, while `[[serial.rx]]` supplies the byte
 stream to the built-in virtual adapter.
+
+The first route that returns a value owns the whole call. Lower routes do not
+run for side effects. For example, a `[[io]]` value for `Serial.PortInit` returns
+success without configuring the virtual port, so a later virtual `Receive`
+fails as uninitialized. A supplied `GetHandle` value is likewise unknown to the
+virtual adapter and fails if a later getter falls through to it. A user adapter
+that returns `AdapterReply::Unhandled` lets that call fall through to virtual
+serial. Stateful serial calls should stay on one route unless the higher route
+deliberately implements the entire chain.
 
 ## Handles, ports, and buffers
 
@@ -133,6 +162,36 @@ serial event records.
 
 `Scenario::serial` contains the exported `SerialScenario` and `SerialRx` types.
 `Trace::serial` contains ordered exported `SerialEvent` records with a
-`SerialDirection`. These additions leave the public `EvalCtx` shape unchanged;
-direct `eval` and `exec_script` calls use a fresh virtual adapter without
-scenario RX data.
+`SerialDirection`. `HardwareValueSource` adds `VirtualSerial` for deterministic
+adapter results and `VirtualSerialRx` for scenario-derived results.
+
+Rust callers that construct these public structs or match the provenance enum
+must update their source:
+
+```rust
+let scenario = Scenario {
+    // existing fields
+    serial: Default::default(),
+    // existing fields
+};
+
+let trace = Trace::new(); // `Trace::default()` is equivalent
+```
+
+Code that still builds a `Trace` literal must add `serial: Vec::new()`. Prefer
+`Trace::new()` or `Trace::default()` so metadata fields start empty. Exhaustive
+matches on `HardwareValueSource` need arms for `VirtualSerial` and
+`VirtualSerialRx`. JSON readers must also accept the new top-level `serial`
+array.
+
+These additions leave the public `EvalCtx` shape unchanged. Each direct `eval`
+or `exec` call gets a fresh adapter. `exec_script` keeps one fresh adapter for
+all statements in that script. None of these direct APIs supplies scenario RX
+data. Public builtin-level helpers that receive only an `EvalCtx` also create
+fresh per-call serial state, so handles do not persist across separate helper
+calls.
+
+The sibling `m1-lsp` crate's `src/eval/engine.rs::offline_scenario` literal needs
+`serial: Default::default()` when its m1-eval dependency advances. That is a
+release-coordination follow-up; this m1-eval change does not modify the sibling
+repository.

--- a/docs/virtual-serial.md
+++ b/docs/virtual-serial.md
@@ -1,0 +1,138 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+# Virtual serial adapter
+
+`m1-eval` includes a deterministic offline RS232 byte-buffer adapter. It does
+not open host serial devices or attempt to reproduce electrical timing. The
+adapter is fresh for every scenario run and uses evaluator time only.
+
+This behavior has synthetic tests but no captured M1 or M1 Sim comparison. It
+is **Assumed** under the repository maturity contract.
+
+## Scenario input
+
+Declare one-shot receive chunks in TOML with `[[serial.rx]]`:
+
+```toml
+[[serial.rx]]
+time_s = 0.025
+port = 0
+bytes = [0x1b, 0x30, 0x35, 0x0d]
+```
+
+`time_s` must be finite and non-negative, `port` must fit a non-negative M1
+Integer, and each byte must be in `0..=255`. Source declarations are ordered by
+time and retain declaration order when timestamps match. A public
+`SerialScenario` constructed directly receives the same stable ordering inside
+the adapter.
+
+`Serial.Receive(handle, port)` sees all not-yet-seen chunks whose timestamp is
+at or before that call's evaluator time. It replaces and flushes that handle's
+receive buffer. It returns `true` when at least one byte arrived and `false`
+otherwise. A receive buffer may hold at most 256 bytes.
+
+Each handle has its own cursor for each port. Two handles receiving from the
+same virtual port therefore observe the same injected stream independently.
+This fan-out is an explicit evaluator contract requested for repeatable tests;
+it is not a claim about a physical port's destructive read behavior.
+
+## Routing
+
+Hardware calls use this precedence:
+
+1. Exact-site `[[io]]` value.
+2. Wildcard `[[io]]` value.
+3. User `HardwareAdapter`.
+4. Virtual serial adapter.
+5. Deterministic `System` model.
+6. Existing documented stubs.
+7. Fail loud.
+
+An external adapter can therefore replace any serial method. Scenario `[[io]]`
+can also replace one method result, while `[[serial.rx]]` supplies the byte
+stream to the built-in virtual adapter.
+
+## Handles, ports, and buffers
+
+- `GetHandle` and deprecated `GetTransmitHandle` return a nonzero M1
+  `UnsignedInteger`. A source call site gets the same handle on every execution.
+  Different call sites get different handles. A fresh run repeats the same
+  deterministic allocation order.
+- Reopening one call site with a different endian flag fails.
+- Handles own separate receive and transmit buffers. Getters read RX. Setters
+  write TX. `Transmit` snapshots TX, so later writes do not alter old events.
+- Buffers are 256 bytes. Negative offsets or lengths, integer widths outside
+  `1..=4`, checked range overflow, and reads beyond delivered RX bytes fail with
+  a method-specific diagnostic.
+- `PortInit` accepts non-negative ports, protocol `0` (RS232), and raw baud
+  values `1200`, `1800`, `2400`, `4800`, `9600`, `19200`, `38400`, `57600`, or
+  `115200`. Repeating the same configuration succeeds. Conflicting
+  reconfiguration, an unknown baud, or another protocol fails clearly.
+- `PortDiagnostic` returns M1 Integer `0` for an uninitialized port and `1` for
+  an initialized, healthy virtual port. Other diagnostic codes are not modeled.
+- Receive and transmit require an initialized port.
+
+## Implemented RS232 methods
+
+| Method | Virtual behavior |
+| --- | --- |
+| `GetHandle`, `GetTransmitHandle` | Stable typed handle creation. |
+| `PortInit`, `PortDiagnostic` | Stateful configuration and status. |
+| `Receive` | Timed RX delivery and per-handle cursor advance. |
+| `GetInteger` | Read 1 to 4 RX bytes and sign-extend. |
+| `GetUnsignedInteger` | Read 1 to 4 RX bytes without sign extension, returned in the catalogue's signed Integer family. |
+| `GetFloat` | Read four RX bytes as IEEE-754 binary32. |
+| `SetInteger`, `SetUnsignedInteger` | Write the selected low bytes to TX and return the first unwritten offset. |
+| `SetFloat` | Write binary32 bits to TX and return the first unwritten offset. |
+| `SetString` | Write exact-length ASCII to TX and return the first unwritten offset. |
+| `Sum8`, `XOR8` | Compute an 8-bit checksum over a checked range. |
+| `Transmit` | Record the requested TX prefix as an ordered event. |
+
+The handle's endian flag controls every multibyte integer and float. Big endian
+places the most significant selected byte first; little endian places the least
+significant byte first.
+
+The pinned catalogue declares `GetUnsignedInteger` and the value argument of
+`SetUnsignedInteger` as signed Integer despite their names. The evaluator
+preserves all 32 bits at those boundaries. Narrow writes keep the selected low
+bytes.
+
+Four details are explicit evaluator assumptions because the available source
+material does not settle them:
+
+- `PortInit` interprets its argument as the raw baud rate used in the manual
+  examples, not the ordinal value of the separate baud-rate enumeration.
+- `SetString` accepts exact-length ASCII only. It does not guess an encoding,
+  padding, or truncation rule.
+- `Sum8` wraps modulo 256. `Sum8` and `XOR8` select the buffer most recently
+  touched by `Receive` or a setter.
+- A setter returns `offset + bytes_written`, interpreted as the first unwritten
+  byte.
+
+The pinned catalogue has no `Serial.GetString`, so the evaluator does not invent
+one.
+
+## Unsupported behavior
+
+`GetLinOffset`, `SetLinHeader`, and `LinDump` remain unsupported after scenario
+and user-adapter precedence. LIN frame layout, protected identifiers, checksum
+rules, and logging effects are not sufficiently defined for this byte model.
+Live host serial IO, framing, parity, timeouts, and hardware faults are also out
+of scope.
+
+## Trace output
+
+JSON traces include an ordered `serial` array. Each event records `direction`,
+`time_s`, `phase`, `base_tick`, `port`, `handle`, `bytes`, `script`, and
+`offset`. RX-derived calls use hardware provenance source
+`virtual-serial-rx` and are marked external. Deterministic handle, configuration,
+TX-buffer, and transmit operations use `virtual-serial` and are not marked
+external. CSV remains the historical time-plus-channel format and contains no
+serial event records.
+
+## Library API
+
+`Scenario::serial` contains the exported `SerialScenario` and `SerialRx` types.
+`Trace::serial` contains ordered exported `SerialEvent` records with a
+`SerialDirection`. These additions leave the public `EvalCtx` shape unchanged;
+direct `eval` and `exec_script` calls use a fresh virtual adapter without
+scenario RX data.

--- a/src/builtins/io_stub.rs
+++ b/src/builtins/io_stub.rs
@@ -1043,7 +1043,7 @@ mod tests {
             )
             .unwrap(),
             Value::m1_float(0.02),
-            "the deterministic model measures from the adapter-backed execution"
+            "the deterministic model measures from the external-adapter execution"
         );
         assert!(h.trace.hardware.iter().any(|record| {
             record.site == site && record.source == HardwareValueSource::SystemModel

--- a/src/builtins/io_stub.rs
+++ b/src/builtins/io_stub.rs
@@ -7,14 +7,15 @@
 //! 1. An exact-call-site scenario override.
 //! 2. A wildcard scenario override for the call name.
 //! 3. An external [`HardwareAdapter`](crate::hardware::HardwareAdapter).
-//! 4. The deterministic `System` clock/tick model.
-//! 5. A generic typed stub. Every other method that the intrinsic registry
+//! 4. The deterministic virtual RS232 adapter.
+//! 5. The deterministic `System` clock/tick model.
+//! 6. A generic typed stub. Every other method that the intrinsic registry
 //!    lists for the object is a hardware-backed read/write with no meaningful
 //!    offline value, but a determinate *type*. Rather than abort a whole-project
 //!    run on the first CAN read, we return the type-correct zero/false/empty
 //!    default for the overload's declared return type (see `typed_io_default`).
 //!    This is the externally-driven default a scenario/log replay would override.
-//! 6. Fail loud. A method the registry does not list on the object is
+//! 7. Fail loud. A method the registry does not list on the object is
 //!    genuinely unknown — we never invent a value for it, so it returns
 //!    [`EvalError::UnsupportedBuiltin`].
 //!
@@ -88,6 +89,30 @@ pub(crate) fn call_with_runtime(
     {
         let value = coerce_hardware_value(value, returns, &call, ctx)?;
         return complete(ctx, &call, value, HardwareValueSource::Adapter);
+    }
+
+    if library_object == "Serial"
+        && let Some(reply) = runtime.serial.as_mut().call(method, &call)?
+    {
+        let value = coerce_hardware_value(reply.value, returns, &call, ctx)?;
+        if let Some(event) = reply.event
+            && let Some(trace) = ctx.trace.as_deref_mut()
+        {
+            trace.record_serial(event);
+        }
+        let source = if reply.external {
+            HardwareValueSource::VirtualSerialRx
+        } else {
+            HardwareValueSource::VirtualSerial
+        };
+        return complete(ctx, &call, value, source);
+    }
+
+    if library_object == "Serial" && crate::virtual_serial::is_explicitly_unsupported(method) {
+        return Err(EvalError::UnsupportedBuiltin {
+            object: source_object.to_string(),
+            method: method.to_string(),
+        });
     }
 
     if let Some(value) = system_model(library_object, method, args, &call.site, ctx, runtime)? {
@@ -570,7 +595,11 @@ mod tests {
                 depth: 0,
                 trace: Some(&mut self.trace),
             };
-            let mut runtime = EvalRuntime { time, hardware };
+            let mut runtime = EvalRuntime {
+                time,
+                hardware,
+                serial: crate::expr::SerialRuntime::fresh(),
+            };
             crate::builtins::dispatch_with_runtime(
                 object,
                 method,

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -777,6 +777,21 @@ fn classify_library(object: &str, method: &str) -> CallCapability {
         let known = !intrinsics::get()
             .library_overloads(object, method)
             .is_empty();
+        if object == "Serial" && known && crate::virtual_serial::is_adapter_backed(method) {
+            return capability(
+                BuiltinSupport::AdapterBacked,
+                CallRoute::IoLibrary(object.to_string()),
+            );
+        }
+        if object == "Serial" && known && crate::virtual_serial::is_explicitly_unsupported(method) {
+            // Keep the IO route so an exact/wildcard scenario override or user
+            // adapter still gets first refusal before the virtual RS232 model
+            // rejects LIN behavior.
+            return capability(
+                BuiltinSupport::Unsupported,
+                CallRoute::IoLibrary(object.to_string()),
+            );
+        }
         if object == "System" && known && MODELED_SYSTEM_METHODS.contains(&method) {
             return capability(
                 BuiltinSupport::Modeled,
@@ -1917,6 +1932,7 @@ mod tests {
             let mut runtime = EvalRuntime {
                 time: crate::hardware::EvalTime::at_start(0.01),
                 hardware,
+                serial: crate::expr::SerialRuntime::fresh(),
             };
             dispatch_with_runtime(object, method, args, site, &mut ctx, &mut runtime)
         }
@@ -2680,6 +2696,12 @@ mod tests {
                 let method = overload.name.as_str();
                 let support = if object == "System" && MODELED_SYSTEM_METHODS.contains(&method) {
                     BuiltinSupport::Modeled
+                } else if object == "Serial" && crate::virtual_serial::is_adapter_backed(method) {
+                    BuiltinSupport::AdapterBacked
+                } else if object == "Serial"
+                    && crate::virtual_serial::is_explicitly_unsupported(method)
+                {
+                    BuiltinSupport::Unsupported
                 } else if io_stub::required_metadata(object, method) {
                     BuiltinSupport::AdapterBacked
                 } else {
@@ -2716,7 +2738,7 @@ mod tests {
                 BuiltinSupport::Modeled => &report.assumed,
                 BuiltinSupport::AdapterBacked => &report.adapter_backed,
                 BuiltinSupport::Stubbed => &report.stubbed,
-                _ => unreachable!("catalog test covers executable methods"),
+                BuiltinSupport::Unsupported => &report.unsupported,
             };
             assert!(
                 bucket.iter().any(|item| item.name == name),
@@ -2737,8 +2759,10 @@ mod tests {
                 .collect();
             let mut harness = Harness::new();
             match harness.call(object, method, &args) {
-                Err(EvalError::MissingHardwareMetadata { .. })
+                Err(EvalError::BadCall { .. } | EvalError::MissingHardwareMetadata { .. })
                     if expected == BuiltinSupport::AdapterBacked => {}
+                Err(EvalError::UnsupportedBuiltin { .. })
+                    if expected == BuiltinSupport::Unsupported => {}
                 Err(EvalError::UnsupportedBuiltin { .. }) => {
                     panic!("coverage says {expected:?}, but dispatch rejects {name}")
                 }
@@ -2777,7 +2801,6 @@ mod tests {
             ("CanComms", "GetUnsignedInteger"), // Integer -> 0
             ("CanComms", "RxMessage"),          // Boolean -> false
             ("CanComms", "SetFloat"),           // Void -> unit
-            ("Serial", "GetFloat"),
             ("Logging", "Running"),
         ];
         for (object, method) in cases {
@@ -2787,6 +2810,16 @@ mod tests {
                 "{object}.{method} should be a stub"
             );
         }
+        assert_eq!(
+            classify_builtin("Serial", "GetFloat"),
+            BuiltinSupport::AdapterBacked,
+            "implemented virtual serial reads should be adapter-backed"
+        );
+        assert_eq!(
+            classify_builtin("Serial", "SetLinHeader"),
+            BuiltinSupport::Unsupported,
+            "unmodeled LIN framing should remain unsupported"
+        );
         for method in ["ElapsedTime", "TickPeriod", "Ticks", "TicksSince"] {
             assert_eq!(
                 classify_builtin("System", method),

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -517,7 +517,9 @@ pub enum BuiltinSupport {
     Modeled,
     /// A hardware call with a documented generic offline fallback.
     Stubbed,
-    /// Hardware metadata which must come from a scenario or typed adapter.
+    /// Runs through a typed hardware-adapter route. The route may use a user
+    /// adapter or an evaluator-owned adapter such as virtual serial. Only some
+    /// calls in this category require external metadata.
     AdapterBacked,
     /// Not implemented — fails loud at runtime.
     Unsupported,

--- a/src/builtins/userfn.rs
+++ b/src/builtins/userfn.rs
@@ -344,7 +344,11 @@ mod tests {
                 depth: 0,
                 trace: None,
             };
-            let mut runtime = EvalRuntime { time, hardware };
+            let mut runtime = EvalRuntime {
+                time,
+                hardware,
+                serial: crate::expr::SerialRuntime::fresh(),
+            };
             call_with_runtime(callee, args, &mut ctx, &mut runtime)
         }
     }

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -1146,6 +1146,7 @@ fn fixture_scenario(
         base_rate_hz: fixture.calculation_rate_hz,
         overrides: Vec::new(),
         io: Vec::new(),
+        serial: Default::default(),
         allow_default_inputs: false,
     })
 }

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -3,8 +3,9 @@
 //! engine *supports*.
 //!
 //! Before a run, a user wants to know which parts of their project the evaluator
-//! implements, which hardware metadata needs a scenario or adapter, which calls
-//! have a typed offline fallback, and which it cannot handle at all. This module
+//! implements, which calls use a typed adapter route, which calls have a typed
+//! offline fallback, and which it cannot handle at all. Adapter routes include
+//! both required external metadata and evaluator-owned adapters. This module
 //! walks every script's CST and answers that statically:
 //!
 //! - every call is resolved through the same project-aware capability model as
@@ -63,7 +64,9 @@ pub struct CoverageReport {
     pub supported: Vec<CoverageItem>,
     /// Items dispatched through an explicit deterministic offline model.
     pub assumed: Vec<CoverageItem>,
-    /// Hardware metadata which requires a scenario or adapter value.
+    /// Calls routed through a typed adapter. This includes both user-supplied
+    /// adapters and evaluator-owned adapters such as virtual serial. Required
+    /// external metadata is a subset of this category.
     pub adapter_backed: Vec<CoverageItem>,
     /// Hardware calls handled by documented typed offline fallbacks.
     pub stubbed: Vec<CoverageItem>,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -263,9 +263,10 @@ impl Engine {
     }
 
     /// Report which builtins/constructs every loaded script uses and whether the
-    /// engine supports, assumes, requires adapter data for, stubs, or cannot
-    /// handle each, along with the whole-project execution schedule. Pure static
-    /// analysis; no scenario is needed, so this is safe before [`Engine::run`].
+    /// engine supports, assumes, routes through a typed adapter, stubs, or cannot
+    /// handle each, along with the whole-project execution schedule. Adapter
+    /// routes may be user-supplied or evaluator-owned. Pure static analysis; no
+    /// scenario is needed, so this is safe before [`Engine::run`].
     pub fn coverage(&self) -> CoverageReport {
         CoverageReport::analyse_loaded(&self.loaded)
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -92,6 +92,28 @@ pub struct EvalCtx<'a> {
 pub(crate) struct EvalRuntime<'h> {
     pub(crate) time: EvalTime,
     pub(crate) hardware: Option<&'h mut dyn HardwareAdapter>,
+    pub(crate) serial: SerialRuntime<'h>,
+}
+
+/// A public evaluator call owns a fresh adapter, while a runner borrows one
+/// adapter across startup and every tick. The enum keeps that ownership detail
+/// private and leaves the public [`EvalCtx`] struct unchanged.
+pub(crate) enum SerialRuntime<'h> {
+    Fresh(crate::virtual_serial::VirtualSerial),
+    Shared(&'h mut crate::virtual_serial::VirtualSerial),
+}
+
+impl SerialRuntime<'_> {
+    pub(crate) fn fresh() -> Self {
+        SerialRuntime::Fresh(crate::virtual_serial::VirtualSerial::empty())
+    }
+
+    pub(crate) fn as_mut(&mut self) -> &mut crate::virtual_serial::VirtualSerial {
+        match self {
+            SerialRuntime::Fresh(serial) => serial,
+            SerialRuntime::Shared(serial) => serial,
+        }
+    }
 }
 
 impl EvalRuntime<'static> {
@@ -108,6 +130,7 @@ impl EvalRuntime<'static> {
         EvalRuntime {
             time,
             hardware: None,
+            serial: SerialRuntime::fresh(),
         }
     }
 }

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -176,6 +176,10 @@ pub enum HardwareValueSource {
     ScenarioWildcard,
     /// An external [`HardwareAdapter`] supplied the value.
     Adapter,
+    /// The evaluator's deterministic virtual RS232 adapter handled the call.
+    VirtualSerial,
+    /// A virtual serial result depended on scenario-controlled receive data.
+    VirtualSerialRx,
     /// The evaluator's deterministic `System` model supplied the value.
     SystemModel,
     /// A documented type-correct offline stub supplied the value.
@@ -189,6 +193,8 @@ impl HardwareValueSource {
             HardwareValueSource::ScenarioExact => "scenario-exact",
             HardwareValueSource::ScenarioWildcard => "scenario-wildcard",
             HardwareValueSource::Adapter => "adapter",
+            HardwareValueSource::VirtualSerial => "virtual-serial",
+            HardwareValueSource::VirtualSerialRx => "virtual-serial-rx",
             HardwareValueSource::SystemModel => "system-model",
             HardwareValueSource::GenericStub => "generic-stub",
         }
@@ -196,7 +202,10 @@ impl HardwareValueSource {
 
     /// Whether this result came from outside evaluator computation.
     pub fn is_external(self) -> bool {
-        !matches!(self, HardwareValueSource::SystemModel)
+        !matches!(
+            self,
+            HardwareValueSource::SystemModel | HardwareValueSource::VirtualSerial
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,9 @@ pub mod ident;
 pub use ident::{Target, classify};
 
 pub mod trace;
-pub use trace::Trace;
+pub use trace::{SerialDirection, SerialEvent, Trace};
+
+mod virtual_serial;
 
 pub mod expr;
 pub use expr::{EvalCtx, eval, eval_at_time};
@@ -42,7 +44,9 @@ pub mod stmt;
 pub use stmt::{exec, exec_at_time, exec_script, exec_script_at_time};
 
 pub mod scenario;
-pub use scenario::{InitialValue, InputKind, InputSeries, IoSeries, RunMode, Scenario};
+pub use scenario::{
+    InitialValue, InputKind, InputSeries, IoSeries, RunMode, Scenario, SerialRx, SerialScenario,
+};
 
 pub mod log;
 pub use log::{Log, LogMeta};

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -458,6 +458,9 @@ fn tick_loop(
     let mut env = Env::new();
     let mut state = StateStore::new();
     let mut trace = Trace::new();
+    // A virtual serial adapter is run-local state. Repeating the same scenario
+    // starts with fresh ports, handles, cursors, and buffers.
+    let mut serial = crate::virtual_serial::VirtualSerial::new(&scenario.serial)?;
 
     // Unseeded-channel defaulting is the scenario's EXPLICIT opt-in
     // (`allow_default_inputs = true`, whole-project mode only): an unseeded
@@ -548,6 +551,7 @@ fn tick_loop(
                     Some(hardware) => Some(&mut **hardware),
                     None => None,
                 },
+                serial: crate::expr::SerialRuntime::Shared(&mut serial),
             };
             exec_script_with_runtime(&root, &mut ctx, &mut runtime)
                 .map_err(|e| e.in_script(&sched.script.name, None))?;
@@ -555,6 +559,7 @@ fn tick_loop(
         startup_written.extend(startup_trace.channels.keys().cloned());
         trace.external.extend(startup_trace.external);
         trace.hardware.extend(startup_trace.hardware);
+        trace.serial.extend(startup_trace.serial);
     }
 
     for i in 0..ticks {
@@ -612,6 +617,7 @@ fn tick_loop(
                     Some(hardware) => Some(&mut **hardware),
                     None => None,
                 },
+                serial: crate::expr::SerialRuntime::Shared(&mut serial),
             };
             exec_script_with_runtime(&root, &mut ctx, &mut runtime)
                 .map_err(|e| e.in_script(&sched.script.name, Some(t)))?;
@@ -1208,6 +1214,7 @@ fn run_counterfactual_inner(
     let mut env = Env::new();
     let mut state = StateStore::new();
     let mut trace = Trace::new();
+    let mut serial = crate::virtual_serial::VirtualSerial::empty();
     // A counterfactual seeds every logged channel as ground truth, so an unseeded
     // *channel* read still fails loud (like function/cone mode): a cone function
     // reading a channel the log does not carry is a genuine error, not a guess.
@@ -1283,6 +1290,7 @@ fn run_counterfactual_inner(
                             Some(hardware) => Some(&mut **hardware),
                             None => None,
                         },
+                        serial: crate::expr::SerialRuntime::Shared(&mut serial),
                     };
                     crate::expr::eval_with_runtime(&value_node, &mut ctx, &mut runtime)?
                 }
@@ -1291,6 +1299,7 @@ fn run_counterfactual_inner(
         }
         trace.external.extend(override_trace.external);
         trace.hardware.extend(override_trace.hardware);
+        trace.serial.extend(override_trace.serial);
         for (path, value) in pending {
             let value = crate::expr::coerce_for_channel(&path, value, &loaded.project)?;
             env.set(path, value);
@@ -1330,6 +1339,7 @@ fn run_counterfactual_inner(
                     Some(hardware) => Some(&mut **hardware),
                     None => None,
                 },
+                serial: crate::expr::SerialRuntime::Shared(&mut serial),
             };
             exec_script_with_runtime(&root, &mut ctx, &mut runtime)
                 .map_err(|e| e.in_script(&sched.script.name, Some(t)))?;
@@ -1541,6 +1551,7 @@ mod tests {
             }],
             overrides: vec![],
             io: vec![],
+            serial: Default::default(),
             allow_default_inputs: false,
         };
         let trace = run(&loaded, &scenario).expect("enum-seeded run evaluates");
@@ -1573,6 +1584,7 @@ mod tests {
             }],
             overrides: vec![],
             io: vec![],
+            serial: Default::default(),
             allow_default_inputs: false,
         };
         let err = run(&loaded, &scenario).expect_err("string input fails loud");
@@ -1597,6 +1609,7 @@ mod tests {
             inputs: vec![],
             overrides: vec![],
             io: vec![],
+            serial: Default::default(),
             allow_default_inputs: false,
         };
         let err = run(&loaded, &scenario).expect_err("unseeded input fails loud");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2614,6 +2614,49 @@ base_rate_hz = 100.0
     }
 
     #[test]
+    fn counterfactual_serial_override_does_not_run_startup_port_initialization() {
+        let loaded = serial_fixture();
+        // Tx Offset selects only the Transmit function downstream, and that
+        // function does not call PortInit. Any initialized port here would have
+        // leaked from the whole-project startup schedule.
+        let channels = vec![InputSeries {
+            channel: "Root.Serial Test.Tx Offset".to_string(),
+            kind: InputKind::Const(Value::m1_integer(0)),
+        }];
+        let log = Log {
+            meta: LogMeta {
+                source: "synthetic-serial-counterfactual".to_string(),
+                duration_s: 0.01,
+                channel_count: channels.len(),
+                units: BTreeMap::new(),
+            },
+            channels,
+        };
+        let overrides = vec![
+            Override::parse("Root.Serial Test.Tx Offset=Serial.Receive(Serial.GetHandle(true), 0)")
+                .expect("serial override expression parses"),
+        ];
+        let cfg = CounterfactualCfg {
+            base_rate_hz: 100.0,
+            duration_s: 0.01,
+        };
+
+        let error = run_counterfactual(&loaded, &log, &overrides, &cfg)
+            .expect_err("counterfactual mode must not borrow whole-project startup state");
+        assert_eq!(
+            error.root_cause(),
+            &EvalError::BadCall {
+                detail: "Serial.Receive: port 0 is not initialized; call Serial.PortInit first"
+                    .to_string(),
+            }
+        );
+        assert_eq!(
+            error.to_string(),
+            "bad call: Serial.Receive: port 0 is not initialized; call Serial.PortInit first"
+        );
+    }
+
+    #[test]
     fn counterfactual_serial_rejects_a_logged_handle_after_in_cone_port_setup() {
         let loaded = serial_fixture();
         let channels = vec![

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2493,6 +2493,11 @@ base_rate_hz = 100.0
         load(&dir.join("Project.m1prj"), None).expect("counterfactual fixture loads")
     }
 
+    fn serial_fixture() -> Loaded {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/serial");
+        load(&dir.join("Project.m1prj"), None).expect("serial fixture loads")
+    }
+
     /// The `fn_symbol` path of each scheduled function in a cone, in order — the
     /// load-bearing observable for the downstream-cone tests.
     fn cone_fn_symbols(cone: &[Scheduled<'_>]) -> Vec<String> {
@@ -2606,6 +2611,53 @@ base_rate_hz = 100.0
                 units: BTreeMap::new(),
             },
         }
+    }
+
+    #[test]
+    fn counterfactual_serial_rejects_a_logged_handle_after_in_cone_port_setup() {
+        let loaded = serial_fixture();
+        let channels = vec![
+            InputSeries {
+                channel: "Root.Serial Test.Counterfactual Gate".to_string(),
+                kind: InputKind::Const(Value::m1_integer(1)),
+            },
+            InputSeries {
+                channel: "Root.Serial Test.Handle A".to_string(),
+                kind: InputKind::Const(Value::m1_unsigned(77)),
+            },
+        ];
+        let log = Log {
+            meta: LogMeta {
+                source: "synthetic-serial-counterfactual".to_string(),
+                duration_s: 0.01,
+                channel_count: channels.len(),
+                units: BTreeMap::new(),
+            },
+            channels,
+        };
+        let overrides = vec![
+            Override::parse("Root.Serial Test.Handle A=Root.Serial Test.Handle A")
+                .expect("identity override parses"),
+        ];
+        let cfg = CounterfactualCfg {
+            base_rate_hz: 100.0,
+            duration_s: 0.01,
+        };
+
+        let error = run_counterfactual(&loaded, &log, &overrides, &cfg)
+            .expect_err("a logged number is not a handle from the fresh virtual adapter");
+        assert_eq!(
+            error.root_cause(),
+            &EvalError::BadCall {
+                detail:
+                    "Serial.Receive: invalid handle 77; handles are nonzero and owned by this run"
+                        .to_string(),
+            }
+        );
+        assert_eq!(
+            error.to_string(),
+            "in Serial Test.Counterfactual Receive.m1scr at t = 0.000 s: bad call: Serial.Receive: invalid handle 77; handles are nonzero and owned by this run"
+        );
     }
 
     fn floats(trace: &Trace, channel: &str) -> Vec<f64> {

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -205,11 +205,33 @@ pub struct Scenario {
     /// Scenario-driven hardware-call overrides (`[[io]]`), keyed by
     /// `"Object.Method"` and resampled every tick. See [`IoSeries`].
     pub io: Vec<IoSeries>,
+    /// Deterministic virtual-serial inputs. Each declaration becomes visible to
+    /// `Serial.Receive` when evaluator time reaches its timestamp.
+    pub serial: SerialScenario,
     /// Whole-project mode only: substitute type-correct startup defaults for
     /// unseeded channel reads (each substitution is reported on the trace)
     /// instead of failing loud. **Off by default** — strict fail-loud is the
     /// baseline; defaulting is an explicit, visible opt-in.
     pub allow_default_inputs: bool,
+}
+
+/// Scenario-owned inputs for the deterministic virtual serial adapter.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SerialScenario {
+    /// Received byte chunks, ordered by timestamp and then declaration order.
+    pub rx: Vec<SerialRx>,
+}
+
+/// One byte chunk made available on a virtual RS232 port at evaluator time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SerialRx {
+    /// Seconds from the beginning of the run. Startup and periodic tick zero
+    /// both observe declarations at `0.0`.
+    pub time_s: f64,
+    /// Non-negative M1 serial port number.
+    pub port: i32,
+    /// Bytes appended to the port's receive stream at [`SerialRx::time_s`].
+    pub bytes: Vec<u8>,
 }
 
 impl Scenario {
@@ -504,6 +526,8 @@ struct RawScenario {
     overrides: Vec<RawInput>,
     #[serde(default)]
     io: Vec<RawIo>,
+    #[serde(default)]
+    serial: RawSerial,
     /// Opt-in unseeded-channel defaulting for whole-project mode (strict
     /// fail-loud when absent/false).
     #[serde(default)]
@@ -515,6 +539,22 @@ struct RawScenario {
 struct RawInitialValue {
     channel: String,
     value: RawValue,
+}
+
+/// Wire shape for `[serial]` and its ergonomic `[[serial.rx]]` entries.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSerial {
+    #[serde(default)]
+    rx: Vec<RawSerialRx>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSerialRx {
+    time_s: f64,
+    port: i64,
+    bytes: Vec<i64>,
 }
 
 /// A raw input/override entry: a channel plus exactly one of `const`/`series`.
@@ -720,6 +760,7 @@ impl RawScenario {
             .into_iter()
             .map(RawIo::into_io)
             .collect::<Result<Vec<_>, _>>()?;
+        let serial = self.serial.into_serial()?;
         let mut io_selectors = BTreeSet::new();
         for entry in &io {
             if !io_selectors.insert((entry.call.clone(), entry.site.clone())) {
@@ -746,7 +787,93 @@ impl RawScenario {
             base_rate_hz: self.base_rate_hz,
             overrides,
             io,
+            serial,
             allow_default_inputs: self.allow_default_inputs,
+        })
+    }
+}
+
+impl RawSerial {
+    fn into_serial(self) -> Result<SerialScenario, EvalError> {
+        let mut rx = self
+            .rx
+            .into_iter()
+            .enumerate()
+            .map(|(declaration, entry)| {
+                if !entry.time_s.is_finite() || entry.time_s < 0.0 {
+                    return Err(EvalError::UnsupportedConstruct {
+                        kind: format!(
+                            "serial rx declaration {} has invalid time_s {} (expected a finite, non-negative time)",
+                            declaration + 1,
+                            entry.time_s
+                        ),
+                        at: 0,
+                    });
+                }
+                let port = i32::try_from(entry.port).map_err(|_| {
+                    EvalError::UnsupportedConstruct {
+                        kind: format!(
+                            "serial rx declaration {} has port {} outside the M1 Integer range",
+                            declaration + 1,
+                            entry.port
+                        ),
+                        at: 0,
+                    }
+                })?;
+                if port < 0 {
+                    return Err(EvalError::UnsupportedConstruct {
+                        kind: format!(
+                            "serial rx declaration {} has negative port {port}",
+                            declaration + 1
+                        ),
+                        at: 0,
+                    });
+                }
+                let bytes = entry
+                    .bytes
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, byte)| {
+                        u8::try_from(byte).map_err(|_| EvalError::UnsupportedConstruct {
+                            kind: format!(
+                                "serial rx declaration {} byte {} is {byte}, outside 0..=255",
+                                declaration + 1,
+                                index
+                            ),
+                            at: 0,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                if bytes.len() > 256 {
+                    return Err(EvalError::UnsupportedConstruct {
+                        kind: format!(
+                            "serial rx declaration {} has {} bytes, exceeding the 256-byte receive buffer",
+                            declaration + 1,
+                            bytes.len()
+                        ),
+                        at: 0,
+                    });
+                }
+                Ok((
+                    declaration,
+                    SerialRx {
+                        time_s: entry.time_s,
+                        port,
+                        bytes,
+                    },
+                ))
+            })
+            .collect::<Result<Vec<_>, EvalError>>()?;
+
+        // Stable ordering makes out-of-order source declarations ergonomic while
+        // preserving source order for chunks with the same timestamp.
+        rx.sort_by(|(left_index, left), (right_index, right)| {
+            left.time_s
+                .total_cmp(&right.time_s)
+                .then_with(|| left_index.cmp(right_index))
+        });
+        Ok(SerialScenario {
+            rx: rx.into_iter().map(|(_, entry)| entry).collect(),
         })
     }
 }
@@ -877,6 +1004,83 @@ series = [[0.0, 0.0], [0.5, 50.0]]
         // At/after the second keyframe -> 50.0.
         assert_eq!(speed.sample(0.5), Value::m1_float(50.0));
         assert_eq!(speed.sample(0.99), Value::m1_float(50.0));
+    }
+
+    #[test]
+    fn parses_and_stably_orders_virtual_serial_rx_declarations() {
+        let scenario = Scenario::from_toml_str(
+            r#"
+mode = "function"
+target = "Root.Demo.Update"
+duration_s = 0.2
+base_rate_hz = 100.0
+
+[[serial.rx]]
+time_s = 0.1
+port = 2
+bytes = [0x43]
+
+[[serial.rx]]
+time_s = 0.0
+port = 2
+bytes = [0x41]
+
+[[serial.rx]]
+time_s = 0.1
+port = 2
+bytes = [0x42]
+"#,
+        )
+        .expect("serial scenario parses");
+
+        assert_eq!(
+            scenario.serial.rx,
+            vec![
+                SerialRx {
+                    time_s: 0.0,
+                    port: 2,
+                    bytes: vec![0x41],
+                },
+                SerialRx {
+                    time_s: 0.1,
+                    port: 2,
+                    bytes: vec![0x43],
+                },
+                SerialRx {
+                    time_s: 0.1,
+                    port: 2,
+                    bytes: vec![0x42],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn virtual_serial_wire_values_are_range_checked() {
+        for (entry, expected) in [
+            (
+                "time_s = -0.1\nport = 0\nbytes = [1]",
+                "finite, non-negative time",
+            ),
+            ("time_s = 0.0\nport = -1\nbytes = [1]", "negative port -1"),
+            ("time_s = 0.0\nport = 0\nbytes = [256]", "outside 0..=255"),
+            (
+                &format!(
+                    "time_s = 0.0\nport = 0\nbytes = [{}]",
+                    std::iter::repeat_n("0", 257).collect::<Vec<_>>().join(", ")
+                ),
+                "257 bytes",
+            ),
+        ] {
+            let source = format!(
+                "mode = \"function\"\ntarget = \"Root.Demo.Update\"\nduration_s = 0.1\nbase_rate_hz = 100.0\n\n[[serial.rx]]\n{entry}\n"
+            );
+            let error = Scenario::from_toml_str(&source).expect_err("invalid serial input fails");
+            assert!(
+                error.to_string().contains(expected),
+                "{error} should contain {expected:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -31,7 +31,8 @@
 //! is deterministic, with a `time` column followed by channels in sorted-name
 //! order.
 
-use crate::hardware::{HardwareProvenance, ResolvedReceiver};
+use crate::env::CallSite;
+use crate::hardware::{EvalPhase, EvalTime, HardwareProvenance, ResolvedReceiver};
 use crate::value::{M1Scalar, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -62,6 +63,9 @@ pub struct Trace {
     /// Structured source records for hardware-backed call sites. A set keeps
     /// repeated ticks compact while retaining every route a site used.
     pub hardware: BTreeSet<HardwareProvenance>,
+    /// Ordered byte transfers through the deterministic virtual serial adapter.
+    /// Unlike de-duplicated hardware provenance, repeated transfers are retained.
+    pub serial: Vec<SerialEvent>,
     /// Final channel value and provenance for each tick that recorded one.
     /// Kept separately from the compatibility columns, whose public shape
     /// cannot represent a missing value before a channel first appears.
@@ -72,6 +76,41 @@ pub struct Trace {
 struct ChannelTick {
     value: Value,
     external: bool,
+}
+
+/// Direction of one observable virtual serial transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SerialDirection {
+    /// Bytes copied from a scenario-controlled port into a handle receive buffer.
+    Rx,
+    /// Bytes copied from a handle transmit buffer onto a virtual port.
+    Tx,
+}
+
+impl SerialDirection {
+    fn as_str(self) -> &'static str {
+        match self {
+            SerialDirection::Rx => "rx",
+            SerialDirection::Tx => "tx",
+        }
+    }
+}
+
+/// One ordered virtual serial byte event.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SerialEvent {
+    /// Receive or transmit.
+    pub direction: SerialDirection,
+    /// Evaluator time at which the script observed or emitted the bytes.
+    pub time: EvalTime,
+    /// Virtual M1 serial port number.
+    pub port: i32,
+    /// Stable nonzero handle used by the call.
+    pub handle: u32,
+    /// Bytes transferred in wire order.
+    pub bytes: Vec<u8>,
+    /// Exact `Serial.Receive` or `Serial.Transmit` call occurrence.
+    pub site: CallSite,
 }
 
 /// One reported default substitution: what value was substituted and which
@@ -228,9 +267,14 @@ impl Trace {
         self.hardware.insert(provenance);
     }
 
+    /// Append one virtual serial transfer in execution order.
+    pub fn record_serial(&mut self, event: SerialEvent) {
+        self.serial.push(event);
+    }
+
     /// Serialise the channel columns + time axis to JSON. The shape is
     /// `{ "time": [...], "channels": { path: [...] }, "external": [...],
-    /// "hardware": [...] }`,
+    /// "hardware": [...], "serial": [...] }`,
     /// values rendered by `value_json`. This historical untyped shape cannot
     /// expose M1 scalar-family metadata. JSON has no non-finite number syntax, so
     /// NaN and positive or negative infinity are written as `null`. Deterministic
@@ -255,6 +299,8 @@ impl Trace {
         out.push_str(&join(self.external.iter().map(|p| json_string(p))));
         out.push_str("],\"hardware\":[");
         out.push_str(&join(self.hardware.iter().map(hardware_json)));
+        out.push_str("],\"serial\":[");
+        out.push_str(&join(self.serial.iter().map(serial_json)));
         out.push_str("]}");
         out
     }
@@ -283,6 +329,27 @@ impl Trace {
         }
         out
     }
+}
+
+/// Render one ordered virtual serial transfer.
+fn serial_json(event: &SerialEvent) -> String {
+    let phase = match event.time.phase {
+        EvalPhase::Startup => "startup",
+        EvalPhase::Periodic => "periodic",
+    };
+    let bytes = join(event.bytes.iter().map(u8::to_string));
+    format!(
+        "{{\"direction\":{},\"time_s\":{},\"phase\":{},\"base_tick\":{},\"port\":{},\"handle\":{},\"bytes\":[{}],\"script\":{},\"offset\":{}}}",
+        json_string(event.direction.as_str()),
+        f64_json(event.time.elapsed_s),
+        json_string(phase),
+        event.time.base_tick,
+        event.port,
+        event.handle,
+        bytes,
+        json_string(event.site.script()),
+        event.site.offset(),
+    )
 }
 
 /// Render one structured hardware provenance record.
@@ -470,7 +537,7 @@ mod tests {
         // BTreeMap ordering: A before B regardless of insertion order.
         assert_eq!(
             json,
-            "{\"time\":[0],\"channels\":{\"A\":[true],\"B\":[2]},\"external\":[\"A\"],\"hardware\":[]}"
+            "{\"time\":[0],\"channels\":{\"A\":[true],\"B\":[2]},\"external\":[\"A\"],\"hardware\":[],\"serial\":[]}"
         );
     }
 
@@ -490,7 +557,7 @@ mod tests {
 
         assert_eq!(
             tr.to_json(),
-            "{\"time\":[0],\"channels\":{\"Fixed\":[0.1000001],\"Float\":[0.1],\"Int\":[-2147483648],\"Uint\":[4294967295]},\"external\":[],\"hardware\":[]}"
+            "{\"time\":[0],\"channels\":{\"Fixed\":[0.1000001],\"Float\":[0.1],\"Int\":[-2147483648],\"Uint\":[4294967295]},\"external\":[],\"hardware\":[],\"serial\":[]}"
         );
     }
 
@@ -509,7 +576,7 @@ mod tests {
         let json = tr.to_json();
         assert_eq!(
             json,
-            "{\"time\":[null,null,null],\"channels\":{\"M1\":[null,null,null]},\"external\":[],\"hardware\":[]}"
+            "{\"time\":[null,null,null],\"channels\":{\"M1\":[null,null,null]},\"external\":[],\"hardware\":[],\"serial\":[]}"
         );
         let parsed: serde_json::Value =
             serde_json::from_str(&json).expect("trace output must be valid JSON");
@@ -529,5 +596,38 @@ mod tests {
         let lines: Vec<&str> = csv.lines().collect();
         assert_eq!(lines[0], "time,\"Root.A,B\"");
         assert_eq!(lines[1], "0,\"x,y\"");
+    }
+
+    #[test]
+    fn serial_events_are_ordered_json_metadata_and_not_csv_columns() {
+        let mut trace = Trace::new();
+        trace.push_tick(0.25);
+        trace.record_channel("Out", Value::m1_integer(1));
+        trace.record_serial(SerialEvent {
+            direction: SerialDirection::Tx,
+            time: EvalTime::periodic(25, 0.25, 0.01, 0.02),
+            port: 2,
+            handle: 7,
+            bytes: vec![0x1b, 0x30],
+            site: CallSite::new("Demo.Send.m1scr", 42),
+        });
+
+        let json: serde_json::Value =
+            serde_json::from_str(&trace.to_json()).expect("serial trace is valid JSON");
+        assert_eq!(
+            json["serial"],
+            serde_json::json!([{
+                "direction": "tx",
+                "time_s": 0.25,
+                "phase": "periodic",
+                "base_tick": 25,
+                "port": 2,
+                "handle": 7,
+                "bytes": [27, 48],
+                "script": "Demo.Send.m1scr",
+                "offset": 42
+            }])
+        );
+        assert_eq!(trace.to_csv(), "time,Out\n0.25,1\n");
     }
 }

--- a/src/virtual_serial.rs
+++ b/src/virtual_serial.rs
@@ -1,0 +1,1461 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Deterministic RS232 byte-buffer model for the `Serial` library.
+//!
+//! The model implements RS232 operations grounded in the pinned intrinsic
+//! catalogue and the M1 Development Manual's examples, plus the explicit
+//! evaluator contracts documented for behavior those sources do not settle. LIN
+//! and nonzero protocol configurations fail clearly instead of inheriting a
+//! generic zero stub. Handles are stable per source call site, nonzero M1 unsigned
+//! values, and own independent receive cursors plus separate receive/transmit
+//! buffers.
+
+use crate::env::CallSite;
+use crate::error::EvalError;
+use crate::hardware::HardwareCall;
+use crate::scenario::SerialScenario;
+use crate::trace::{SerialDirection, SerialEvent};
+use crate::value::{M1Scalar, Value};
+use std::collections::BTreeMap;
+
+const BUFFER_BYTES: usize = 256;
+
+/// Methods implemented by the deterministic RS232 model.
+pub(crate) const ADAPTER_BACKED_METHODS: &[&str] = &[
+    "GetFloat",
+    "GetHandle",
+    "GetInteger",
+    "GetTransmitHandle",
+    "GetUnsignedInteger",
+    "PortDiagnostic",
+    "PortInit",
+    "Receive",
+    "SetFloat",
+    "SetInteger",
+    "SetString",
+    "SetUnsignedInteger",
+    "Sum8",
+    "Transmit",
+    "XOR8",
+];
+
+/// Catalogue methods deliberately rejected by the virtual adapter.
+pub(crate) const UNSUPPORTED_METHODS: &[&str] = &["GetLinOffset", "LinDump", "SetLinHeader"];
+
+pub(crate) fn is_adapter_backed(method: &str) -> bool {
+    ADAPTER_BACKED_METHODS.contains(&method)
+}
+
+pub(crate) fn is_explicitly_unsupported(method: &str) -> bool {
+    UNSUPPORTED_METHODS.contains(&method)
+}
+
+/// Result of one virtual serial call. Only byte transfers carry an event.
+#[derive(Debug)]
+pub(crate) struct SerialReply {
+    pub(crate) value: Value,
+    pub(crate) event: Option<SerialEvent>,
+    pub(crate) external: bool,
+}
+
+impl SerialReply {
+    fn value(value: Value) -> Self {
+        SerialReply {
+            value,
+            event: None,
+            external: false,
+        }
+    }
+
+    fn external_value(value: Value) -> Self {
+        SerialReply {
+            value,
+            event: None,
+            external: true,
+        }
+    }
+
+    fn event(value: Value, event: SerialEvent, external: bool) -> Self {
+        SerialReply {
+            value,
+            event: Some(event),
+            external,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Injection {
+    time_s: f64,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PortConfig {
+    baud: i32,
+    protocol: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActiveBuffer {
+    Receive,
+    Transmit,
+}
+
+#[derive(Debug, Clone)]
+struct HandleState {
+    big_endian: bool,
+    receive: Vec<u8>,
+    transmit: Vec<u8>,
+    receive_cursors: BTreeMap<i32, usize>,
+    active: ActiveBuffer,
+}
+
+impl HandleState {
+    fn new(big_endian: bool) -> Self {
+        HandleState {
+            big_endian,
+            receive: Vec::new(),
+            transmit: vec![0; BUFFER_BYTES],
+            receive_cursors: BTreeMap::new(),
+            active: ActiveBuffer::Transmit,
+        }
+    }
+
+    fn active_bytes(&self) -> &[u8] {
+        match self.active {
+            ActiveBuffer::Receive => &self.receive,
+            ActiveBuffer::Transmit => &self.transmit,
+        }
+    }
+}
+
+/// Fresh per-run state for deterministic virtual serial ports.
+pub(crate) struct VirtualSerial {
+    injections: BTreeMap<i32, Vec<Injection>>,
+    ports: BTreeMap<i32, PortConfig>,
+    handles: BTreeMap<u32, HandleState>,
+    site_handles: BTreeMap<(CallSite, String), u32>,
+    next_handle: u32,
+}
+
+impl VirtualSerial {
+    pub(crate) fn new(scenario: &SerialScenario) -> Result<Self, EvalError> {
+        let mut injections: BTreeMap<i32, Vec<Injection>> = BTreeMap::new();
+        for (index, entry) in scenario.rx.iter().enumerate() {
+            if !entry.time_s.is_finite() || entry.time_s < 0.0 {
+                return Err(EvalError::UnsupportedConstruct {
+                    kind: format!(
+                        "serial rx declaration {} has invalid time_s {} (expected a finite, non-negative time)",
+                        index + 1,
+                        entry.time_s
+                    ),
+                    at: 0,
+                });
+            }
+            if entry.port < 0 {
+                return Err(EvalError::UnsupportedConstruct {
+                    kind: format!(
+                        "serial rx declaration {} has negative port {}",
+                        index + 1,
+                        entry.port
+                    ),
+                    at: 0,
+                });
+            }
+            if entry.bytes.len() > BUFFER_BYTES {
+                return Err(EvalError::UnsupportedConstruct {
+                    kind: format!(
+                        "serial rx declaration {} has {} bytes, exceeding the {BUFFER_BYTES}-byte receive buffer",
+                        index + 1,
+                        entry.bytes.len()
+                    ),
+                    at: 0,
+                });
+            }
+            injections.entry(entry.port).or_default().push(Injection {
+                time_s: entry.time_s,
+                bytes: entry.bytes.clone(),
+            });
+        }
+        for entries in injections.values_mut() {
+            // `SerialScenario` is public and can be built directly, bypassing
+            // wire normalization. Stable sorting here keeps that API just as
+            // deterministic as TOML/JSON parsing.
+            entries.sort_by(|left, right| left.time_s.total_cmp(&right.time_s));
+        }
+        Ok(VirtualSerial {
+            injections,
+            ports: BTreeMap::new(),
+            handles: BTreeMap::new(),
+            site_handles: BTreeMap::new(),
+            next_handle: 1,
+        })
+    }
+
+    pub(crate) fn empty() -> Self {
+        VirtualSerial::new(&SerialScenario::default())
+            .expect("the empty virtual serial scenario is valid")
+    }
+
+    /// Handle one known `Serial` method. Unknown methods return `None` so the
+    /// normal fail-loud builtin boundary remains authoritative.
+    pub(crate) fn call(
+        &mut self,
+        method: &str,
+        call: &HardwareCall,
+    ) -> Result<Option<SerialReply>, EvalError> {
+        let reply = match method {
+            "GetHandle" | "GetTransmitHandle" => {
+                let big_endian = bool_arg(call, 0)?;
+                SerialReply::value(Value::m1_unsigned(self.open_handle(
+                    call.site.clone(),
+                    method,
+                    big_endian,
+                )?))
+            }
+            "PortInit" => {
+                let port = port_arg(call, 0)?;
+                let baud = positive_integer_arg(call, 1, "baud")?;
+                if !matches!(
+                    baud,
+                    1_200 | 1_800 | 2_400 | 4_800 | 9_600 | 19_200 | 38_400 | 57_600 | 115_200
+                ) {
+                    return Err(serial_error(
+                        method,
+                        format!(
+                            "baud {baud} is unsupported; expected one of 1200, 1800, 2400, 4800, 9600, 19200, 38400, 57600, or 115200"
+                        ),
+                    ));
+                }
+                let protocol = integer_arg(call, 2)?;
+                if protocol != 0 {
+                    return Err(serial_error(
+                        method,
+                        format!(
+                            "protocol {protocol} is unsupported; the virtual adapter implements RS232 protocol 0 only"
+                        ),
+                    ));
+                }
+                let requested = PortConfig { baud, protocol };
+                if let Some(existing) = self.ports.get(&port) {
+                    if *existing != requested {
+                        return Err(serial_error(
+                            method,
+                            format!(
+                                "port {port} is already initialized at baud {} with protocol {}; requested baud {baud}, protocol {protocol}",
+                                existing.baud, existing.protocol
+                            ),
+                        ));
+                    }
+                } else {
+                    self.ports.insert(port, requested);
+                }
+                SerialReply::value(Value::Bool(true))
+            }
+            "PortDiagnostic" => {
+                let port = port_arg(call, 0)?;
+                // Both pinned catalogue enums agree that zero means Not in Use
+                // and one means OK. Their other diagnostic codes conflict, so
+                // the virtual adapter deliberately reports only these two.
+                let status = if self.ports.contains_key(&port) { 1 } else { 0 };
+                SerialReply::value(Value::m1_integer(status))
+            }
+            "Receive" => self.receive(call)?,
+            "Transmit" => self.transmit(call)?,
+            "GetInteger" => {
+                let handle = handle_arg(call, 0)?;
+                let offset = offset_arg(call, 1)?;
+                let length = integer_width(call, 2)?;
+                let state = self.handle(method, handle)?;
+                let bytes = receive_range(method, state, offset, length)?;
+                let raw = decode(bytes, state.big_endian);
+                let shift = 32 - length * 8;
+                SerialReply::external_value(Value::m1_integer(((raw << shift) as i32) >> shift))
+            }
+            "GetUnsignedInteger" => {
+                let handle = handle_arg(call, 0)?;
+                let offset = offset_arg(call, 1)?;
+                let length = integer_width(call, 2)?;
+                let state = self.handle(method, handle)?;
+                let bytes = receive_range(method, state, offset, length)?;
+                // The pinned catalogue declares Integer even for this unsigned
+                // operation. Preserve all 32 bits in that signed storage family.
+                SerialReply::external_value(Value::m1_integer(
+                    decode(bytes, state.big_endian) as i32
+                ))
+            }
+            "GetFloat" => {
+                let handle = handle_arg(call, 0)?;
+                let offset = offset_arg(call, 1)?;
+                let state = self.handle(method, handle)?;
+                let bytes = receive_range(method, state, offset, 4)?;
+                SerialReply::external_value(Value::m1_float(f32::from_bits(decode(
+                    bytes,
+                    state.big_endian,
+                ))))
+            }
+            "SetInteger" => {
+                let handle = handle_arg(call, 0)?;
+                let offset = offset_arg(call, 1)?;
+                let length = integer_width(call, 2)?;
+                let value = integer_arg(call, 3)? as u32;
+                let state = self.handle_mut(method, handle)?;
+                write_integer(method, state, offset, length, value)?;
+                SerialReply::value(Value::m1_integer((offset + length) as i32))
+            }
+            "SetUnsignedInteger" => {
+                let handle = handle_arg(call, 0)?;
+                let offset = offset_arg(call, 1)?;
+                let length = integer_width(call, 2)?;
+                let value = unsigned_bits_arg(call, 3)?;
+                let state = self.handle_mut(method, handle)?;
+                write_integer(method, state, offset, length, value)?;
+                SerialReply::value(Value::m1_integer((offset + length) as i32))
+            }
+            "SetFloat" => {
+                let handle = handle_arg(call, 0)?;
+                let offset = offset_arg(call, 1)?;
+                let value = float_arg(call, 2)?;
+                let state = self.handle_mut(method, handle)?;
+                write_integer(method, state, offset, 4, value.to_bits())?;
+                SerialReply::value(Value::m1_integer((offset + 4) as i32))
+            }
+            "SetString" => {
+                let handle = handle_arg(call, 0)?;
+                let offset = offset_arg(call, 1)?;
+                let length = nonnegative_length(call, 2)?;
+                let text = string_arg(call, 3)?;
+                if !text.is_ascii() {
+                    return Err(serial_error(
+                        method,
+                        "text must be ASCII for the deterministic RS232 byte subset",
+                    ));
+                }
+                if text.len() != length {
+                    return Err(serial_error(
+                        method,
+                        format!(
+                            "length {length} does not match the ASCII text length {}",
+                            text.len()
+                        ),
+                    ));
+                }
+                let state = self.handle_mut(method, handle)?;
+                let range = buffer_range(method, offset, length, BUFFER_BYTES)?;
+                state.transmit[range].copy_from_slice(text.as_bytes());
+                state.active = ActiveBuffer::Transmit;
+                SerialReply::value(Value::m1_integer((offset + length) as i32))
+            }
+            "Sum8" | "XOR8" => {
+                let handle = handle_arg(call, 0)?;
+                let offset = offset_arg(call, 1)?;
+                let length = nonnegative_length(call, 2)?;
+                let state = self.handle(method, handle)?;
+                let active = state.active_bytes();
+                let range = buffer_range(method, offset, length, active.len())?;
+                let result = if method == "Sum8" {
+                    active[range]
+                        .iter()
+                        .fold(0_u8, |sum, byte| sum.wrapping_add(*byte))
+                } else {
+                    active[range].iter().fold(0_u8, |xor, byte| xor ^ byte)
+                };
+                let value = Value::m1_integer(i32::from(result));
+                if state.active == ActiveBuffer::Receive {
+                    SerialReply::external_value(value)
+                } else {
+                    SerialReply::value(value)
+                }
+            }
+            method if is_explicitly_unsupported(method) => {
+                return Err(EvalError::UnsupportedBuiltin {
+                    object: call.source_receiver.clone(),
+                    method: method.to_string(),
+                });
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(reply))
+    }
+
+    fn open_handle(
+        &mut self,
+        site: CallSite,
+        method: &str,
+        big_endian: bool,
+    ) -> Result<u32, EvalError> {
+        let key = (site, method.to_string());
+        if let Some(handle) = self.site_handles.get(&key).copied() {
+            let state = self
+                .handles
+                .get(&handle)
+                .expect("site handle always has handle state");
+            if state.big_endian != big_endian {
+                return Err(serial_error(
+                    method,
+                    format!(
+                        "call site already opened handle {handle} with bigendian={}, then requested bigendian={big_endian}",
+                        state.big_endian
+                    ),
+                ));
+            }
+            return Ok(handle);
+        }
+        let handle = self.next_handle;
+        self.next_handle = self.next_handle.checked_add(1).ok_or_else(|| {
+            serial_error(method, "exhausted the nonzero 32-bit serial handle space")
+        })?;
+        self.site_handles.insert(key, handle);
+        self.handles.insert(handle, HandleState::new(big_endian));
+        Ok(handle)
+    }
+
+    fn handle(&self, method: &str, handle: u32) -> Result<&HandleState, EvalError> {
+        self.handles.get(&handle).ok_or_else(|| {
+            serial_error(
+                method,
+                format!("invalid handle {handle}; handles are nonzero and owned by this run"),
+            )
+        })
+    }
+
+    fn handle_mut(&mut self, method: &str, handle: u32) -> Result<&mut HandleState, EvalError> {
+        self.handles.get_mut(&handle).ok_or_else(|| {
+            serial_error(
+                method,
+                format!("invalid handle {handle}; handles are nonzero and owned by this run"),
+            )
+        })
+    }
+
+    fn receive(&mut self, call: &HardwareCall) -> Result<SerialReply, EvalError> {
+        let method = "Receive";
+        let handle = handle_arg(call, 0)?;
+        let port = port_arg(call, 1)?;
+        self.require_initialized(method, port)?;
+        let cursor = self
+            .handle(method, handle)?
+            .receive_cursors
+            .get(&port)
+            .copied()
+            .unwrap_or(0);
+        let injections = self.injections.get(&port).map(Vec::as_slice).unwrap_or(&[]);
+        let end = injections[cursor..]
+            .iter()
+            .take_while(|entry| entry.time_s <= call.time.elapsed_s)
+            .count()
+            + cursor;
+        let bytes = injections[cursor..end]
+            .iter()
+            .flat_map(|entry| entry.bytes.iter().copied())
+            .collect::<Vec<_>>();
+        if bytes.len() > BUFFER_BYTES {
+            return Err(serial_error(
+                method,
+                format!(
+                    "{len} pending bytes on port {port} exceed the {BUFFER_BYTES}-byte receive buffer for handle {handle}",
+                    len = bytes.len()
+                ),
+            ));
+        }
+
+        let state = self.handle_mut(method, handle)?;
+        state.receive.clear();
+        state.receive.extend_from_slice(&bytes);
+        state.receive_cursors.insert(port, end);
+        state.active = ActiveBuffer::Receive;
+        if bytes.is_empty() {
+            return Ok(SerialReply::external_value(Value::Bool(false)));
+        }
+        Ok(SerialReply::event(
+            Value::Bool(true),
+            SerialEvent {
+                direction: SerialDirection::Rx,
+                time: call.time,
+                port,
+                handle,
+                bytes,
+                site: call.site.clone(),
+            },
+            true,
+        ))
+    }
+
+    fn transmit(&mut self, call: &HardwareCall) -> Result<SerialReply, EvalError> {
+        let method = "Transmit";
+        let handle = handle_arg(call, 0)?;
+        let port = port_arg(call, 1)?;
+        let length = nonnegative_length(call, 2)?;
+        self.require_initialized(method, port)?;
+        let state = self.handle(method, handle)?;
+        let range = buffer_range(method, 0, length, state.transmit.len())?;
+        Ok(SerialReply::event(
+            Value::Bool(true),
+            SerialEvent {
+                direction: SerialDirection::Tx,
+                time: call.time,
+                port,
+                handle,
+                bytes: state.transmit[range].to_vec(),
+                site: call.site.clone(),
+            },
+            false,
+        ))
+    }
+
+    fn require_initialized(&self, method: &str, port: i32) -> Result<(), EvalError> {
+        if self.ports.contains_key(&port) {
+            Ok(())
+        } else {
+            Err(serial_error(
+                method,
+                format!("port {port} is not initialized; call Serial.PortInit first"),
+            ))
+        }
+    }
+}
+
+fn receive_range<'a>(
+    method: &str,
+    state: &'a HandleState,
+    offset: usize,
+    length: usize,
+) -> Result<&'a [u8], EvalError> {
+    let range = buffer_range(method, offset, length, state.receive.len())?;
+    Ok(&state.receive[range])
+}
+
+fn write_integer(
+    method: &str,
+    state: &mut HandleState,
+    offset: usize,
+    length: usize,
+    value: u32,
+) -> Result<(), EvalError> {
+    let range = buffer_range(method, offset, length, state.transmit.len())?;
+    let bytes = if state.big_endian {
+        value.to_be_bytes()[4 - length..].to_vec()
+    } else {
+        value.to_le_bytes()[..length].to_vec()
+    };
+    state.transmit[range].copy_from_slice(&bytes);
+    state.active = ActiveBuffer::Transmit;
+    Ok(())
+}
+
+fn decode(bytes: &[u8], big_endian: bool) -> u32 {
+    if big_endian {
+        bytes
+            .iter()
+            .fold(0_u32, |value, byte| (value << 8) | u32::from(*byte))
+    } else {
+        bytes
+            .iter()
+            .enumerate()
+            .fold(0_u32, |value, (shift, byte)| {
+                value | (u32::from(*byte) << (shift * 8))
+            })
+    }
+}
+
+fn buffer_range(
+    method: &str,
+    offset: usize,
+    length: usize,
+    available: usize,
+) -> Result<std::ops::Range<usize>, EvalError> {
+    let end = offset.checked_add(length).ok_or_else(|| {
+        serial_error(
+            method,
+            format!("offset {offset} plus length {length} overflows the buffer index"),
+        )
+    })?;
+    if end > available {
+        return Err(serial_error(
+            method,
+            format!("byte range {offset}..{end} exceeds the available buffer length {available}"),
+        ));
+    }
+    Ok(offset..end)
+}
+
+fn handle_arg(call: &HardwareCall, index: usize) -> Result<u32, EvalError> {
+    match call.arguments.get(index) {
+        Some(Value::M1(M1Scalar::UnsignedInteger(handle))) => Ok(*handle),
+        Some(value) => Err(serial_error(
+            &call.method,
+            format!("argument {} must be an M1 Handle, got {value:?}", index + 1),
+        )),
+        None => Err(missing_arg(call, index)),
+    }
+}
+
+fn integer_arg(call: &HardwareCall, index: usize) -> Result<i32, EvalError> {
+    match call.arguments.get(index) {
+        Some(Value::M1(M1Scalar::Integer(value))) => Ok(*value),
+        Some(value) => Err(serial_error(
+            &call.method,
+            format!(
+                "argument {} must be an M1 Integer, got {value:?}",
+                index + 1
+            ),
+        )),
+        None => Err(missing_arg(call, index)),
+    }
+}
+
+/// The catalogue declares `SetUnsignedInteger.value` as Integer, while its name
+/// and the official hexadecimal example also admit unsigned 32-bit values.
+/// Preserve either M1 integer family's bits at this one boundary.
+fn unsigned_bits_arg(call: &HardwareCall, index: usize) -> Result<u32, EvalError> {
+    match call.arguments.get(index) {
+        Some(Value::M1(M1Scalar::Integer(value))) => Ok(*value as u32),
+        Some(Value::M1(M1Scalar::UnsignedInteger(value))) => Ok(*value),
+        Some(value) => Err(serial_error(
+            &call.method,
+            format!(
+                "argument {} must be an M1 Integer or UnsignedInteger, got {value:?}",
+                index + 1
+            ),
+        )),
+        None => Err(missing_arg(call, index)),
+    }
+}
+
+fn positive_integer_arg(call: &HardwareCall, index: usize, name: &str) -> Result<i32, EvalError> {
+    let value = integer_arg(call, index)?;
+    if value > 0 {
+        Ok(value)
+    } else {
+        Err(serial_error(
+            &call.method,
+            format!("{name} must be positive, got {value}"),
+        ))
+    }
+}
+
+fn port_arg(call: &HardwareCall, index: usize) -> Result<i32, EvalError> {
+    let port = integer_arg(call, index)?;
+    if port >= 0 {
+        Ok(port)
+    } else {
+        Err(serial_error(
+            &call.method,
+            format!("port must be non-negative, got {port}"),
+        ))
+    }
+}
+
+fn offset_arg(call: &HardwareCall, index: usize) -> Result<usize, EvalError> {
+    let offset = integer_arg(call, index)?;
+    usize::try_from(offset).map_err(|_| {
+        serial_error(
+            &call.method,
+            format!("offset must be non-negative, got {offset}"),
+        )
+    })
+}
+
+fn nonnegative_length(call: &HardwareCall, index: usize) -> Result<usize, EvalError> {
+    let length = integer_arg(call, index)?;
+    usize::try_from(length).map_err(|_| {
+        serial_error(
+            &call.method,
+            format!("length must be non-negative, got {length}"),
+        )
+    })
+}
+
+fn integer_width(call: &HardwareCall, index: usize) -> Result<usize, EvalError> {
+    let length = nonnegative_length(call, index)?;
+    if (1..=4).contains(&length) {
+        Ok(length)
+    } else {
+        Err(serial_error(
+            &call.method,
+            format!("integer length must be in 1..=4 bytes, got {length}"),
+        ))
+    }
+}
+
+fn bool_arg(call: &HardwareCall, index: usize) -> Result<bool, EvalError> {
+    match call.arguments.get(index) {
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(value) => Err(serial_error(
+            &call.method,
+            format!("argument {} must be Boolean, got {value:?}", index + 1),
+        )),
+        None => Err(missing_arg(call, index)),
+    }
+}
+
+fn float_arg(call: &HardwareCall, index: usize) -> Result<f32, EvalError> {
+    match call.arguments.get(index) {
+        Some(Value::M1(M1Scalar::FloatingPoint(value))) => Ok(*value),
+        Some(value) => Err(serial_error(
+            &call.method,
+            format!(
+                "argument {} must be M1 FloatingPoint, got {value:?}",
+                index + 1
+            ),
+        )),
+        None => Err(missing_arg(call, index)),
+    }
+}
+
+fn string_arg(call: &HardwareCall, index: usize) -> Result<&str, EvalError> {
+    match call.arguments.get(index) {
+        Some(Value::Str(value)) => Ok(value),
+        Some(value) => Err(serial_error(
+            &call.method,
+            format!("argument {} must be String, got {value:?}", index + 1),
+        )),
+        None => Err(missing_arg(call, index)),
+    }
+}
+
+fn missing_arg(call: &HardwareCall, index: usize) -> EvalError {
+    serial_error(&call.method, format!("missing argument {}", index + 1))
+}
+
+fn serial_error(method: &str, detail: impl Into<String>) -> EvalError {
+    EvalError::BadCall {
+        detail: format!("Serial.{method}: {}", detail.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hardware::{EvalTime, ResolvedReceiver};
+    use crate::scenario::SerialRx;
+
+    fn call(method: &str, site: usize, arguments: Vec<Value>, t: f64) -> HardwareCall {
+        HardwareCall {
+            receiver: ResolvedReceiver::Library {
+                object: "Serial".to_string(),
+            },
+            source_receiver: "Serial".to_string(),
+            method: method.to_string(),
+            site: CallSite::new("Serial.Test.m1scr", site),
+            arguments,
+            time: EvalTime::periodic((t * 100.0) as u64, t, 0.01, 0.01),
+        }
+    }
+
+    fn invoke(
+        serial: &mut VirtualSerial,
+        method: &str,
+        site: usize,
+        arguments: Vec<Value>,
+        t: f64,
+    ) -> Result<SerialReply, EvalError> {
+        serial
+            .call(method, &call(method, site, arguments, t))?
+            .ok_or_else(|| serial_error(method, "test method was not handled"))
+    }
+
+    fn open(serial: &mut VirtualSerial, site: usize, big_endian: bool) -> u32 {
+        let reply = invoke(
+            serial,
+            "GetHandle",
+            site,
+            vec![Value::Bool(big_endian)],
+            0.0,
+        )
+        .expect("handle opens");
+        match reply.value {
+            Value::M1(M1Scalar::UnsignedInteger(handle)) => handle,
+            other => panic!("unexpected handle {other:?}"),
+        }
+    }
+
+    fn init(serial: &mut VirtualSerial, port: i32) {
+        invoke(
+            serial,
+            "PortInit",
+            90,
+            vec![
+                Value::m1_integer(port),
+                Value::m1_integer(115_200),
+                Value::m1_integer(0),
+            ],
+            0.0,
+        )
+        .expect("port initializes");
+    }
+
+    #[test]
+    fn handles_are_nonzero_stable_and_independent_per_site() {
+        let mut serial = VirtualSerial::empty();
+        let first = open(&mut serial, 10, true);
+        let repeated = open(&mut serial, 10, true);
+        let second = open(&mut serial, 20, true);
+        assert_ne!(first, 0);
+        assert_eq!(first, repeated);
+        assert_ne!(first, second);
+
+        let mut fresh = VirtualSerial::empty();
+        assert_eq!(open(&mut fresh, 10, true), first);
+        assert_eq!(open(&mut fresh, 20, true), second);
+    }
+
+    #[test]
+    fn receivers_on_one_port_have_independent_cursors_and_flushes() {
+        let scenario = SerialScenario {
+            rx: vec![
+                SerialRx {
+                    time_s: 0.0,
+                    port: 0,
+                    bytes: vec![1, 2],
+                },
+                SerialRx {
+                    time_s: 0.1,
+                    port: 0,
+                    bytes: vec![3],
+                },
+            ],
+        };
+        let mut serial = VirtualSerial::new(&scenario).expect("valid serial scenario");
+        init(&mut serial, 0);
+        let a = open(&mut serial, 10, true);
+        let b = open(&mut serial, 20, true);
+        for handle in [a, b] {
+            let reply = invoke(
+                &mut serial,
+                "Receive",
+                30 + handle as usize,
+                vec![Value::m1_unsigned(handle), Value::m1_integer(0)],
+                0.0,
+            )
+            .expect("each handle independently receives the first chunk");
+            assert_eq!(reply.value, Value::Bool(true));
+            assert_eq!(reply.event.expect("rx event").bytes, vec![1, 2]);
+        }
+        let empty = invoke(
+            &mut serial,
+            "Receive",
+            40,
+            vec![Value::m1_unsigned(a), Value::m1_integer(0)],
+            0.05,
+        )
+        .expect("empty receive succeeds");
+        assert_eq!(empty.value, Value::Bool(false));
+        let later = invoke(
+            &mut serial,
+            "Receive",
+            40,
+            vec![Value::m1_unsigned(a), Value::m1_integer(0)],
+            0.1,
+        )
+        .expect("later chunk arrives");
+        assert_eq!(later.event.expect("rx event").bytes, vec![3]);
+    }
+
+    #[test]
+    fn endian_integer_float_and_string_writes_produce_wire_bytes() {
+        for (big_endian, expected) in [
+            (
+                true,
+                vec![0x30, 0x35, 0x3f, 0xc0, 0, 0, b'O', b'K', 0xff, 0xfe],
+            ),
+            (
+                false,
+                vec![0x35, 0x30, 0, 0, 0xc0, 0x3f, b'O', b'K', 0xfe, 0xff],
+            ),
+        ] {
+            let mut serial = VirtualSerial::empty();
+            init(&mut serial, 0);
+            let handle = open(&mut serial, 10, big_endian);
+            invoke(
+                &mut serial,
+                "SetUnsignedInteger",
+                20,
+                vec![
+                    Value::m1_unsigned(handle),
+                    Value::m1_integer(0),
+                    Value::m1_integer(2),
+                    Value::m1_integer(0x3035),
+                ],
+                0.0,
+            )
+            .expect("integer writes");
+            invoke(
+                &mut serial,
+                "SetFloat",
+                30,
+                vec![
+                    Value::m1_unsigned(handle),
+                    Value::m1_integer(2),
+                    Value::m1_float(1.5),
+                ],
+                0.0,
+            )
+            .expect("float writes");
+            invoke(
+                &mut serial,
+                "SetString",
+                40,
+                vec![
+                    Value::m1_unsigned(handle),
+                    Value::m1_integer(6),
+                    Value::m1_integer(2),
+                    Value::Str("OK".to_string()),
+                ],
+                0.0,
+            )
+            .expect("string writes");
+            invoke(
+                &mut serial,
+                "SetInteger",
+                45,
+                vec![
+                    Value::m1_unsigned(handle),
+                    Value::m1_integer(8),
+                    Value::m1_integer(2),
+                    Value::m1_integer(-2),
+                ],
+                0.0,
+            )
+            .expect("signed integer writes");
+            let tx = invoke(
+                &mut serial,
+                "Transmit",
+                50,
+                vec![
+                    Value::m1_unsigned(handle),
+                    Value::m1_integer(0),
+                    Value::m1_integer(10),
+                ],
+                0.25,
+            )
+            .expect("transmit succeeds")
+            .event
+            .expect("tx event");
+            assert_eq!(tx.bytes, expected);
+            assert_eq!(tx.time.elapsed_s, 0.25);
+            assert_eq!(tx.site.offset(), 50);
+        }
+    }
+
+    #[test]
+    fn checksums_follow_the_explicit_active_buffer_contract_and_provenance() {
+        let scenario = SerialScenario {
+            rx: vec![SerialRx {
+                time_s: 0.0,
+                port: 0,
+                bytes: vec![1, 2, 3],
+            }],
+        };
+        let mut serial = VirtualSerial::new(&scenario).expect("valid serial scenario");
+        init(&mut serial, 0);
+        let handle = open(&mut serial, 10, true);
+
+        invoke(
+            &mut serial,
+            "SetUnsignedInteger",
+            20,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(0),
+                Value::m1_integer(3),
+                Value::m1_integer(0x00fa_0a03),
+            ],
+            0.0,
+        )
+        .expect("TX bytes are written");
+        let tx_sum = invoke(
+            &mut serial,
+            "Sum8",
+            30,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(0),
+                Value::m1_integer(3),
+            ],
+            0.0,
+        )
+        .expect("TX sum succeeds");
+        let tx_xor = invoke(
+            &mut serial,
+            "XOR8",
+            31,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(0),
+                Value::m1_integer(3),
+            ],
+            0.0,
+        )
+        .expect("TX xor succeeds");
+        assert_eq!(tx_sum.value, Value::m1_integer(7));
+        assert_eq!(tx_xor.value, Value::m1_integer(0xf3));
+        assert!(!tx_sum.external);
+        assert!(!tx_xor.external);
+
+        invoke(
+            &mut serial,
+            "Receive",
+            40,
+            vec![Value::m1_unsigned(handle), Value::m1_integer(0)],
+            0.0,
+        )
+        .expect("RX bytes are delivered");
+        for (method, expected) in [("Sum8", 6), ("XOR8", 0)] {
+            let reply = invoke(
+                &mut serial,
+                method,
+                50,
+                vec![
+                    Value::m1_unsigned(handle),
+                    Value::m1_integer(0),
+                    Value::m1_integer(3),
+                ],
+                0.0,
+            )
+            .expect("RX checksum succeeds");
+            assert_eq!(reply.value, Value::m1_integer(expected));
+            assert!(reply.external, "RX-derived checksum must be external");
+        }
+    }
+
+    #[test]
+    fn endian_signed_unsigned_and_float_reads_use_receive_buffer() {
+        for (big_endian, bytes) in [
+            (
+                true,
+                vec![0xff, 0xfe, 0x89, 0xab, 0xcd, 0xef, 0x3f, 0xc0, 0, 0],
+            ),
+            (
+                false,
+                vec![0xfe, 0xff, 0xef, 0xcd, 0xab, 0x89, 0, 0, 0xc0, 0x3f],
+            ),
+        ] {
+            let scenario = SerialScenario {
+                rx: vec![SerialRx {
+                    time_s: 0.0,
+                    port: 0,
+                    bytes,
+                }],
+            };
+            let mut serial = VirtualSerial::new(&scenario).expect("valid serial scenario");
+            init(&mut serial, 0);
+            let handle = open(&mut serial, 10, big_endian);
+            invoke(
+                &mut serial,
+                "Receive",
+                20,
+                vec![Value::m1_unsigned(handle), Value::m1_integer(0)],
+                0.0,
+            )
+            .expect("receive succeeds");
+            assert_eq!(
+                invoke(
+                    &mut serial,
+                    "GetInteger",
+                    30,
+                    vec![
+                        Value::m1_unsigned(handle),
+                        Value::m1_integer(0),
+                        Value::m1_integer(2),
+                    ],
+                    0.0,
+                )
+                .expect("signed read")
+                .value,
+                Value::m1_integer(-2)
+            );
+            assert_eq!(
+                invoke(
+                    &mut serial,
+                    "GetUnsignedInteger",
+                    40,
+                    vec![
+                        Value::m1_unsigned(handle),
+                        Value::m1_integer(2),
+                        Value::m1_integer(4),
+                    ],
+                    0.0,
+                )
+                .expect("unsigned read")
+                .value,
+                Value::m1_integer(0x89ab_cdef_u32 as i32)
+            );
+            assert_eq!(
+                invoke(
+                    &mut serial,
+                    "GetFloat",
+                    50,
+                    vec![Value::m1_unsigned(handle), Value::m1_integer(6)],
+                    0.0,
+                )
+                .expect("float read")
+                .value,
+                Value::m1_float(1.5)
+            );
+        }
+    }
+
+    #[test]
+    fn status_and_invalid_configuration_fail_or_report_precisely() {
+        let mut serial = VirtualSerial::empty();
+        assert_eq!(
+            invoke(
+                &mut serial,
+                "PortDiagnostic",
+                1,
+                vec![Value::m1_integer(2)],
+                0.0,
+            )
+            .expect("uninitialized diagnostic is a status")
+            .value,
+            Value::m1_integer(0)
+        );
+        init(&mut serial, 2);
+        assert_eq!(
+            invoke(
+                &mut serial,
+                "PortDiagnostic",
+                1,
+                vec![Value::m1_integer(2)],
+                0.0,
+            )
+            .expect("initialized port reports OK")
+            .value,
+            Value::m1_integer(1)
+        );
+        let unsupported = invoke(
+            &mut serial,
+            "PortInit",
+            2,
+            vec![
+                Value::m1_integer(2),
+                Value::m1_integer(19_200),
+                Value::m1_integer(1),
+            ],
+            0.0,
+        )
+        .expect_err("LIN config fails");
+        assert!(unsupported.to_string().contains("RS232 protocol 0 only"));
+
+        let invalid = invoke(
+            &mut serial,
+            "GetInteger",
+            3,
+            vec![
+                Value::m1_unsigned(99),
+                Value::m1_integer(0),
+                Value::m1_integer(1),
+            ],
+            0.0,
+        )
+        .expect_err("unknown handle fails");
+        assert!(invalid.to_string().contains("invalid handle 99"));
+    }
+
+    #[test]
+    fn buffer_boundaries_lengths_and_receive_overflow_fail_precisely() {
+        let scenario = SerialScenario {
+            rx: vec![SerialRx {
+                time_s: 0.0,
+                port: 0,
+                bytes: (0_u16..=255).map(|byte| byte as u8).collect(),
+            }],
+        };
+        let mut serial = VirtualSerial::new(&scenario).expect("valid serial scenario");
+        init(&mut serial, 0);
+        let handle = open(&mut serial, 10, true);
+        invoke(
+            &mut serial,
+            "Receive",
+            20,
+            vec![Value::m1_unsigned(handle), Value::m1_integer(0)],
+            0.0,
+        )
+        .expect("full receive buffer fits");
+        let boundary = invoke(
+            &mut serial,
+            "GetFloat",
+            30,
+            vec![Value::m1_unsigned(handle), Value::m1_integer(252)],
+            0.0,
+        )
+        .expect("four-byte read at 252 fits");
+        assert_eq!(boundary.value, Value::m1_float(f32::from_bits(0xfcfd_feff)));
+
+        let too_far = invoke(
+            &mut serial,
+            "GetFloat",
+            31,
+            vec![Value::m1_unsigned(handle), Value::m1_integer(253)],
+            0.0,
+        )
+        .expect_err("four-byte read at 253 exceeds 256 bytes");
+        assert!(too_far.to_string().contains("253..257"));
+
+        for length in [0, 5] {
+            let error = invoke(
+                &mut serial,
+                "GetInteger",
+                32,
+                vec![
+                    Value::m1_unsigned(handle),
+                    Value::m1_integer(0),
+                    Value::m1_integer(length),
+                ],
+                0.0,
+            )
+            .expect_err("invalid integer width fails");
+            assert!(error.to_string().contains("1..=4 bytes"));
+        }
+        let negative = invoke(
+            &mut serial,
+            "GetInteger",
+            33,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(-1),
+                Value::m1_integer(1),
+            ],
+            0.0,
+        )
+        .expect_err("negative offset fails");
+        assert!(negative.to_string().contains("offset must be non-negative"));
+
+        invoke(
+            &mut serial,
+            "SetInteger",
+            34,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(255),
+                Value::m1_integer(1),
+                Value::m1_integer(-1),
+            ],
+            0.0,
+        )
+        .expect("last TX byte is writable");
+        let write_oob = invoke(
+            &mut serial,
+            "SetInteger",
+            35,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(255),
+                Value::m1_integer(2),
+                Value::m1_integer(1),
+            ],
+            0.0,
+        )
+        .expect_err("TX write beyond 256 bytes fails");
+        assert!(write_oob.to_string().contains("255..257"));
+
+        let overflow = SerialScenario {
+            rx: vec![
+                SerialRx {
+                    time_s: 0.0,
+                    port: 0,
+                    bytes: vec![1; 200],
+                },
+                SerialRx {
+                    time_s: 0.0,
+                    port: 0,
+                    bytes: vec![2; 100],
+                },
+            ],
+        };
+        let mut serial = VirtualSerial::new(&overflow).expect("each chunk fits by itself");
+        init(&mut serial, 0);
+        let handle = open(&mut serial, 10, true);
+        let error = invoke(
+            &mut serial,
+            "Receive",
+            20,
+            vec![Value::m1_unsigned(handle), Value::m1_integer(0)],
+            0.0,
+        )
+        .expect_err("pending bytes beyond buffer capacity fail");
+        assert!(error.to_string().contains("300 pending bytes"));
+    }
+
+    #[test]
+    fn ports_are_isolated_and_direct_scenarios_are_sorted() {
+        let scenario = SerialScenario {
+            rx: vec![
+                SerialRx {
+                    time_s: 0.1,
+                    port: 0,
+                    bytes: vec![3],
+                },
+                SerialRx {
+                    time_s: 0.0,
+                    port: 1,
+                    bytes: vec![9],
+                },
+                SerialRx {
+                    time_s: 0.0,
+                    port: 0,
+                    bytes: vec![1],
+                },
+                SerialRx {
+                    time_s: 0.1,
+                    port: 0,
+                    bytes: vec![4],
+                },
+            ],
+        };
+        let mut serial = VirtualSerial::new(&scenario).expect("valid direct serial scenario");
+        init(&mut serial, 0);
+        init(&mut serial, 1);
+        let handle = open(&mut serial, 10, true);
+        let port_one = invoke(
+            &mut serial,
+            "Receive",
+            20,
+            vec![Value::m1_unsigned(handle), Value::m1_integer(1)],
+            0.0,
+        )
+        .expect("port one receives")
+        .event
+        .expect("port one event");
+        assert_eq!(port_one.bytes, vec![9]);
+        let port_zero = invoke(
+            &mut serial,
+            "Receive",
+            21,
+            vec![Value::m1_unsigned(handle), Value::m1_integer(0)],
+            0.1,
+        )
+        .expect("port zero receives independently")
+        .event
+        .expect("port zero event");
+        assert_eq!(port_zero.bytes, vec![1, 3, 4]);
+    }
+
+    #[test]
+    fn port_init_is_idempotent_and_rejects_unknown_or_conflicting_config() {
+        let mut serial = VirtualSerial::empty();
+        init(&mut serial, 0);
+        init(&mut serial, 0);
+
+        let conflicting = invoke(
+            &mut serial,
+            "PortInit",
+            90,
+            vec![
+                Value::m1_integer(0),
+                Value::m1_integer(9_600),
+                Value::m1_integer(0),
+            ],
+            0.0,
+        )
+        .expect_err("conflicting reconfiguration fails");
+        assert!(conflicting.to_string().contains("already initialized"));
+
+        let unknown_baud = invoke(
+            &mut serial,
+            "PortInit",
+            91,
+            vec![
+                Value::m1_integer(1),
+                Value::m1_integer(12_345),
+                Value::m1_integer(0),
+            ],
+            0.0,
+        )
+        .expect_err("unknown baud fails");
+        assert!(
+            unknown_baud
+                .to_string()
+                .contains("baud 12345 is unsupported")
+        );
+
+        let handle = open(&mut serial, 12, true);
+        let uninitialized = invoke(
+            &mut serial,
+            "Transmit",
+            92,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(2),
+                Value::m1_integer(0),
+            ],
+            0.0,
+        )
+        .expect_err("uninitialized port fails");
+        assert!(
+            uninitialized
+                .to_string()
+                .contains("port 2 is not initialized")
+        );
+    }
+
+    #[test]
+    fn tx_events_are_snapshots_and_lin_methods_are_unsupported() {
+        let mut serial = VirtualSerial::empty();
+        init(&mut serial, 0);
+        let handle = open(&mut serial, 10, true);
+        invoke(
+            &mut serial,
+            "SetUnsignedInteger",
+            20,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(0),
+                Value::m1_integer(1),
+                Value::m1_integer(1),
+            ],
+            0.0,
+        )
+        .expect("first write");
+        let first = invoke(
+            &mut serial,
+            "Transmit",
+            30,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(0),
+                Value::m1_integer(1),
+            ],
+            0.0,
+        )
+        .expect("first transmit")
+        .event
+        .expect("first tx event");
+        invoke(
+            &mut serial,
+            "SetUnsignedInteger",
+            20,
+            vec![
+                Value::m1_unsigned(handle),
+                Value::m1_integer(0),
+                Value::m1_integer(1),
+                Value::m1_integer(2),
+            ],
+            0.1,
+        )
+        .expect("later write");
+        assert_eq!(first.bytes, vec![1], "event retained its byte snapshot");
+
+        for method in UNSUPPORTED_METHODS {
+            let arguments = match *method {
+                "GetLinOffset" => vec![Value::m1_unsigned(handle), Value::m1_integer(1)],
+                "LinDump" => vec![Value::m1_unsigned(handle)],
+                "SetLinHeader" => vec![
+                    Value::m1_unsigned(handle),
+                    Value::m1_integer(0),
+                    Value::m1_integer(1),
+                    Value::m1_integer(1),
+                    Value::Bool(false),
+                    Value::Bool(false),
+                ],
+                _ => unreachable!(),
+            };
+            assert!(matches!(
+                invoke(&mut serial, method, 40, arguments, 0.0),
+                Err(EvalError::UnsupportedBuiltin { object, method: rejected })
+                    if object == "Serial" && rejected == *method
+            ));
+        }
+    }
+}

--- a/tests/evm1_smoke.rs
+++ b/tests/evm1_smoke.rs
@@ -403,7 +403,7 @@ const = {{ unsigned = 2097152 }}
         "{label}: the offline bus supplied no receive calls"
     );
     eprintln!(
-        "{label}: {} adapter-backed receive substitution(s)",
+        "{label}: {} external-adapter receive substitution(s)",
         bus_substitutions.len()
     );
     for item in bus_substitutions {

--- a/tests/fixtures/serial/Project.m1prj
+++ b/tests/fixtures/serial/Project.m1prj
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!-- Synthetic virtual-serial fixture. No proprietary or captured data. -->
+<MoTeCM1BuildSession>
+ <Project Name="Virtual Serial" TargetHardware="ecu120">
+  <ComponentStream><List>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Serial Test"/>
+   <Component Classname="BuiltIn.GroupCompound" Name="Root.Events"/>
+   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On 100Hz"/>
+   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On 50Hz"/>
+   <Component Classname="BuiltIn.EventKernel" Name="Root.Events.On Startup"/>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Init OK"><Props Type="bool"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Diagnostic"><Props Type="i32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Startup Byte"><Props Type="i32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Handle A"><Props Type="u32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Handle B"><Props Type="u32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Available A"><Props Type="bool"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Available B"><Props Type="bool"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Byte A"><Props Type="i32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Byte B"><Props Type="i32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Nested Byte"><Props Type="i32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Tx Offset"><Props Type="i32"/></Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Serial Test.Init.m1scr" Name="Root.Serial Test.Init">
+    <Props SelectedTrigger="Root.Events.On Startup"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Serial Test.Startup Receive.m1scr" Name="Root.Serial Test.Startup Receive">
+    <Props SelectedTrigger="Root.Events.On Startup"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Serial Test.Receive A.m1scr" Name="Root.Serial Test.Receive A">
+    <Props SelectedTrigger="Root.Events.On 100Hz"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Serial Test.Receive B.m1scr" Name="Root.Serial Test.Receive B">
+    <Props SelectedTrigger="Root.Events.On 50Hz"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Serial Test.Nested.m1scr" Name="Root.Serial Test.Nested">
+    <Props SelectedTrigger="Root.Events.On 50Hz"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Serial Test.Transmit.m1scr" Name="Root.Serial Test.Transmit">
+    <Props SelectedTrigger="Root.Events.On 50Hz"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUserParam" Filename="Serial Test.Read Helper.m1scr" Name="Root.Serial Test.Read Helper">
+    <Signature ReturnType="i32"><Params/></Signature>
+   </Component>
+  </List></ComponentStream>
+ </Project>
+</MoTeCM1BuildSession>

--- a/tests/fixtures/serial/Project.m1prj
+++ b/tests/fixtures/serial/Project.m1prj
@@ -19,6 +19,8 @@
    <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Byte B"><Props Type="i32"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Nested Byte"><Props Type="i32"/></Component>
    <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Tx Offset"><Props Type="i32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Counterfactual Gate"><Props Type="i32"/></Component>
+   <Component Classname="BuiltIn.Channel" Name="Root.Serial Test.Counterfactual Available"><Props Type="bool"/></Component>
    <Component Classname="BuiltIn.FuncUser" Filename="Serial Test.Init.m1scr" Name="Root.Serial Test.Init">
     <Props SelectedTrigger="Root.Events.On Startup"/>
    </Component>
@@ -36,6 +38,9 @@
    </Component>
    <Component Classname="BuiltIn.FuncUser" Filename="Serial Test.Transmit.m1scr" Name="Root.Serial Test.Transmit">
     <Props SelectedTrigger="Root.Events.On 50Hz"/>
+   </Component>
+   <Component Classname="BuiltIn.FuncUser" Filename="Serial Test.Counterfactual Receive.m1scr" Name="Root.Serial Test.Counterfactual Receive">
+    <Props SelectedTrigger="Root.Events.On 100Hz"/>
    </Component>
    <Component Classname="BuiltIn.FuncUserParam" Filename="Serial Test.Read Helper.m1scr" Name="Root.Serial Test.Read Helper">
     <Signature ReturnType="i32"><Params/></Signature>

--- a/tests/fixtures/serial/Scripts/Serial Test.Counterfactual Receive.m1scr
+++ b/tests/fixtures/serial/Scripts/Serial Test.Counterfactual Receive.m1scr
@@ -1,0 +1,9 @@
+// Synthetic virtual-serial fixture. No proprietary or captured data.
+// A counterfactual can reach this function without running On Startup. It
+// configures the port in-cone, then proves that a logged handle is not a handle
+// allocated by the fresh virtual adapter.
+if (Counterfactual Gate > 0)
+{
+ Serial.PortInit(0, 115200, 0);
+ Counterfactual Available = Serial.Receive(Handle A, 0);
+}

--- a/tests/fixtures/serial/Scripts/Serial Test.Init.m1scr
+++ b/tests/fixtures/serial/Scripts/Serial Test.Init.m1scr
@@ -1,0 +1,3 @@
+// Synthetic virtual-serial fixture. No proprietary or captured data.
+Init OK = Serial.PortInit(0, 115200, 0);
+Diagnostic = Serial.PortDiagnostic(0);

--- a/tests/fixtures/serial/Scripts/Serial Test.Init.m1scr
+++ b/tests/fixtures/serial/Scripts/Serial Test.Init.m1scr
@@ -1,3 +1,4 @@
 // Synthetic virtual-serial fixture. No proprietary or captured data.
 Init OK = Serial.PortInit(0, 115200, 0);
 Diagnostic = Serial.PortDiagnostic(0);
+Counterfactual Gate = 0;

--- a/tests/fixtures/serial/Scripts/Serial Test.Nested.m1scr
+++ b/tests/fixtures/serial/Scripts/Serial Test.Nested.m1scr
@@ -1,0 +1,2 @@
+// Synthetic virtual-serial fixture. No proprietary or captured data.
+Nested Byte = Read Helper();

--- a/tests/fixtures/serial/Scripts/Serial Test.Read Helper.m1scr
+++ b/tests/fixtures/serial/Scripts/Serial Test.Read Helper.m1scr
@@ -1,0 +1,10 @@
+// Synthetic virtual-serial fixture. No proprietary or captured data.
+local h = Serial.GetHandle(true);
+if (Serial.Receive(h, 0))
+{
+ Out = Serial.GetUnsignedInteger(h, 0, 1);
+}
+else
+{
+ Out = -1;
+}

--- a/tests/fixtures/serial/Scripts/Serial Test.Receive A.m1scr
+++ b/tests/fixtures/serial/Scripts/Serial Test.Receive A.m1scr
@@ -1,0 +1,8 @@
+// Synthetic virtual-serial fixture. No proprietary or captured data.
+local h = Serial.GetHandle(true);
+Handle A = h;
+Available A = Serial.Receive(h, 0);
+if (Available A)
+{
+ Byte A = Serial.GetUnsignedInteger(h, 0, 1);
+}

--- a/tests/fixtures/serial/Scripts/Serial Test.Receive B.m1scr
+++ b/tests/fixtures/serial/Scripts/Serial Test.Receive B.m1scr
@@ -1,0 +1,8 @@
+// Synthetic virtual-serial fixture. No proprietary or captured data.
+local h = Serial.GetHandle(true);
+Handle B = h;
+Available B = Serial.Receive(h, 0);
+if (Available B)
+{
+ Byte B = Serial.GetUnsignedInteger(h, 0, 1);
+}

--- a/tests/fixtures/serial/Scripts/Serial Test.Startup Receive.m1scr
+++ b/tests/fixtures/serial/Scripts/Serial Test.Startup Receive.m1scr
@@ -1,0 +1,9 @@
+// Synthetic virtual-serial fixture. No proprietary or captured data.
+if (Init OK)
+{
+ local h = Serial.GetHandle(true);
+ if (Serial.Receive(h, 0))
+ {
+  Startup Byte = Serial.GetUnsignedInteger(h, 0, 1);
+ }
+}

--- a/tests/fixtures/serial/Scripts/Serial Test.Transmit.m1scr
+++ b/tests/fixtures/serial/Scripts/Serial Test.Transmit.m1scr
@@ -1,0 +1,6 @@
+// Synthetic virtual-serial fixture. No proprietary or captured data.
+local h = Serial.GetHandle(true);
+local next = Serial.SetUnsignedInteger(h, 0, 2, 0x3035);
+next = Serial.SetFloat(h, next, 1.5);
+Tx Offset = Serial.SetString(h, next, 2, "OK");
+Serial.Transmit(h, 0, Tx Offset);

--- a/tests/snapshots/snapshot__cone_trace.snap
+++ b/tests/snapshots/snapshot__cone_trace.snap
@@ -2,4 +2,4 @@
 source: tests/snapshot.rs
 expression: trace.to_json()
 ---
-{"time":[0,0.01,0.02],"channels":{"Root.Chain.Final":[50,50,50],"Root.Chain.Mid":[5,5,5],"Root.Chain.Raw":[4,4,4]},"external":["Root.Chain.Raw"],"hardware":[]}
+{"time":[0,0.01,0.02],"channels":{"Root.Chain.Final":[50,50,50],"Root.Chain.Mid":[5,5,5],"Root.Chain.Raw":[4,4,4]},"external":["Root.Chain.Raw"],"hardware":[],"serial":[]}

--- a/tests/snapshots/snapshot__integral_trace.snap
+++ b/tests/snapshots/snapshot__integral_trace.snap
@@ -2,4 +2,4 @@
 source: tests/snapshot.rs
 expression: trace.to_json()
 ---
-{"time":[0,0.1,0.2,0.3,0.4],"channels":{"Root.Acc.Rate":[2,2,2,2,2],"Root.Acc.Total":[0,0.2,0.4,0.6,0.8]},"external":["Root.Acc.Rate"],"hardware":[]}
+{"time":[0,0.1,0.2,0.3,0.4],"channels":{"Root.Acc.Rate":[2,2,2,2,2],"Root.Acc.Total":[0,0.2,0.4,0.6,0.8]},"external":["Root.Acc.Rate"],"hardware":[],"serial":[]}

--- a/tests/snapshots/snapshot__single_function_trace.snap
+++ b/tests/snapshots/snapshot__single_function_trace.snap
@@ -2,4 +2,4 @@
 source: tests/snapshot.rs
 expression: trace.to_json()
 ---
-{"time":[0,0.01,0.02,0.03,0.04],"channels":{"Root.Demo.Gain":[2.5,2.5,2.5,2.5,2.5],"Root.Demo.Output":[50,50,50,50,50],"Root.Demo.Speed":[20,20,20,20,20]},"external":["Root.Demo.Gain","Root.Demo.Speed"],"hardware":[]}
+{"time":[0,0.01,0.02,0.03,0.04],"channels":{"Root.Demo.Gain":[2.5,2.5,2.5,2.5,2.5],"Root.Demo.Output":[50,50,50,50,50],"Root.Demo.Speed":[20,20,20,20,20]},"external":["Root.Demo.Gain","Root.Demo.Speed"],"hardware":[],"serial":[]}

--- a/tests/snapshots/snapshot__whole_project_trace.snap
+++ b/tests/snapshots/snapshot__whole_project_trace.snap
@@ -3,4 +3,4 @@ source: tests/snapshot.rs
 assertion_line: 115
 expression: trace.to_json()
 ---
-{"time":[0,0.01,0.02,0.03,0.04,0.05],"channels":{"Root.MR.Fast Out":[50,50,50,50,50,50],"Root.MR.Fast Shared":[5,5,5,5,5,5],"Root.MR.Seed":[2,2,2,2,2,2],"Root.MR.Slow Echo":[4,4,4,4,4,4],"Root.MR.Slow Out":[4,4,4,4,4,4],"Root.MR.Slow Total":[0,0,0.04,0.04,0.08,0.08],"Root.MR.Started":[1,1,1,1,1,1]},"external":["Root.MR.Seed","Root.MR.Slow Out"],"hardware":[]}
+{"time":[0,0.01,0.02,0.03,0.04,0.05],"channels":{"Root.MR.Fast Out":[50,50,50,50,50,50],"Root.MR.Fast Shared":[5,5,5,5,5,5],"Root.MR.Seed":[2,2,2,2,2,2],"Root.MR.Slow Echo":[4,4,4,4,4,4],"Root.MR.Slow Out":[4,4,4,4,4,4],"Root.MR.Slow Total":[0,0,0.04,0.04,0.08,0.08],"Root.MR.Started":[1,1,1,1,1,1]},"external":["Root.MR.Seed","Root.MR.Slow Out"],"hardware":[],"serial":[]}

--- a/tests/virtual_serial.rs
+++ b/tests/virtual_serial.rs
@@ -51,6 +51,13 @@ fn unsigned(value: &Value) -> u32 {
     }
 }
 
+fn assert_serial_bad_call(error: &EvalError, expected: &str) {
+    match error.root_cause() {
+        EvalError::BadCall { detail } => assert_eq!(detail, expected),
+        other => panic!("expected serial BadCall, got {other:?}"),
+    }
+}
+
 #[test]
 fn whole_project_serial_is_timed_rate_gated_nested_and_fresh_per_run() {
     let engine = engine();
@@ -186,6 +193,69 @@ fn whole_project_serial_is_timed_rate_gated_nested_and_fresh_per_run() {
     assert!(
         !first.to_csv().contains("serial"),
         "CSV remains channel-only"
+    );
+}
+
+#[test]
+fn function_mode_does_not_run_startup_serial_initialization() {
+    let scenario = Scenario::from_toml_str(
+        r#"
+mode = "function"
+target = "Serial Test.Receive A"
+duration_s = 0.01
+base_rate_hz = 100.0
+
+[[serial.rx]]
+time_s = 0.0
+port = 0
+bytes = [0x11]
+"#,
+    )
+    .expect("function-mode serial scenario parses");
+    let error = engine()
+        .run(&scenario)
+        .expect_err("function mode must not borrow whole-project startup state");
+
+    assert_serial_bad_call(
+        &error,
+        "Serial.Receive: port 0 is not initialized; call Serial.PortInit first",
+    );
+    assert_eq!(
+        error.to_string(),
+        "in Serial Test.Receive A.m1scr at t = 0.000 s: bad call: Serial.Receive: port 0 is not initialized; call Serial.PortInit first"
+    );
+}
+
+#[test]
+fn overriding_port_init_does_not_mutate_virtual_serial_state() {
+    let scenario = Scenario::from_toml_str(
+        r#"
+mode = "whole-project"
+duration_s = 0.01
+base_rate_hz = 100.0
+
+[[io]]
+call = "Serial.PortInit"
+const = true
+
+[[serial.rx]]
+time_s = 0.0
+port = 0
+bytes = [0x11]
+"#,
+    )
+    .expect("mixed-route serial scenario parses");
+    let error = engine()
+        .run(&scenario)
+        .expect_err("a higher-priority PortInit result does not configure virtual serial");
+
+    assert_serial_bad_call(
+        &error,
+        "Serial.Receive: port 0 is not initialized; call Serial.PortInit first",
+    );
+    assert_eq!(
+        error.to_string(),
+        "in Serial Test.Startup Receive.m1scr at startup: bad call: Serial.Receive: port 0 is not initialized; call Serial.PortInit first"
     );
 }
 

--- a/tests/virtual_serial.rs
+++ b/tests/virtual_serial.rs
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Synthetic end-to-end coverage for the deterministic virtual RS232 adapter.
+//! No proprietary project data or captured M1 serial traffic is used here.
+
+use m1_eval::{
+    AdapterReply, Engine, EvalError, HardwareAdapter, HardwareCall, HardwareValueSource, M1Scalar,
+    Scenario, SerialDirection, Value,
+};
+use std::path::Path;
+
+fn engine() -> Engine {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/serial/Project.m1prj");
+    Engine::load(&fixture, None).expect("synthetic serial fixture loads")
+}
+
+fn whole_project_scenario() -> Scenario {
+    Scenario::from_toml_str(
+        r#"
+mode = "whole-project"
+duration_s = 0.05
+base_rate_hz = 100.0
+
+[[serial.rx]]
+time_s = 0.0
+port = 0
+bytes = [0x11]
+
+[[serial.rx]]
+time_s = 0.01
+port = 0
+bytes = [0x22]
+
+[[serial.rx]]
+time_s = 0.02
+port = 0
+bytes = [0x33]
+
+[[serial.rx]]
+time_s = 0.02
+port = 0
+bytes = [0x34]
+"#,
+    )
+    .expect("virtual serial scenario parses")
+}
+
+fn unsigned(value: &Value) -> u32 {
+    match value {
+        Value::M1(M1Scalar::UnsignedInteger(value)) => *value,
+        other => panic!("expected M1 unsigned value, got {other:?}"),
+    }
+}
+
+#[test]
+fn whole_project_serial_is_timed_rate_gated_nested_and_fresh_per_run() {
+    let engine = engine();
+    let scenario = whole_project_scenario();
+    let first = engine.run(&scenario).expect("first serial run succeeds");
+    let second = engine.run(&scenario).expect("second serial run succeeds");
+
+    assert_eq!(first.to_json(), second.to_json(), "fresh runs are stable");
+    assert_eq!(
+        first.channels["Root.Serial Test.Init OK"],
+        vec![Value::Bool(true); 5]
+    );
+    assert_eq!(
+        first.channels["Root.Serial Test.Diagnostic"],
+        vec![Value::m1_integer(1); 5]
+    );
+    assert_eq!(
+        first.channels["Root.Serial Test.Startup Byte"],
+        vec![Value::m1_integer(0x11); 5]
+    );
+
+    let handle_a = unsigned(&first.channels["Root.Serial Test.Handle A"][0]);
+    let handle_b = unsigned(&first.channels["Root.Serial Test.Handle B"][0]);
+    assert_ne!(handle_a, 0);
+    assert_ne!(handle_b, 0);
+    assert_ne!(handle_a, handle_b);
+    assert!(
+        first.channels["Root.Serial Test.Handle A"]
+            .iter()
+            .all(|value| unsigned(value) == handle_a)
+    );
+    assert!(
+        first.channels["Root.Serial Test.Handle B"]
+            .iter()
+            .all(|value| unsigned(value) == handle_b)
+    );
+
+    // Receiver A runs at 100 Hz. Receiver B and the nested helper run at 50 Hz,
+    // yet each handle has an independent cursor over the same virtual port.
+    assert_eq!(
+        first.channels["Root.Serial Test.Byte A"],
+        vec![
+            Value::m1_integer(0x11),
+            Value::m1_integer(0x22),
+            Value::m1_integer(0x33),
+            Value::m1_integer(0x33),
+            Value::m1_integer(0x33),
+        ]
+    );
+    assert_eq!(
+        first.channels["Root.Serial Test.Byte B"],
+        vec![
+            Value::m1_integer(0x11),
+            Value::m1_integer(0x11),
+            Value::m1_integer(0x22),
+            Value::m1_integer(0x22),
+            Value::m1_integer(0x22),
+        ]
+    );
+    assert_eq!(
+        first.channels["Root.Serial Test.Nested Byte"],
+        vec![
+            Value::m1_integer(0x11),
+            Value::m1_integer(0x11),
+            Value::m1_integer(0x22),
+            Value::m1_integer(0x22),
+            Value::m1_integer(-1),
+        ]
+    );
+    assert_eq!(
+        first.channels["Root.Serial Test.Available A"],
+        vec![
+            Value::Bool(true),
+            Value::Bool(true),
+            Value::Bool(true),
+            Value::Bool(false),
+            Value::Bool(false),
+        ]
+    );
+
+    let tx = first
+        .serial
+        .iter()
+        .filter(|event| event.direction == SerialDirection::Tx)
+        .collect::<Vec<_>>();
+    assert_eq!(tx.len(), 3);
+    assert_eq!(
+        tx.iter()
+            .map(|event| event.time.elapsed_s)
+            .collect::<Vec<_>>(),
+        vec![0.0, 0.02, 0.04]
+    );
+    assert!(tx.iter().all(|event| {
+        event.port == 0
+            && event.bytes == [0x30, 0x35, 0x3f, 0xc0, 0, 0, b'O', b'K']
+            && event.site.script() == "Serial Test.Transmit.m1scr"
+    }));
+    let rx = first
+        .serial
+        .iter()
+        .filter(|event| event.direction == SerialDirection::Rx)
+        .collect::<Vec<_>>();
+    assert!(rx.iter().any(|event| {
+        event.time.phase == m1_eval::EvalPhase::Startup
+            && event.time.elapsed_s == 0.0
+            && event.bytes == [0x11]
+            && event.site.script() == "Serial Test.Startup Receive.m1scr"
+    }));
+    assert!(rx.iter().any(|event| {
+        event.time.phase == m1_eval::EvalPhase::Periodic
+            && event.time.elapsed_s == 0.02
+            && event.bytes == [0x33, 0x34]
+            && event.site.script() == "Serial Test.Receive A.m1scr"
+    }));
+
+    assert!(first.hardware.iter().any(|item| {
+        item.canonical_call() == "Serial.Receive"
+            && item.source == HardwareValueSource::VirtualSerialRx
+    }));
+    assert!(first.hardware.iter().any(|item| {
+        item.canonical_call() == "Serial.Transmit"
+            && item.source == HardwareValueSource::VirtualSerial
+    }));
+    assert!(first.external.contains("Serial.Receive"));
+    assert!(!first.external.contains("Serial.Transmit"));
+
+    let json: serde_json::Value =
+        serde_json::from_str(&first.to_json()).expect("trace JSON is valid");
+    assert_eq!(
+        json["serial"].as_array().map(Vec::len),
+        Some(first.serial.len())
+    );
+    assert!(
+        !first.to_csv().contains("serial"),
+        "CSV remains channel-only"
+    );
+}
+
+#[derive(Default)]
+struct StatusAdapter {
+    calls: Vec<String>,
+    diagnostic: i32,
+}
+
+impl HardwareAdapter for StatusAdapter {
+    fn call(&mut self, call: &HardwareCall) -> Result<AdapterReply, EvalError> {
+        self.calls.push(call.canonical_name());
+        if call.canonical_name() == "Serial.PortDiagnostic" {
+            Ok(Value::m1_integer(self.diagnostic).into())
+        } else {
+            Ok(AdapterReply::Unhandled)
+        }
+    }
+}
+
+fn init_scenario(extra: &str) -> Scenario {
+    Scenario::from_toml_str(&format!(
+        "mode = \"function\"\ntarget = \"Serial Test.Init\"\nduration_s = 0.01\nbase_rate_hz = 100.0\n{extra}"
+    ))
+    .expect("init scenario parses")
+}
+
+#[test]
+fn io_override_then_external_adapter_precede_the_virtual_model() {
+    let engine = engine();
+    let mut adapter = StatusAdapter {
+        diagnostic: 9,
+        ..Default::default()
+    };
+    let trace = engine
+        .run_with_adapter(&init_scenario(""), &mut adapter)
+        .expect("external adapter supplies diagnostic");
+    assert_eq!(
+        trace.channels["Root.Serial Test.Diagnostic"],
+        vec![Value::m1_integer(9)]
+    );
+    assert_eq!(
+        adapter.calls,
+        vec!["Serial.PortInit", "Serial.PortDiagnostic"]
+    );
+    assert!(trace.hardware.iter().any(|item| {
+        item.canonical_call() == "Serial.PortDiagnostic"
+            && item.source == HardwareValueSource::Adapter
+    }));
+
+    let mut adapter = StatusAdapter {
+        diagnostic: 9,
+        ..Default::default()
+    };
+    let scenario =
+        init_scenario("\n[[io]]\ncall = \"Serial.PortDiagnostic\"\nconst = { integer = 7 }\n");
+    let trace = engine
+        .run_with_adapter(&scenario, &mut adapter)
+        .expect("scenario override wins");
+    assert_eq!(
+        trace.channels["Root.Serial Test.Diagnostic"],
+        vec![Value::m1_integer(7)]
+    );
+    assert_eq!(adapter.calls, vec!["Serial.PortInit"]);
+    assert!(trace.hardware.iter().any(|item| {
+        item.canonical_call() == "Serial.PortDiagnostic"
+            && item.source == HardwareValueSource::ScenarioWildcard
+    }));
+
+    let mut adapter = StatusAdapter {
+        diagnostic: 9,
+        ..Default::default()
+    };
+    let scenario = init_scenario(
+        "\n[[io]]\ncall = \"Serial.PortDiagnostic\"\nconst = { integer = 7 }\n\n[[io]]\ncall = \"Serial.PortDiagnostic\"\nscript = \"Serial Test.Init.m1scr\"\noffset = 124\nconst = { integer = 8 }\n",
+    );
+    let trace = engine
+        .run_with_adapter(&scenario, &mut adapter)
+        .expect("exact site override wins over wildcard and adapter");
+    assert_eq!(
+        trace.channels["Root.Serial Test.Diagnostic"],
+        vec![Value::m1_integer(8)]
+    );
+    assert_eq!(adapter.calls, vec!["Serial.PortInit"]);
+    assert!(trace.hardware.iter().any(|item| {
+        item.canonical_call() == "Serial.PortDiagnostic"
+            && item.source == HardwareValueSource::ScenarioExact
+    }));
+}
+
+#[test]
+fn coverage_and_runtime_agree_on_rs232_and_lin_support() {
+    let engine = engine();
+    let coverage = engine.coverage();
+    for method in [
+        "GetHandle",
+        "GetUnsignedInteger",
+        "PortDiagnostic",
+        "PortInit",
+        "Receive",
+        "SetFloat",
+        "SetString",
+        "SetUnsignedInteger",
+        "Transmit",
+    ] {
+        let name = format!("Serial.{method}");
+        assert!(
+            coverage.adapter_backed.iter().any(|item| item.name == name),
+            "{name} should be adapter-backed: {coverage:?}"
+        );
+    }
+    assert!(coverage.unsupported.iter().all(|item| {
+        !matches!(
+            item.name.as_str(),
+            "Serial.GetHandle"
+                | "Serial.GetUnsignedInteger"
+                | "Serial.PortDiagnostic"
+                | "Serial.PortInit"
+                | "Serial.Receive"
+                | "Serial.SetFloat"
+                | "Serial.SetString"
+                | "Serial.SetUnsignedInteger"
+                | "Serial.Transmit"
+        )
+    }));
+    engine
+        .run(&whole_project_scenario())
+        .expect("every adapter-backed serial method in the fixture executes");
+}
+
+#[test]
+fn directly_constructed_serial_scenarios_are_validated_before_execution() {
+    let engine = engine();
+    let mut scenario = whole_project_scenario();
+    scenario.serial.rx[0].time_s = f64::NAN;
+    let error = engine
+        .run(&scenario)
+        .expect_err("non-finite direct scenario time fails");
+    assert!(error.to_string().contains("invalid time_s NaN"));
+
+    let mut scenario = whole_project_scenario();
+    scenario.serial.rx[0].bytes = vec![0; 257];
+    let error = engine
+        .run(&scenario)
+        .expect_err("oversized direct scenario chunk fails");
+    assert!(error.to_string().contains("257 bytes"));
+}

--- a/tests/virtual_serial.rs
+++ b/tests/virtual_serial.rs
@@ -227,6 +227,36 @@ bytes = [0x11]
 }
 
 #[test]
+fn cone_mode_does_not_run_startup_serial_initialization() {
+    let scenario = Scenario::from_toml_str(
+        r#"
+mode = "cone"
+target = "Root.Serial Test.Byte A"
+duration_s = 0.01
+base_rate_hz = 100.0
+
+[[serial.rx]]
+time_s = 0.0
+port = 0
+bytes = [0x11]
+"#,
+    )
+    .expect("cone-mode serial scenario parses");
+    let error = engine()
+        .run(&scenario)
+        .expect_err("cone mode must not borrow whole-project startup state");
+
+    assert_serial_bad_call(
+        &error,
+        "Serial.Receive: port 0 is not initialized; call Serial.PortInit first",
+    );
+    assert_eq!(
+        error.to_string(),
+        "in Serial Test.Receive A.m1scr at t = 0.000 s: bad call: Serial.Receive: port 0 is not initialized; call Serial.PortInit first"
+    );
+}
+
+#[test]
 fn overriding_port_init_does_not_mutate_virtual_serial_state() {
     let scenario = Scenario::from_toml_str(
         r#"


### PR DESCRIPTION
## Summary

- add fresh, deterministic virtual RS232 state with stable typed handles, timed scenario RX, independent receive cursors, byte-buffer reads and writes, status, and ordered JSON RX/TX events
- preserve routing precedence across exact and wildcard `[[io]]`, user adapters, virtual serial, the System model, and typed stubs
- fail precisely for invalid handles, bounds, configuration, uninitialized ports, and unsupported LIN behavior
- document whole-project, function, cone, and counterfactual state boundaries plus the public API migration

## Evidence boundary

The implementation follows the pinned Serial catalogue and local Development Manual examples for the well-defined RS232 byte-buffer subset. Ambiguous behavior is labeled as an evaluator contract, and unsupported behavior fails instead of being guessed. All committed fixtures are synthetic; this PR contains no proprietary serial captures or project data.

## Validation

- `cargo test`: 535 unit tests plus all default-feature integration and documentation tests
- `cargo test --all-targets --all-features`: 548 unit tests plus integrations; the documented proprietary LD test remains ignored
- `cargo +1.88.0 test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo fmt --all -- --check` and clean diff checks
- independent exact-head replay review: CLEAN

Closes #52